### PR TITLE
Improve readme for vimmers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ Files:
                     -- set g:syntastic_ocaml_checkers = ['merlin']  
                     --  or g:syntastic_omlet_checkers = ['merlin']
 
+Alternatively you can install vim support using [Vundle](https://github.com/gmarik/vundle).
+Add the following to your .vimrc
+
+    Bundle 'def-lkb/merlin', {'rtp' : 'vim/'}
+
+Integration with [neocomplcache](https://github.com/Shougo/neocomplcache) 
+for automatic completion can be enabled with:
+
+    if !exists('g:neocomplcache_force_omni_patterns')
+      let g:neocomplcache_force_omni_patterns = {}
+    endif
+    let g:neocomplcache_force_omni_patterns.ocaml = '[^. *\t]\.\w*\|\h\w*|#'
+
 Features
 --------
 


### PR DESCRIPTION
Many (most?) vim users install plugins through vundle and it's a little not obvious how to do it because merlin is not just a vimscript plugin. I've added instructions to clarify that. Also, neocomplcache is a really popular completion plugin so I've added a small vimscript snippet to make it work with merlin. Idea being not having to press C-x C-o anytime you'd like merlin to complete for you.   

Finally, I want to say that merlin is awesome from what I'm seeing :D keep it up!
