### PR TITLE
Vim: Fix locate when editing in sub-directories

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -217,6 +217,8 @@ def command_locate(path, line, col):
     else:
       curr_fpath = vim.current.buffer.name
       fpath = pos_or_err['file']
+      cwd = os.path.dirname(curr_fpath)
+      fpath = os.path.join(cwd, fpath)
       l = pos_or_err['pos']['line']
       c = pos_or_err['pos']['col']
       if curr_fpath != fpath:


### PR DESCRIPTION
The locate call returned the file name, not a full path so the locate opens the
wrong path in Vim.

E.g. If I edit using `vim src/foo.ml` and call locate on something contained in
`src/bar.ml` then it will fail and open a buffer `./bar.ml`.
