### PR TITLE
merlin.el: Fix initial line to satisfy package.el

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1,4 +1,4 @@
-;; merlin.el --- Mode for Merlin, an assistant for OCaml.   -*- coding: utf-8 -*-
+;;; merlin.el --- Mode for Merlin, an assistant for OCaml.   -*- coding: utf-8 -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Simon Castellan <simon.castellan(_)iuwt.fr>


### PR DESCRIPTION
A triple-semicolon is required in order for source files to be parseable by `package-buffer-info`, and therefore installed via `package.el`

Context: I'm adding merlin.el to [MELPA](http://melpa.milkbox.net)
