### PR TITLE
travis for 4.00.1, 4.01.0

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,0 +1,30 @@
+OPAM_DEPENDS="yojson menhir ocamlfind"
+
+case "$OCAML_VERSION,$OPAM_VERSION" in
+4.00.1,1.0.0) ppa=avsm/ocaml40+opam10 ;;
+4.00.1,1.1.0) ppa=avsm/ocaml40+opam11 ;;
+4.01.0,1.0.0) ppa=avsm/ocaml41+opam10 ;;
+4.01.0,1.1.0) ppa=avsm/ocaml41+opam11 ;;
+*) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
+esac
+
+echo "yes" | sudo add-apt-repository ppa:$ppa
+sudo apt-get update -qq
+sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam time
+
+export OPAMYES=1
+export OPAMVERBOSE=1
+echo OCaml version
+ocaml -version
+echo OPAM versions
+opam --version
+opam --git-version
+
+# opam init git://github.com/ocaml/opam-repository >/dev/null 2>&1
+opam init
+opam install ${OPAM_DEPENDS}
+
+eval `opam config env`
+./configure
+make all_versions
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+script: bash -ex .travis-ci.sh
+env:
+  - OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
+  - OCAML_VERSION=4.00.1 OPAM_VERSION=1.1.0


### PR DESCRIPTION
Simple travis settings to build merlin on supported versions of OCaml for PR. It's a nice smoke test for external contributions and it does get annoying building on different compilers.

One of the committers @def-lkb @trefis @asmanur will need to enable CI for merlin on https://travis-ci.org/ and once this PR is merged travis will kick off and report the status. I've done this for my own fork and it worked fine.

Note that you might also want to add the test target in the shell script.
