### PR TITLE
fix the regression introduced by byte compilation

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -928,7 +928,7 @@ variable `merlin-ac-cache')."
     (prefix . merlin-ac-prefix))))
 
 (when (featurep 'auto-complete)
-  (ac-define-source "merlin" merlin-ac-source))
+  (eval '(ac-define-source "merlin" merlin-ac-source)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; EXPRESSION TYPING ;;


### PR DESCRIPTION
I don't know elisp well enough to tell you why this works but it fixes merlin.el in master for me.

Now I'm curious whether merlin.el in master is working for anyone else currently?

closes #163

see:
https://github.com/ScottyB/ac-js2/pull/9#issuecomment-25448288
