### PR TITLE
Kill pending errors that are edited by the user

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -854,6 +854,21 @@ If there is no error, do nothing."
   (setq merlin-pending-errors nil)
   (merlin-error-delete-overlays))
 
+(defun merlin--kill-error-if-edited (overlay
+				     is-after
+				     beg
+				     end
+				     &optional length)
+  "Remove an error from the pending error lists if it is edited by the user."
+  (when is-after
+    (let ((err (nth (position overlay merlin-pending-errors-overlays)
+		    merlin-pending-errors)))
+      (setq merlin-pending-errors
+	    (delete err merlin-pending-errors))
+      (setq merlin-pending-errors-overlays
+	    (delete overlay merlin-pending-errors-overlays))
+      (delete-overlay overlay))))
+
 (defun merlin-error-display-in-margin (errors)
   "Given a list of ERRORS, put annotations in the margin corresponding to them."
   (let* ((err-point
@@ -866,6 +881,8 @@ If there is no error, do nothing."
           (lambda (err)
             (let* ((bounds (cdr (assoc 'bounds err)))
                    (overlay (make-overlay (car bounds) (cdr bounds))))
+	      (push #'merlin--kill-error-if-edited
+		    (overlay-get overlay 'modification-hooks))
               (if (merlin-error-warning-p (cdr (assoc 'message err)))
                   (merlin-put-margin-overlay overlay
                                              merlin-margin-warning-string


### PR DESCRIPTION
Editing text that contains error overlays does not currently work well. The correspondence between error and source can quickly become lost, and in a number of cases (eg use of transpose-lines) editing can leave empty overlays lying around that are mostly useless and definitely confusing.

There's also a display bug with such empty overlays: because they contain no text, they have no text properties, leading to the `!` in the fringe changing colour. It's pretty confusing and flaky.

I think it is better to simply remove overlays that are edited by the user, so I've implemented that.
