### PR TITLE
Fix minor bugs

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1473,7 +1473,7 @@ Returns the position."
   (interactive)
   (if (merlin-process-dead-p)
       (let* ((command (concat merlin-command " -version"))
-             (version (shell-command-to-string version))
+             (version (shell-command-to-string command))
              (version (replace-regexp-in-string "\n$" "" version)))
         (message "%s (from shell)" version))
     (message "%s" (merlin-send-command '(version)))))


### PR DESCRIPTION
The new type-enclosing stuff used in merlin-locate has a small flaw: if the locate fails, the type-enclosing machinery is still activated, stomping the error message. This PR fixes that, and some ancillary minor stuff.
