### PR TITLE
(emacs) Improvement on retrieving type information

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1190,7 +1190,7 @@ prefix of `bar' is `'."
                    'at (merlin/unmake-point (point)))
              callback-if-success callback-if-exn)))
 
-(defun merlin--print-type-buffer ()
+(defun merlin--display-type-buffer ()
   "Print type buffer to the echo area."
   (let* ((type (with-current-buffer merlin-type-buffer-name
                 (font-lock-fontify-region (point-min) (point-max))
@@ -1203,11 +1203,11 @@ prefix of `bar' is `'."
 (defun merlin/toggle-display-type-buffer ()
   "Show type buffer to the echo area."
   (interactive)
-  (if (memq 'merlin--print-type-buffer pre-command-hook)
-      (remove-hook 'pre-command-hook 'merlin--print-type-buffer t)
+  (if (memq 'merlin--display-type-buffer pre-command-hook)
+      (remove-hook 'pre-command-hook 'merlin--display-type-buffer t)
     (progn
-      (merlin--print-type-buffer)
-      (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t))))
+      (merlin--display-type-buffer)
+      (add-hook 'pre-command-hook 'merlin--display-type-buffer nil t))))
 
 (defun merlin--type-display (bounds type &optional quiet)
   "Display the type TYPE of the expression occuring at BOUNDS.
@@ -1218,13 +1218,13 @@ If QUIET is non nil, then an overlay and the merlin types can be used."
            (start (car bounds))
            (end (cdr bounds))
            (exp (buffer-substring-no-properties start end))
-           (type-message (concat exp " : " type)))
-      (merlin/display-in-type-buffer type-message)
-      (merlin--print-type-buffer)
-      (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t)
+           (type-info (if (cl-search " " exp) type (concat exp " : " type))))
+      (merlin/display-in-type-buffer type-info)
+      (merlin--display-type-buffer)
+      (add-hook 'pre-command-hook 'merlin--display-type-buffer nil t)
       (run-at-time merlin-type-display-time nil
                    (lambda () (remove-hook 'pre-command-hook
-                                           'merlin--print-type-buffer
+                                           'merlin--display-type-buffer
                                            t)))
       (if (and (not quiet) bounds)
           (merlin--highlight bounds 'merlin-type-face)))))

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1180,6 +1180,9 @@ prefix of `bar' is `'."
 ;; EXPRESSION TYPING ;;
 ;;;;;;;;;;;;;;;;;;;;;;;
 
+(defvar merlin-type-display-time 10
+  "Time duration for displaying type information in the echo area.")
+
 (defun merlin--type-expression (exp callback-if-success &optional callback-if-exn)
   "Get the type of EXP inside the local context."
   (when exp (merlin/send-command-async
@@ -1217,9 +1220,10 @@ If QUIET is non nil, then an overlay and the merlin types can be used."
       (merlin/display-in-type-buffer type)
       (merlin--print-type-buffer)
       (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t)
-      (run-at-time 10 nil (lambda () (remove-hook 'pre-command-hook
-                                                  'merlin--print-type-buffer
-                                                  t)))
+      (run-at-time merlin-type-display-time nil
+                   (lambda () (remove-hook 'pre-command-hook
+                                           'merlin--print-type-buffer
+                                           t)))
       (if (and (not quiet) bounds)
           (merlin--highlight bounds 'merlin-type-face)))))
 

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1200,16 +1200,14 @@ prefix of `bar' is `'."
         (display-buffer merlin-type-buffer-name)
       (message "%s" type))))
 
-(defun merlin/show-type-buffer ()
+(defun merlin/toggle-display-type-buffer ()
   "Show type buffer to the echo area."
   (interactive)
-  (merlin--print-type-buffer)
-  (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t))
-
-(defun merlin/hide-type-buffer ()
-  "Hide type buffer from the echo area."
-  (interactive)
-  (remove-hook 'pre-command-hook 'merlin--print-type-buffer t))
+  (if (memq 'merlin--print-type-buffer pre-command-hook)
+      (remove-hook 'pre-command-hook 'merlin--print-type-buffer t)
+    (progn
+      (merlin--print-type-buffer)
+      (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t))))
 
 (defun merlin--type-display (bounds type &optional quiet)
   "Display the type TYPE of the expression occuring at BOUNDS.

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1214,8 +1214,12 @@ prefix of `bar' is `'."
 If QUIET is non nil, then an overlay and the merlin types can be used."
   (if (not type)
       (unless quiet (message "<no information>"))
-    (let ((count (merlin--count-lines type)))
-      (merlin/display-in-type-buffer type)
+    (let* ((count (merlin--count-lines type))
+           (start (car bounds))
+           (end (cdr bounds))
+           (exp (buffer-substring-no-properties start end))
+           (type-message (concat exp " : " type)))
+      (merlin/display-in-type-buffer type-message)
       (merlin--print-type-buffer)
       (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t)
       (run-at-time merlin-type-display-time nil

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1188,21 +1188,23 @@ prefix of `bar' is `'."
              callback-if-success callback-if-exn)))
 
 (defun merlin--print-type-buffer ()
-  "Print type buffer to the echo area"
-  (let ((type (with-current-buffer merlin-type-buffer-name
+  "Print type buffer to the echo area."
+  (let* ((type (with-current-buffer merlin-type-buffer-name
                 (font-lock-fontify-region (point-min) (point-max))
-                (buffer-string))))
-    (message "%s" type)
-    ))
+                (buffer-string)))
+         (count (merlin--count-lines type)))
+    (if (> count 8)
+        (display-buffer merlin-type-buffer-name)
+      (message "%s" type))))
 
 (defun merlin/show-type-buffer ()
-  "Show type buffer to the echo area"
+  "Show type buffer to the echo area."
   (interactive)
   (merlin--print-type-buffer)
   (add-hook 'pre-command-hook 'merlin--print-type-buffer nil t))
 
 (defun merlin/hide-type-buffer ()
-  "Hide type buffer from the echo area"
+  "Hide type buffer from the echo area."
   (interactive)
   (remove-hook 'pre-command-hook 'merlin--print-type-buffer t))
 
@@ -1218,12 +1220,6 @@ If QUIET is non nil, then an overlay and the merlin types can be used."
       (run-at-time 10 nil (lambda () (remove-hook 'pre-command-hook
                                                   'merlin--print-type-buffer
                                                   t)))
-      ;; (if (> count 8)
-      ;;     (display-buffer merlin-type-buffer-name)
-      ;;   (message "%s"
-      ;;     (with-current-buffer merlin-type-buffer-name
-      ;;       (font-lock-fontify-region (point-min) (point-max))
-      ;;       (buffer-string))))
       (if (and (not quiet) bounds)
           (merlin--highlight bounds 'merlin-type-face)))))
 


### PR DESCRIPTION
Hello,

I did a bit improvement on displaying type information of OCaml expressions in Merlin Emacs and want to contribute back to your excellent project.

The problems I feel inconvenient are:
- when querying for type information by `C-c C-t`, the type information is nicely displayed in the echo area of Emacs, but is immediately cleared when the Emacs cursor moves, or other event happens. 
- The type information can also be looked up in the `type buffer` of Emacs, but this buffer contains only type information but not the corresponding function or expression. 

What I improve are:
- Allow to display the type information in the echo area for a certain amount of time, even when the Emacs cursor moves or the other event occurs. This amount of time can be adjusted by the variable `merlin-type-display-time`. Currently, I set it to 10 seconds. That is, when typing `C-c C-t` to retrieve type information in the echo area, it will automatically disappear after 10 seconds.
- Add an option to allow always display the last retrieved type information in the echo area as long as the user wants. This can be done by invoking the function `merlin/toggle-display-type-buffer`, which enable or disable the continuity of displaying the last retrieved type information.
- Adding also the corresponding expression in the type information. For example, the below picture shows that the type information is not only `var -> var -> Globals.pos -> pure_form` but also include the expression `mk_neq_var`

![show-type](https://cloud.githubusercontent.com/assets/20593743/18707260/d4480f30-8027-11e6-9e24-5fba5a1f02bb.png)

I want to you ask for your opinion about these improvements. Do you think they can be useful?
