### PR TITLE
Fixed broken link to MerlinDestruct video

### DIFF
--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -109,7 +109,7 @@ Add these bindings to rename interactively: >
 - if the thing under the cursor is a pattern variable or a pattern wildcard,
   refines that pattern (if possible).
 
-See http://the-lambda-church.github.io/merlin/destruct.ogv
+See https://ocaml.github.io/merlin/destruct.ogv
 
 :MerlinOutline                                                *:MerlinOutline*
 


### PR DESCRIPTION
The link in the VIM documentation which demonstrates the MerlinDestruct function is broken.