### PR TITLE
Make merlin-iedit-occurrences even more friendly

### DIFF
--- a/emacs/merlin-iedit.el
+++ b/emacs/merlin-iedit.el
@@ -39,7 +39,7 @@
 (defun merlin-iedit-occurrences ()
   "Edit occurrences of identifier under cursor using `iedit'"
   (interactive)
-  (if iedit-mode (iedit-mode -1)
+  (if (bound-and-true-p iedit-mode) (iedit-mode -1)
     (let ((r (merlin/call "occurrences"
                           "-identifier-at" (merlin/unmake-point (point)))))
       (when r


### PR DESCRIPTION
This works even if the user is [autoloading](https://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html) iedit; the current version fails with "Symbol's value as variable is void".