### PR TITLE
Add Neomake Maker

### DIFF
--- a/vim/merlin/autoload/neomake/ocaml.vim
+++ b/vim/merlin/autoload/neomake/ocaml.vim
@@ -1,0 +1,8 @@
+function! neomake#makers#ft#ocaml#merlin()
+  let maker = {'name': 'merlin'}
+  function! maker.get_list_entries(jobinfo)
+    return merlin#ErrorLocList()
+  endfunction
+
+  return maker
+endfunction

--- a/vim/merlin/autoload/neomake/ocaml.vim
+++ b/vim/merlin/autoload/neomake/ocaml.vim
@@ -1,8 +1,7 @@
 function! neomake#makers#ft#ocaml#merlin()
-  let maker = {'name': 'merlin'}
+  let maker = {}
   function! maker.get_list_entries(jobinfo)
     return merlin#ErrorLocList()
   endfunction
-
   return maker
 endfunction


### PR DESCRIPTION
Modeled after the Syntastic formatter, the Merlin Neomake maker can be
enabled by setting `let g:neomake_ocaml_enabled_makers = ['merlin']`.

I can also update the vim from scratch wiki if this is merged.