### PR TITLE
Extend function application infos

### DIFF
--- a/src/frontend/query_json.ml
+++ b/src/frontend/query_json.ml
@@ -220,11 +220,25 @@ let json_of_completions {Compl. entries; context } =
     "entries", `List (List.map json_of_completion entries);
     "context", (match context with
         | `Unknown -> `Null
-        | `Application {Compl. argument_type; labels} ->
-          let label (name,ty) = `Assoc ["name", `String name;
-                                        "type", `String ty] in
-          let a = `Assoc ["argument_type", `String argument_type;
-                          "labels", `List (List.map label labels)] in
+        | `Application {Compl. argument_type; index; func_name; func_sig; func_loc; labels; } ->
+          let { Lexing.pos_lnum; pos_bol; pos_cnum } = func_loc.Location.loc_start in
+          let label (name, ty) =
+            `Assoc ["name", `String name; "type", `String ty]
+          in
+          let arg (name, ty) =
+            `Assoc [
+              "name", (match name with None -> `Null | Some n -> `String n);
+              "type", `String ty
+            ]
+          in
+          let a = `Assoc [
+              "argument_type", `String argument_type;
+              "labels", `List (List.map label labels);
+              "func_sig", `List (List.map arg func_sig);
+              "func_name", (match func_name with Some n -> `String n | None -> `Null);
+              "func_pos", `List [`Int pos_lnum; `Int (pos_cnum - pos_bol)];
+              "index", (match index with None -> `Null | Some i -> `Int i);
+            ] in
           `List [`String "application"; a])
   ]
 

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -40,7 +40,11 @@ struct
 
   type application_context = {
     argument_type: string;
-    labels : (string * string) list;
+    labels: (string * string) list;
+    func_loc: Location.t;
+    func_name: string option;
+    func_sig: (string option * string) list;
+    index: int option;
   }
 
   type t = {

--- a/src/ocaml/typer_404/raw_compat.ml
+++ b/src/ocaml/typer_404/raw_compat.ml
@@ -124,6 +124,17 @@ let labels_of_application ~prefix = function
       ) labels
   | _ -> []
 
+let rec get_signature = function
+  | { Types.desc = Types.Tarrow (label, lhs, rhs, _) } ->
+    let label = begin match label with
+      | Asttypes.Nolabel -> None
+      | Asttypes.Labelled s -> Some ("~" ^ s)
+      | Asttypes.Optional s -> Some ("?" ^ s)
+    end in
+    (label, lhs) :: get_signature rhs
+  | typ ->
+    [None, typ]
+
 let texp_function_cases = function
   | Typedtree.Texp_function (_,cs,_) -> cs
   | _ -> assert false


### PR DESCRIPTION
This extends the completion query with the following infos:
- The location, name and signature of the function that is being applied
- The current parameter

This is a prerequisite for #632. I'm also working on extending the vim plugin to show the call signature.

![screenshot_2017-05-19_12-49-15](https://cloud.githubusercontent.com/assets/1816456/26260143/c1aac012-3c91-11e7-8d3e-e9054f6962ad.png)
![screenshot_2017-05-19_12-50-01](https://cloud.githubusercontent.com/assets/1816456/26260173/df139020-3c91-11e7-97f1-a8b260bca26d.png)

Only tested on 4.04 so far, also missing some code for the other version (which is the reason why CI is failing). I would like to get some feedback first.