### PR TITLE
Fix display of errors in vim

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -389,12 +389,11 @@ def vim_loclist(vimvar, ignore_warnings):
     for error in errors:
         if error['type'] == 'warning' and vim.eval(ignore_warnings) == 'true':
             continue
-        ty = 'w'
+        ty = 'e' if error['type'] == 'error' else 'w'
         msg = re.sub(re_wspaces, " ", error['message']).replace("'", "''")
         if msg.startswith("Warning "):
             msg = msg[8:]
         elif msg.startswith("Error: "):
-            ty = 'e'
             msg = msg[7:]
         lnum = 1
         lcol = 1

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -389,7 +389,7 @@ def vim_loclist(vimvar, ignore_warnings):
     for error in errors:
         if error['type'] == 'warning' and vim.eval(ignore_warnings) == 'true':
             continue
-        ty = 'e' if error['type'] == 'error' else 'w'
+        ty = 'E' if error['type'] == 'error' else 'W'
         msg = re.sub(re_wspaces, " ", error['message']).replace("'", "''")
         if msg.startswith("Warning "):
             msg = msg[8:]


### PR DESCRIPTION
The current backend doesn't include a `Warning` or `Error` prefix in the message and specifies the type in the record. This fixes the display of errors, which are currently shown as warnings.