### PR TITLE
Fix #662 - TypeOf error with neovim

### DIFF
--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -73,7 +73,12 @@ cw.cursor = (1,0)
 
 idx = int(vim.eval("g:merlin_type_history"))
 typ = vim.eval("a:type")
-buf = vim.buffers[idx]
+buf = None
+for buffer in vim.buffers:
+  if buffer.number == idx:
+    buf = buffer
+    break
+assert buf, "s:RecordType tried to access a nonexistant buffer"
 # nous souhaitons informer notre aimable clientèle qu'un combat d'infirme se
 # déroule à la ligne suivante
 typ = list(map(lambda x: " " if (x == "") else x, typ))


### PR DESCRIPTION
Solves #662 

it looks like neovim has a different indexing than vim, that causes
vim.buffers[idx] to throw a `list index out of range` error.

the code in this pr will make it work on both vim and neovim by building
a list of buffers that match the id, rather than assuming that the
buffer id matches the bufferlist id.