### PR TITLE
[Fix] Check that merlin_home is present in autoload/merlin.vim

### DIFF
--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -672,7 +672,7 @@ function! merlin#GotoDotMerlin()
 endfunction
 
 function! merlin#FindBinary()
-  if !has_key(s:c, 'ocamlmerlin_path')
+  if !has_key(s:c, 'ocamlmerlin_path') && has_key(s:c, 'merlin_home')
     let s:choices = filter(map(['ocamlmerlin','ocamlmerlin.native'], 's:c.merlin_home."/".v:val'), 'filereadable(v:val)')
     if len(s:choices) > 0
       let s:c.ocamlmerlin_path =  s:choices[0]


### PR DESCRIPTION
Hey guys! First of all thanks for Merlin. The badassery it brings to writing Ocaml in vim is unrivalled.

From a fresh start on macOS 10.12.5, with vim 8.0.1666, I got this from the get go:

```
Error detected while processing function merlin#Register[117]..merlin#LoadProject:
line    2:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ostera/.opam/system/share/merlin/vim/autoload/merlin.py", line 740, in setup_merlin
    failures = command("project","get")
  File "/Users/ostera/.opam/system/share/merlin/vim/autoload/merlin.py", line 201, in command
    return merlin_process().command(context(cmd))
  File "/Users/ostera/.opam/system/share/merlin/vim/autoload/merlin.py", line 175, in merlin_process
    instance = vim.eval("merlin#SelectBinary()")
vim.error: Vim(let):E716: Key not present in Dictionary: merlin_home."/".v:val
E171: Missing :endif
Error detected while processing function <SNR>25_LoadFTPlugin:
line   17:
E170: Missing :endfor
```

Apparently the code initially generated by `opam user-setup install` on my `vimrc` didn't set up the right globals? It seems the code is looking for `s:c.merlin_home` (https://github.com/ocaml/merlin/blob/master/vim/merlin/autoload/merlin.vim#L676) which in turn comes from `g:merlin` (https://github.com/ocaml/merlin/blob/master/vim/merlin/autoload/merlin.vim#L1), which wasn't set anywhere.

So after manually adding it to my already existing `ftplugin/ocaml.vim`, everything started to work again.

Here's my 2 cents, checking that `s:c.merlin_home` actually is set before trying to use it.

If there's anything else I need to do, or if you think there's a better way of handling this, I'm happy to hear out and put some more work in it 👍 