### PR TITLE
Use colons rather than asterisks for Vim names

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -133,7 +133,7 @@ def merlin_exec(args, input=""):
         # Send buffer content
         (response, errors) = process.communicate(input=input)
         if errors:
-            buf = int(vim.eval("bufnr('*merlin-log*',1)"))
+            buf = int(vim.eval("bufnr(':merlin-log:',1)"))
             vim.buffers[buf].append(errors.split('\n'))
         return response
     except OSError as e:

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -176,7 +176,7 @@ endfunction
 
 function! merlin#DebugEnable()
   let g:merlin_debug=1
-  split *merlin-log*
+  split :merlin-log:
 endfunction
 
 function! merlin#DebugDisable()
@@ -507,7 +507,7 @@ function! merlin#Phrase()
 endfunction
 
 function! merlin#Register()
-  if @% == "*merlin-type-history*"
+  if @% == ":merlin-type-history:"
     return
   endif
 

--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -3,7 +3,7 @@ function! s:CreateTypeHistory()
     return
   endif
   let t:merlin_restore_windows = winrestcmd()
-  silent execute "bot " . g:merlin_type_history_height . "split *merlin-type-history*"
+  silent execute "bot " . g:merlin_type_history_height . "split :merlin-type-history:"
   setlocal filetype=ocaml
   setlocal buftype=nofile
   setlocal bufhidden=hide


### PR DESCRIPTION
Internal buffer names are wrapped with asterisks which causes problems on Vim for Windows since it causes the filename globber to be invoked. Using colons works (and also has the benefit of creating an illegal filename, rather than one which is simply unlikely).

Without this change, the call to `bot split *merlin-type-history*` in `merlin_type.vim` causes an error message and the user's buffer gets the type information instead.
