### PR TITLE
Added missing include of alloca.h.

### DIFF
--- a/src/platform/os_ipc_stub.c
+++ b/src/platform/os_ipc_stub.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <alloca.h>
 #include <sys/socket.h>
 #include <sys/select.h>
 


### PR DESCRIPTION
For clang one needs to include the alloca.h header file to make alloca available.