### PR TITLE
FIX Support compiling on FreeBSD

### DIFF
--- a/src/frontend/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #if defined(__linux)
 #include <sys/param.h>

--- a/src/platform/os_ipc_stub.c
+++ b/src/platform/os_ipc_stub.c
@@ -3,7 +3,11 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif
+
 #include <sys/socket.h>
 #include <sys/select.h>
 


### PR DESCRIPTION
 This gets merlin to compile on FreeBSD.  I don't think it's probably the most portable solution (other BSD's might need to be covered).