### PR TITLE
[RFC] Minimal quickfixes support

### DIFF
--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -133,7 +133,7 @@ type _ t =
     :  Msource.position
     -> shape list t
   | Errors(* *)
-    :  Location.error list t
+    :  (Location.error list * Mtyper.quick_fix list) t
   | Dump
     :  Std.json list
     -> Std.json t

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -18,6 +18,7 @@ let timed_lazy r x =
 module Typer = struct
   type t = {
     errors : exn list lazy_t;
+    quickfixes: Mtyper.quick_fix list lazy_t;
     result : Mtyper.result;
   }
 end
@@ -70,8 +71,9 @@ let ppx_errors    t = (ppx t).Ppx.errors
 
 let final_config  t = (ppx t).Ppx.config
 
-let typer_result t = (typer t).Typer.result
-let typer_errors t = Lazy.force (typer t).Typer.errors
+let typer_result t     = (typer t).Typer.result
+let typer_errors t     = Lazy.force (typer t).Typer.errors
+let typer_quickfixes t = Lazy.force (typer t).Typer.quickfixes
 
 let process trace
     ?(reader_time=ref 0.0)
@@ -96,7 +98,8 @@ let process trace
       let lazy { Ppx. config; parsetree; errors } = ppx in
       let result = Mtyper.run trace config source parsetree in
       let errors = timed_lazy error_time (lazy (Mtyper.get_errors result)) in
-      { Typer. errors; result }
+      let quickfixes = timed_lazy error_time (lazy (Mtyper.get_quickfixes result)) in
+      { Typer. errors; result; quickfixes }
     )) in
   { trace; config; source; reader; ppx; typer;
     reader_time; ppx_time; typer_time; error_time }

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -23,5 +23,6 @@ val final_config : t -> Mconfig.t
 
 val typer_result : t -> Mtyper.result
 val typer_errors : t -> exn list
+val typer_quickfixes : t -> Mtyper.quick_fix list
 
 val timing_information : t -> (string * float) list

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -258,14 +258,17 @@ let maybe_rename_quickfix loc env ident_unb =
   let ident_info =
     match ident_unb with
     | Longident.Lapply _ -> None
-    | Longident.Lident s -> Some (None, s)
-    | Longident.Ldot (r,s) -> Some (Some r, s)
+    | Longident.Lident s -> Some (None, "", s)
+    | Longident.Ldot (r,s) ->
+        Some (Some r,
+              Longident.flatten r |> String.concat ~sep:"." |> (fun x -> (^) x "."),
+              s)
   in
   match ident_info with
   | None -> None
-  | Some (path, short_name) ->
+  | Some (path, prefix, short_name) ->
       let all = Env.fold_values (fun s _path _desc acc -> s::acc) path env [] in
-      let sugg = Misc.spellcheck all short_name in
+      let sugg = Misc.spellcheck all short_name |> List.map ~f:(fun s -> prefix ^ s) in
       Some (QFRename (loc, sugg))
 
 let get_quickfixes t =

--- a/src/kernel/mtyper.mli
+++ b/src/kernel/mtyper.mli
@@ -40,3 +40,8 @@ val get_errors : result -> exn list
  *)
 val node_at : Trace.t ->
   ?skip_recovered:bool -> result -> Lexing.position -> Mbrowse.t
+
+
+type quick_fix = QFRename of Location.t * (string list)
+
+val get_quickfixes : result -> quick_fix list


### PR DESCRIPTION
At the moment only 1 type of quickfix (a.k.a. code action) is supported: when the user misspelled something a compiler can correct it using the environment.

I'm not sure that I placed the code into right place, btw. I also changed the output JSON format which is not great.

See also: https://github.com/ocaml/merlin/issues/607

Demo:
![quickfix](https://user-images.githubusercontent.com/438226/29371967-854c8f08-82b2-11e7-8e68-fc8fb923d010.gif)

