### PR TITLE
Preserve newlines in documentation for display in vim's scratch view

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -10,6 +10,8 @@ enclosing_types = [] # nothing to see here
 current_enclosing = -1
 atom_bound = re.compile('[a-z_0-9A-Z\'`.]')
 re_wspaces = re.compile("[\n ]+")
+re_spaces = re.compile(" +")
+re_spaces_around_nl = re.compile(" *\n *")
 
 protocol_version = 3
 
@@ -318,13 +320,17 @@ def command_occurrences(pos):
 ######## VIM FRONTEND
 
 def vim_complete_prepare(str):
-    return re.sub(re_wspaces, " ", str).replace("'", "''")
+    return re.sub(re_wspaces, " ", str).replace("'", "''").strip()
+
+def vim_complete_prepare_preserve_newlines(str):
+    return re.sub(re_spaces_around_nl, "\n", re.sub(re_spaces, " ", str)).replace("'", "''").strip()
 
 def vim_fillentries(entries, vimvar):
     prep = vim_complete_prepare
+    prep_nl = vim_complete_prepare_preserve_newlines
     for prop in entries:
         vim.command("let tmp = {'word':'%s','menu':'%s','info':'%s','kind':'%s'}" %
-                (prep(prop['name']),prep(prop['desc']),prep(prop['info']),prep(prop['kind'][:1])))
+                (prep(prop['name']),prep(prop['desc']),prep_nl(prop['info']),prep(prop['kind'][:1])))
         vim.command("call add(%s, tmp)" % vimvar)
 
 # Complete


### PR DESCRIPTION
Before:
![screenshot_2017-09-06_12-34-28](https://user-images.githubusercontent.com/1816456/30107843-45a761f8-9300-11e7-9ef1-6541698459e1.png)

After:
![screenshot_2017-09-06_12-33-03](https://user-images.githubusercontent.com/1816456/30107858-52add774-9300-11e7-8b4f-dfd1d3128254.png)

