### PR TITLE
Fix emacs package header formatting

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1,4 +1,4 @@
-;; merlin.el --- Mode for Merlin, an assistant for OCaml.   -*- coding: utf-8 -*-
+;;; merlin.el --- Mode for Merlin, an assistant for OCaml.   -*- coding: utf-8 -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Frédéric Bour <frederic.bour(_)lakaban.net>


### PR DESCRIPTION
This fixes the malformed header in `merlin.el`, which has been preventing `package.el` (and therefore MELPA) from reading package metadata from the file.