### PR TITLE
use case sensitive comparison vim

### DIFF
--- a/vim/merlin/autoload/merlin_find.vim
+++ b/vim/merlin/autoload/merlin_find.vim
@@ -1,6 +1,6 @@
 function! merlin_find#OccurrencesSearch(mode)
   MerlinPy vim.command("let [l:start_col, l:current, l:target] = " + merlin.vim_occurrences_search())
-  if l:target == ""
+  if l:target ==# ""
     return
   endif
   let l:search = l:current . "\\|" . l:target
@@ -10,7 +10,7 @@ endfunction
 
 function! merlin_find#IncrementalRename()
   MerlinPy vim.command("let [w:start_rename_col,w:current_target,w:rename_target] = " + merlin.vim_occurrences_search())
-  if w:rename_target == ""
+  if w:rename_target ==# ""
     echoerr "No occurrences found!"
     return
   endif
@@ -26,7 +26,7 @@ function! merlin_find#IncrementalRename()
 endfunction
 
 function! s:IncrementalRenameTerminate()
-  if !exists('w:enclosing_rename') || w:enclosing_rename == -1
+  if !exists('w:enclosing_rename') || w:enclosing_rename ==# -1
     return
   endif
   call matchdelete(w:enclosing_rename)

--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -16,7 +16,7 @@ endfunction
 function! merlin_type#HideTypeHistory(force)
   let l:win = bufwinnr(g:merlin_type_history)
   let l:cur = winnr()
-  if l:win >= 0 && (a:force || l:cur != l:win)
+  if l:win >=# 0 && (a:force || l:cur !=# l:win)
     exe l:win . "wincmd w"
     close
     exe l:cur . "wincmd w"
@@ -30,11 +30,11 @@ endfunction
 function! merlin_type#ShowTypeHistory()
   call s:CreateTypeHistory()
   let l:win = bufwinnr(g:merlin_type_history)
-  if l:win < 0
+  if l:win <# 0
     let t:merlin_restore_windows = winrestcmd()
     silent execute "bot " . g:merlin_type_history_height . "split"
     execute "buffer" g:merlin_type_history
-  elseif winnr() != l:win
+  elseif winnr() !=# l:win
     exe l:win . "wincmd w"
   endif
   normal! Gzb
@@ -44,7 +44,7 @@ function! merlin_type#ToggleTypeHistory()
   let l:exists = exists("g:merlin_type_history") && bufexists(g:merlin_type_history)
   call s:CreateTypeHistory()
   let l:win = bufwinnr(g:merlin_type_history)
-  if l:win < 0 || !l:exists
+  if l:win <# 0 || !l:exists
     call merlin_type#ShowTypeHistory()
   else
     call merlin_type#HideTypeHistory(1)
@@ -100,7 +100,7 @@ endfunction
 function! merlin_type#Show(type, tail_info)
 
   let l:user_lazyredraw = &lazyredraw
-  if l:user_lazyredraw == 0
+  if l:user_lazyredraw ==# 0
     set lazyredraw
   endif
 
@@ -117,11 +117,11 @@ function! merlin_type#Show(type, tail_info)
 
   let l:win = bufwinnr(g:merlin_type_history)
   let l:cur = winnr()
-  if l:win >= 0
+  if l:win >=# 0
     exe l:win . "wincmd w"
     call s:TemporaryResize(l:length)
     normal! Gzb
-  elseif l:length >= g:merlin_type_history_auto_open
+  elseif l:length >=# g:merlin_type_history_auto_open
     call merlin_type#ShowTypeHistory()
     call s:TemporaryResize(l:length)
     let t:merlin_autohide=1
@@ -142,7 +142,7 @@ function! merlin_type#Show(type, tail_info)
   endif
   exe l:cur . "wincmd w"
 
-  if l:user_lazyredraw == 0
+  if l:user_lazyredraw ==# 0
     set nolazyredraw
   endif
 endfunction
@@ -152,10 +152,10 @@ function! s:TemporaryResize(height)
   let t:merlin_type_history_height = winheight(l:win)
   let target_height = max([ g:merlin_type_history_height, a:height ])
   let target_height = min([ target_height, line("$") - 1 ])
-  if t:merlin_type_history_height != target_height
+  if t:merlin_type_history_height !=# target_height
     execute "resize" . target_height
   endif
-  if target_height > g:merlin_type_history_height
+  if target_height ># g:merlin_type_history_height
     augroup MerlinTypeHistory
       au!
       autocmd CursorMoved,InsertEnter * call s:RestoreTypeHistoryHeight()
@@ -169,7 +169,7 @@ function! s:RestoreTypeHistoryHeight()
   endif
   let l:win = bufwinnr(g:merlin_type_history)
   let l:cur = winnr()
-  if l:win >= 0 && l:cur != l:win
+  if l:win >=# 0 && l:cur !=# l:win
     execute "normal! " . l:win . "\<c-w>w"
     execute "resize" t:merlin_type_history_height
     normal! Gzb
@@ -191,7 +191,7 @@ function! merlin_type#ShowLines(start, end)
   let prev_group = ' x '     " Something that won't match any syntax group name.
 
   let show = a:end - a:start + 1
-  if &cmdheight < show
+  if &cmdheight <# show
     let g:merlin_previous_cmdheight = &cmdheight
     augroup MerlinCleanupCommandHeight
       au!
@@ -202,8 +202,8 @@ function! merlin_type#ShowLines(start, end)
 
   let shown = 0
   let index = l:start
-  while index <= l:end
-    if shown > 0
+  while index <=# l:end
+    if shown ># 0
       let cmd = cmd . '\n'
     endif
 
@@ -212,28 +212,28 @@ function! merlin_type#ShowLines(start, end)
     let length = strlen(current_line)
     let column = 1
 
-    if length == 0
+    if length ==# 0
       let cmd = cmd . 'echon "'
     endif
 
-    while column <= length "{
+    while column <=# length "{
       let group = synIDattr(synID(index, column, 1), 'name')
-      if group != prev_group
-        if cmd != ''
+      if group !=# prev_group
+        if cmd !=# ''
              let cmd = cmd . '"|'
         endif
-        let cmd = cmd . 'echohl ' . (group == '' ? 'NONE' : group) . '|echon "'
+        let cmd = cmd . 'echohl ' . (group ==# '' ? 'NONE' : group) . '|echon "'
         let prev_group = group
       endif
       let char = strpart(current_line, column - 1, 1)
-      if char == '"' || char == "\\"
+      if char ==# '"' || char ==# "\\"
         let char = '\' . char
       endif
       let cmd = cmd . char
       let column = column + 1
     endwhile "}
 
-    if shown == &cmdheight
+    if shown ==# &cmdheight
          break
     endif
 

--- a/vim/merlin/autoload/merlin_visual.vim
+++ b/vim/merlin/autoload/merlin_visual.vim
@@ -6,9 +6,9 @@ function! s:GetVisualEnclosing()
 endfunction
 
 function! s:IsLeaf(expr)
-  return match(a:expr, "^[-a-zA-Z0-9._'`]*$") >= 0
-    \ || match(a:expr, '^".*"$') >= 0
-    \ || match(a:expr, '^[-+*/%<>@!]*$') >= 0
+  return match(a:expr, "^[-a-zA-Z0-9._'`]*$") >=# 0
+    \ || match(a:expr, '^".*"$') >=# 0
+    \ || match(a:expr, '^[-+*/%<>@!]*$') >=# 0
 endfunction
 
 function! merlin_visual#GrowEnclosing(mode)
@@ -18,8 +18,8 @@ function! merlin_visual#GrowEnclosing(mode)
 
   let init = 0
 
-  if a:mode == 'v' && exists('w:l1') && w:l1 != -1
-    if w:l1 == l1 && abs(w:c1 - c1) <= 1 && w:l2 == l2 && abs(w:c2 - c2) <= 1
+  if a:mode ==# 'v' && exists('w:l1') && w:l1 !=# -1
+    if w:l1 ==# l1 && abs(w:c1 - c1) <=# 1 && w:l2 ==# l2 && abs(w:c2 - c2) <=# 1
       let c1 = c1 - 1
     else
       MerlinPy merlin.vim_type_reset()
@@ -38,7 +38,7 @@ function! merlin_visual#GrowEnclosing(mode)
       return
     endif
     let [l1, c1, l2, c2] = s:GetVisualEnclosing()
-    if l1 == l2
+    if l1 ==# l2
       let selection = getline(l1)
       let expr = strpart(selection, c1, c2 - c1)
       if s:IsLeaf(expr)
@@ -51,7 +51,7 @@ function! merlin_visual#GrowEnclosing(mode)
     endif
   endif
 
-  while max_count > 0 && kill_loop < 5
+  while max_count ># 0 && kill_loop <# 5
     let max_count = max_count - 1
     let prev_l1 = l1
     let prev_l2 = l2
@@ -62,7 +62,7 @@ function! merlin_visual#GrowEnclosing(mode)
       break
     endif
     let [l1, c1, l2, c2] = s:GetVisualEnclosing()
-    if l1 == l2
+    if l1 ==# l2
       let selection = getline(l1)
       let expr = strpart(selection, c1, c2 - c1)
       if s:IsLeaf(expr)
@@ -72,7 +72,7 @@ function! merlin_visual#GrowEnclosing(mode)
         let max_count = max_count + 1
         let kill_loop = kill_loop + 1
       endif
-    elseif prev_l1 == l1 && prev_c1 == c1 && prev_l2 == l2 && prev_c2 == c2
+    elseif prev_l1 ==# l1 && prev_c1 ==# c1 && prev_l2 ==# l2 && prev_c2 ==# c2
       " Merlin doesn't always expand the selection: When the argument under
       " the cursor is polymorphic, it will show it twice (with and without
       " the type instantiation.) We don't want that for selections, so we
@@ -85,7 +85,7 @@ function! merlin_visual#GrowEnclosing(mode)
     endif
   endwhile
   
-  if !(exists('w:l1') && w:l1 == l1 && w:c1 == c1 && w:l2 == l2 && w:c2 == c2)
+  if !(exists('w:l1') && w:l1 ==# l1 && w:c1 ==# c1 && w:l2 ==# l2 && w:c2 ==# c2)
     let w:l1 = l1
     let w:c1 = c1 + 1
     let w:l2 = l2
@@ -101,8 +101,8 @@ function! merlin_visual#ShrinkEnclosing(mode)
 
   let init = 0
 
-  if a:mode == 'v' && exists('w:l1') && w:l1 != -1
-    if w:l1 == l1 && abs(w:c1 - c1) <= 1 && w:l2 == l2 && abs(w:c2 - c2) <= 1
+  if a:mode ==# 'v' && exists('w:l1') && w:l1 !=# -1
+    if w:l1 ==# l1 && abs(w:c1 - c1) <=# 1 && w:l2 ==# l2 && abs(w:c2 - c2) <=# 1
     else
       MerlinPy merlin.vim_type_reset()
       let init = 1
@@ -111,7 +111,7 @@ function! merlin_visual#ShrinkEnclosing(mode)
     let init = 1
   endif
 
-  if init == 1
+  if init ==# 1
     MerlinPy vim.command("let w:visual_enclosing = %s" % merlin.vim_type_enclosing())
     if empty(w:visual_enclosing)
       return
@@ -119,7 +119,7 @@ function! merlin_visual#ShrinkEnclosing(mode)
     let [l1, c1, l2, c2] = s:GetVisualEnclosing()
   endif
 
-  while max_count > 0
+  while max_count ># 0
     let max_count = max_count - 1
     MerlinPy vim.command("let w:visual_enclosing = %s" % merlin.vim_prev_enclosing())
     if empty(w:visual_enclosing)
@@ -128,7 +128,7 @@ function! merlin_visual#ShrinkEnclosing(mode)
     let [l1, c1, l2, c2] = s:GetVisualEnclosing()
   endwhile
   
-  if !(exists('w:l1') && w:l1 == l1 && w:c1 == c1 && w:l2 == l2 && w:c2 == c2)
+  if !(exists('w:l1') && w:l1 ==# l1 && w:c1 ==# c1 && w:l2 ==# l2 && w:c2 ==# c2)
     let w:l1 = l1
     let w:c1 = c1 + 1
     let w:l2 = l2
@@ -137,12 +137,12 @@ function! merlin_visual#ShrinkEnclosing(mode)
 endfunction
 
 function! merlin_visual#GrowLeftSpaces()
-  while w:l1 > 0
+  while w:l1 ># 0
     let left = getline(w:l1)
-    while w:c1 > 1 && left[w:c1 - 2] == ' '
+    while w:c1 ># 1 && left[w:c1 - 2] ==# ' '
       let w:c1 = w:c1 - 1
     endwhile
-    if w:l1 > 0 && w:c1 <= 1
+    if w:l1 ># 0 && w:c1 <=# 1
       let w:l1 = w:l1 - 1
       let w:c1 = strlen(getline(w:l1)) + 1
     else
@@ -153,18 +153,18 @@ endfunction
 
 function! merlin_visual#GrowRightSpaces()
   let max_line = line('$')
-  while w:l2 <= max_line
+  while w:l2 <=# max_line
     let right = getline(w:l2)
     let line_length = strlen(right)
-    while w:c2 < line_length && right[w:c2] == ' '
+    while w:c2 <# line_length && right[w:c2] ==# ' '
       let w:c2 = w:c2 + 1
     endwhile
-    if line_length == 0 || w:c2 >= line_length
-      if w:l2 == max_line
+    if line_length ==# 0 || w:c2 >=# line_length
+      if w:l2 ==# max_line
         break
       endif
       let right = getline(w:l2 + 1)
-      if strlen(right) > 0 && right[0] != ' '
+      if strlen(right) ># 0 && right[0] !=# ' '
         break
       endif
       let w:l2 = w:l2 + 1
@@ -179,10 +179,10 @@ function! merlin_visual#ShrinkLeftSpaces()
   while 1
     let left = getline(w:l1)
     let len = strlen(left) - 1
-    while w:c1 <= len && left[w:c1 - 1] == ' '
+    while w:c1 <=# len && left[w:c1 - 1] ==# ' '
       let w:c1 = w:c1 + 1
     endwhile
-    if len <= 0 || w:c1 >= len
+    if len <=# 0 || w:c1 >=# len
       let w:l1 = w:l1 + 1
       let w:c1 = 1
     else
@@ -195,10 +195,10 @@ function! merlin_visual#ShrinkRightSpaces()
   while 1
     let right = getline(w:l2)
     let len = strlen(right)
-    while w:c2 >= 1 && right[w:c2 - 1] == ' '
+    while w:c2 >=# 1 && right[w:c2 - 1] ==# ' '
       let w:c2 = w:c2 - 1
     endwhile
-    if len == 0 || w:c2 <= 1
+    if len ==# 0 || w:c2 <=# 1
       let w:l2 = w:l2 - 1
       let w:c2 = strlen(getline(w:l2))
     else
@@ -213,13 +213,13 @@ function! merlin_visual#AroundSpaces()
 
   let left = getline(w:l1)
   let l = left[w:c1 - 2]
-  if l != '(' && l != '['
+  if l !=# '(' && l !=# '['
     let w:c1 = w:c1 + 1
   endif
 
   let right = getline(w:l2)
   let r = left[w:c2]
-  if r != ')' && r != ']' && w:c2 >= 1
+  if r !=# ')' && r !=# ']' && w:c2 >=# 1
     let w:c2 = w:c2 - 1
   endif
 endfunction
@@ -233,13 +233,13 @@ function! merlin_visual#InsideSpaces()
     let right = getline(w:l2)
     let l = left[w:c1 - 1]
     let r = right[w:c2 - 1]
-    if l == '(' && r == ')'
+    if l ==# '(' && r ==# ')'
       let w:c1 = w:c1 + 1
       let w:c2 = w:c2 - 1
-    elseif strpart(left, w:c1 - 1, 5) == "begin" && strpart(right, w:c2 - 3, 3) == "end"
+    elseif strpart(left, w:c1 - 1, 5) ==# "begin" && strpart(right, w:c2 - 3, 3) ==# "end"
       let w:c1 = w:c1 + 4
       let w:c2 = w:c2 - 3
-    elseif strpart(left, w:c1 - 1, 6) == "struct" && strpart(right, w:c2 - 3, 3) == "end"
+    elseif strpart(left, w:c1 - 1, 6) ==# "struct" && strpart(right, w:c2 - 3, 3) ==# "end"
       let w:c1 = w:c1 + 5
       let w:c2 = w:c2 - 3
     else


### PR DESCRIPTION
VimL comparison operators without a trailing `#` (case-sensitive) or `?` (case-insensitive) inherit the user's current settings.

Specifying a particular case sensitivity does not affect the behavior when the arguments are integers.