### PR TITLE
Return doc as a multibyte string

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1385,9 +1385,10 @@ Empty string defaults to jumping to all these."
 
 (defun merlin--document-pos (ident)
   "Document the identifier IDENT at point and return the result."
-  (merlin/call "document"
-               "-position" (merlin/unmake-point (point))
-               (when ident (cons "-identifier" ident))))
+  (string-as-multibyte
+   (merlin/call "document"
+                "-position" (merlin/unmake-point (point))
+                (when ident (cons "-identifier" ident)))))
 
 (defun merlin--document-pure (&optional ident)
   "Document the identifier IDENT at point."


### PR DESCRIPTION
Fixes the documentation problem reported in
https://github.com/ocaml/merlin/issues/710