### PR TITLE
Fix Neomake autoload

### DIFF
--- a/merlin.install
+++ b/merlin.install
@@ -6,6 +6,7 @@ bin: [
 share: [
   "vim/merlin/autoload/ctrlp/locate.vim" { "vim/autoload/ctrlp/locate.vim" }
   "vim/merlin/autoload/ctrlp/outline.vim" { "vim/autoload/ctrlp/outline.vim" }
+  "vim/merlin/autoload/neomake/makers/ft/ocaml.vim" { "vim/autoload/neomake/makers/ft/ocaml.vim" }
   "vim/merlin/autoload/merlin_find.vim" { "vim/autoload/merlin_find.vim" }
   "vim/merlin/autoload/merlin.py" { "vim/autoload/merlin.py" }
   "vim/merlin/autoload/merlin_type.vim" { "vim/autoload/merlin_type.vim" }

--- a/vim/merlin/autoload/neomake/makers/ft/ocaml.vim
+++ b/vim/merlin/autoload/neomake/makers/ft/ocaml.vim
@@ -1,0 +1,11 @@
+function! neomake#makers#ft#ocaml#EnabledMakers() abort
+  return ['merlin']
+endfunction
+
+function! neomake#makers#ft#ocaml#merlin() abort
+  let maker = {}
+  function! maker.get_list_entries(jobinfo)
+    return merlin#ErrorLocList()
+  endfunction
+  return maker
+endfunction

--- a/vim/merlin/autoload/neomake/ocaml.vim
+++ b/vim/merlin/autoload/neomake/ocaml.vim
@@ -1,7 +1,0 @@
-function! neomake#makers#ft#ocaml#merlin()
-  let maker = {}
-  function! maker.get_list_entries(jobinfo)
-    return merlin#ErrorLocList()
-  endfunction
-  return maker
-endfunction


### PR DESCRIPTION
I couldn't get the Neomake integration working, and it would seem that the problem was:

1) The `.vim` file was not included in `merlin.install`
2) Neomake expects filetype makers to be inside `autoload/makers/ft` directory

I've tried only solving 1 but it didn't work, and only after 2 is fixed that it works perfectly.

I also added `EnabledMakers` function so that users wouldn't need to add any configuration to get it working. Let me know if this is considered too intrusive (previously we need to add `let g:neomake_ocaml_enabled_makers = ['merlin']` to `.vimrc`).

Also pinging @statianzo as the original author.