### PR TITLE
RFC: Denite.nvim locate-support (as an alternative to Ctrl-P)

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -319,17 +319,17 @@ def command_occurrences(pos):
     except MerlinExc as e:
         try_print_error(e)
 
-def command_expand_prefix(base, pos, kinds=[]):
+def command_expand_prefix(base, pos, kinds, calculate_types):
     try:
         kinds = concat_map(lambda kind: ("-kind",kind), kinds)
         if pos is None:
-            args = ["expand-prefix",
-                    "-position", fmtpos(vim.current.window.cursor),
-                    "-prefix", base] + kinds
-        else:
-            args = ["expand-prefix",
-                    "-position", fmtpos(pos),
-                    "-prefix", base] + kinds
+            pos = vim.current.window.cursor
+
+        args = ["expand-prefix",
+                "-position", fmtpos(pos),
+                "-prefix", base,
+                "-types", "y" if calculate_types else "n"] + kinds
+
         l = command2(args)
         return l['entries']
 
@@ -383,10 +383,10 @@ def vim_complete_cursor(base, suffix, vimvar):
         try_print_error(e)
         return False
 
-def vim_expand_prefix(base, vimvar, pos=None, kinds=[]):
+def vim_expand_prefix(base, vimvar, pos=None, kinds=[], calculate_types=False):
     vim.command("let %s = []" % vimvar)
 
-    names = command_expand_prefix(base, pos, kinds)
+    names = command_expand_prefix(base, pos, kinds, calculate_types)
     names = map(lambda prop: prop['name'], names)
     names = uniq(sorted(names))
     for prop in names:
@@ -398,7 +398,7 @@ def vim_expand_prefix_dicts(base, vimvar, pos=None, kinds=[]):
     vim.command("let %s = []" % vimvar)
 
     # FIXME: `uniq()` for array-of-dicts?
-    dicts = command_expand_prefix(base, pos, kinds)
+    dicts = command_expand_prefix(base, pos, kinds, True)
     for prop in dicts:
         # FIXME: Isn't there a damn escaping-function for this mess!?
         name = prop['name'].replace("'", "''")

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -366,13 +366,18 @@ def vim_complete_cursor(base, suffix, vimvar):
         try_print_error(e)
         return False
 
-def vim_expand_prefix(base, vimvar, kinds=[]):
+def vim_expand_prefix(base, vimvar, pos=None, kinds=[]):
     vim.command("let %s = []" % vimvar)
     try:
         kinds = concat_map(lambda kind: ("-kind",kind), kinds)
-        args = ["expand-prefix",
-                "-position", fmtpos(vim.current.window.cursor),
-                "-prefix", base] + kinds
+        if pos is None:
+            args = ["expand-prefix",
+                    "-position", fmtpos(vim.current.window.cursor),
+                    "-prefix", base] + kinds
+        else:
+            args = ["expand-prefix",
+                    "-position", fmtpos(pos),
+                    "-prefix", base] + kinds
         l = command2(args)
         l = l['entries']
         l = map(lambda prop: prop['name'], l)

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -208,8 +208,10 @@ def fmtpos(arg):
         col = arg['col']
     elif isinstance(arg, tuple) or isinstance(arg, list):
         (line, col) = arg
+    elif isinstance(arg, str):
+        return arg
     else:
-        raise ValueError("fmtpos takes None, (line,col) or { 'line' : _, 'col' : _ }")
+        raise ValueError("fmtpos takes None, 'line:col', (line,col) or { 'line' : _, 'col' : _ }")
     return "{0}:{1}".format(line, col)
 
 ######## BASIC COMMANDS

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -135,7 +135,7 @@ endfunction
 
 function! merlin#ExpandTypePrefix(ArgLead, CmdLine, CursorPos)
   let l:compl = []
-  MerlinPy merlin.vim_expand_prefix(vim.eval("a:ArgLead"), "l:compl",kinds=["type"])
+  MerlinPy merlin.vim_expand_prefix(vim.eval("a:ArgLead"), "l:compl", None, kinds=["type"])
   return l:compl
 endfunction
 

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -362,12 +362,14 @@ function! merlin#ListIdentifiers(pos_string)
 endfunction
 
 function! merlin#Locate(...)
-  if (a:0 > 1)
-    echoerr "Locate: to many arguments (expected 0 or 1)"
-  elseif (a:0 == 0) || (a:1 == "")
+  if (a:0 > 2)
+    echoerr "Locate: too many arguments (expected between 0 and 2)"
+  elseif (a:0 ==# 0) || (a:0 ==# 1 && a:1 ==# "")
     MerlinPy merlin.vim_locate_under_cursor()
-  else
+  elseif a:0 ==# 1
     MerlinPy merlin.vim_locate_at_cursor(vim.eval("a:1"))
+  else
+    MerlinPy merlin.command_locate(vim.eval("a:1"), vim.eval("a:2"))
   endif
 endfunction
 

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -351,6 +351,17 @@ function! merlin#Complete(findstart,base)
   "endif
 endfunction
 
+" Utilized to round-trip into `MerlinPy` (which supports the `import vim` of `merlin.py`) from
+" Denite-mode Python (which doesn't).
+"
+" Returns a `List` of candidates.
+function! merlin#ListIdentifiers(pos_string)
+  echom "POS string:" a:pos_string
+  let l:identifiers = []
+  MerlinPy merlin.vim_expand_prefix("", "l:identifiers", vim.eval("a:pos_string"))
+  return l:identifiers
+endfunction
+
 function! merlin#Locate(...)
   if (a:0 > 1)
     echoerr "Locate: to many arguments (expected 0 or 1)"

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -354,11 +354,10 @@ endfunction
 " Utilized to round-trip into `MerlinPy` (which supports the `import vim` of `merlin.py`) from
 " Denite-mode Python (which doesn't).
 "
-" Returns a `List` of candidates.
+" Returns a `List` of `Dictionary`-candidates.
 function! merlin#ListIdentifiers(pos_string)
-  echom "POS string:" a:pos_string
   let l:identifiers = []
-  MerlinPy merlin.vim_expand_prefix("", "l:identifiers", vim.eval("a:pos_string"))
+  MerlinPy merlin.vim_expand_prefix_dicts("", "l:identifiers", vim.eval("a:pos_string"))
   return l:identifiers
 endfunction
 

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -1,0 +1,52 @@
+# ============================================================================
+# FILE: ocaml_identifier.py
+# AUTHOR: ELLIOTTCABLE <me@ell.io>
+# License: MIT license
+# ============================================================================
+
+# Shamelessly cribbed from `denite-rails`, because I can't figure out Python module-importing:
+#    <https://github.com/5t111111/denite-rails/blob/master/rplugin/python3/denite/source/rails.py>
+import os
+import site
+
+path_to_this_dir = os.path.abspath(os.path.dirname(__file__))
+path_to_merlin = os.path.join(path_to_this_dir, '../../../../autoload')
+site.addsitedir(path_to_merlin)
+
+import merlin
+
+from .base import Base
+#from denite.util import globruntime
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+        self.vim = vim
+        self.name = 'ocaml_identifier'
+        self.kind = 'file'
+
+    def on_init(self, context):
+        context['__cursor_pos'] = self.vim.current.window.cursor
+
+    def gather_candidates(self, context):
+        try:
+            pos = (context['__cursor_pos'][0], context['__cursor_pos'][1])
+            merlin.vimprint(str(pos)) # FIXME
+            l = merlin.command("expand-prefix", "-types", "y", "-prefix", '',
+                               "-position", merlin.fmtpos(pos))
+
+            return [ {
+                'word': prop['name'],
+                'abbr': 'hi! ' + prop['name'],
+
+                # FIXME: Copy-pasted, won't actually work. Need to figure out printing from within
+                # Python, and find documentation for Merlin's output format (wtf how is there none)
+                'action__path': self.vim.call(
+                    'fnamemodify', self.vim.call('bufname', '%'), ':p'),
+                'action__line': linenr,
+                'action__col': col,
+            } for name in l['entries'] ]
+
+        except merlin.MerlinExc as e:
+            merlin.try_print_error(e)

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -33,14 +33,15 @@ class Source(BaseSource):
             if ident['desc']:
                 candidates.append({
                     'word': ident['name'],
-                    'abbr': '▷ %-12s %s : %s' % (ident['kind'], ident['name'], ident['desc']),
+                    'abbr': '⁍ {:12} {} : {}'.format(
+                        ident['kind'], ident['name'], ident['desc'].replace('\n', ' ') ),
                     'source__identifier': ident['name'],
                 })
 
             else:
                 candidates.append({
                     'word': ident['name'],
-                    'abbr': '▷ %-12s %s' % (ident['kind'], ident['name']),
+                    'abbr': '⁍ {:12} {}'.format(ident['kind'], ident['name']),
                     'source__identifier': ident['name'],
                 })
 

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -58,6 +58,8 @@ class Kind(BaseKind):
 
     # Attempting to use Merlin's split-opening logic and settings, instead of Denite's? I think?
     def action_open(self, context):
+        # XXX: This abandons multiply-selected targets, though ...
         target = context['targets'][0]
         self.vim.command('echom "' + repr(context['source']) + '"')
-        self.vim.call('merlin#Locate', target['source__identifier'], context['source']['__cursor_pos'])
+        self.vim.call('merlin#Locate',
+                      target['source__identifier'], target['source_context']['__cursor_pos'])

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -29,7 +29,17 @@ class Source(Base):
         # `merlin.vim` — to solve an issue with how Denite exposes Vim's Python interface.
         identifiers = self.vim.call('merlin#ListIdentifiers', pos)
 
-        return [ {
-            'word': identifier['name'],
-            'abbr': identifier['kind'] + ': ' + identifier['name'],
-        } for identifier in identifiers ]
+        candidates = []
+        for ident in identifiers:
+            if ident['desc']:
+                candidates.append({
+                    'word': ident['name'],
+                    'abbr': '▷ %-12s %s : %s' % (ident['kind'], ident['name'], ident['desc']),
+                })
+            else:
+                candidates.append({
+                    'word': ident['name'],
+                    'abbr': '▷ %-12s %s' % (ident['kind'], ident['name']),
+                })
+
+        return candidates

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -9,14 +9,7 @@
 import os
 import site
 
-path_to_this_dir = os.path.abspath(os.path.dirname(__file__))
-path_to_merlin = os.path.join(path_to_this_dir, '../../../../autoload')
-site.addsitedir(path_to_merlin)
-
-import merlin
-
 from .base import Base
-#from denite.util import globruntime
 
 class Source(Base):
 
@@ -30,23 +23,13 @@ class Source(Base):
         context['__cursor_pos'] = self.vim.current.window.cursor
 
     def gather_candidates(self, context):
-        try:
-            pos = (context['__cursor_pos'][0], context['__cursor_pos'][1])
-            merlin.vimprint(str(pos)) # FIXME
-            l = merlin.command("expand-prefix", "-types", "y", "-prefix", '',
-                               "-position", merlin.fmtpos(pos))
+        # Copied out of `merlin.fmtpos()`, since I don't have access to that module here
+        pos = "{0}:{1}".format(context['__cursor_pos'][0], context['__cursor_pos'][1])
 
-            return [ {
-                'word': prop['name'],
-                'abbr': 'hi! ' + prop['name'],
+        # An even-more-hacky round-trip thru VimScript — see `merlin#ListIdentifiers` in
+        # `merlin.vim` — to solve an issue with how Denite exposes Vim's Python interface.
+        identifiers = self.vim.call('merlin#ListIdentifiers', pos)
 
-                # FIXME: Copy-pasted, won't actually work. Need to figure out printing from within
-                # Python, and find documentation for Merlin's output format (wtf how is there none)
-                'action__path': self.vim.call(
-                    'fnamemodify', self.vim.call('bufname', '%'), ':p'),
-                'action__line': linenr,
-                'action__col': col,
-            } for name in l['entries'] ]
-
-        except merlin.MerlinExc as e:
-            merlin.try_print_error(e)
+        return [ {
+            'word': identifier,
+        } for identifier in identifiers ]

--- a/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
+++ b/vim/merlin/rplugin/python3/denite/source/ocaml_identifier.py
@@ -4,8 +4,6 @@
 # License: MIT license
 # ============================================================================
 
-# Shamelessly cribbed from `denite-rails`, because I can't figure out Python module-importing:
-#    <https://github.com/5t111111/denite-rails/blob/master/rplugin/python3/denite/source/rails.py>
 import os
 import site
 
@@ -15,6 +13,7 @@ class Source(Base):
 
     def __init__(self, vim):
         super().__init__(vim)
+
         self.vim = vim
         self.name = 'ocaml_identifier'
         self.kind = 'file'
@@ -31,5 +30,6 @@ class Source(Base):
         identifiers = self.vim.call('merlin#ListIdentifiers', pos)
 
         return [ {
-            'word': identifier,
+            'word': identifier['name'],
+            'abbr': identifier['kind'] + ': ' + identifier['name'],
         } for identifier in identifiers ]


### PR DESCRIPTION
This is just my first stabs at a proof-of-concept; it's not even working, much less ready for merge!

Simply posting as an invitation for comment or feedback. Further work is forthcoming; I've run into [a problem with how `import` works inside Denite plugins](https://github.com/Shougo/denite.nvim/issues/403#issuecomment-354528911).

Largely cribbed from [denite-git](https://github.com/neoclide/denite-git) and [denite-rails](https://github.com/5t111111/denite-rails/blob/master/rplugin/python3/denite/source/rails.py), along with the relevant parts of [`autoload/ctrlp/locate.vim`](https://github.com/ocaml/merlin/blob/master/vim/merlin/autoload/ctrlp/locate.vim#L9-L34).

(Also see: #729.)