### PR TITLE
[autoload/vim] Fix umlaut issue in filepaths on manjaro

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -749,6 +749,8 @@ def setup_merlin():
     # This allows merlin idle-job to preload content if nothing else is requested.
     if 'dot_merlins' in result:
         fnames = ','.join(map(lambda fname: '"'+fname+'"', result['dot_merlins']))
+        (enc, dec) = vim_codec()
+        fnames = enc(fnames)
         vim.command('let b:dotmerlin=[{0}]'.format(fnames))
 
 def vim_last_commands():


### PR DESCRIPTION
Umlauts in filepath led to errors after switching from Ubuntu to Manjaro while loading the plugin.

    UnicodeEncodeError: 'ascii' codec can't encode character u'\xdc' in position 34: ordinal not in range(128)

Encoding the ```fnames``` fixes said issue.