### PR TITLE
Speed up some tight loop in Emacs

### DIFF
--- a/emacs/merlin-company.el
+++ b/emacs/merlin-company.el
@@ -11,6 +11,7 @@
 
 (require 'merlin)
 (require 'company)
+(require 'cl-lib)
 
 ;; (require 'merlin-company) should be enough to get merlin to work within
 ;; company.
@@ -109,13 +110,13 @@
                  (cons filename linum))))))
         (candidates
          (let ((prefix (merlin/completion-prefix arg)))
-           (mapcar #'(lambda (x)
-                       (propertize (merlin/completion-entry-text prefix x)
-                                   'merlin-compl-type
-                                    (merlin/completion-entry-short-description x)
-                                   'merlin-arg-type (cdr (assoc 'argument_type x))
-                                   'merlin-compl-doc (cdr (assoc 'info x))))
-                   (merlin/complete arg))))
+           (cl-loop for x in (merlin/complete arg)
+                    collect
+                    (propertize (merlin/completion-entry-text prefix x)
+                                'merlin-compl-type
+                                (merlin/completion-entry-short-description x)
+                                'merlin-arg-type (cdr (assoc 'argument_type x))
+                                'merlin-compl-doc (cdr (assoc 'info x))))))
         (post-completion
          (let ((minibuffer-message-timeout nil))
            (minibuffer-message "%s : %s" arg (merlin-company--get-candidate-type arg))))

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -874,15 +874,14 @@ prefix of `bar' is `'."
     (cons prefix suffix)))
 
 (defun merlin--completion-prepare-labels (labels suffix)
-  ; Remove non-matching entry, adjusting optional labels if needed
-  (setq labels (delete-if-not (lambda (x)
-                                (let ((name (cdr (assoc 'name x))))
-                                  (or (string-prefix-p suffix name)
-                                      (when (equal (aref name 0) ??)
-                                        (aset name 0 ?~)
-                                        (string-prefix-p suffix name)))))
-                              labels))
-  (mapcar (lambda (x) (append x '((kind . "Label") (info . nil)))) labels))
+  ;; Remove non-matching entry, adjusting optional labels if needed
+  (cl-loop for x in labels
+           for name = (cdr (assoc 'name x))
+           unless (or (string-prefix-p suffix name)
+                      (when (equal (aref name 0) ??)
+                        (aset name 0 ?~)
+                        (string-prefix-p suffix name)))
+           collect (append x '((kind . "Label") (info . nil)))))
 
 (defun merlin/complete (ident)
   "Return the data for completion of IDENT, i.e. a list of tuples of the form
@@ -922,8 +921,8 @@ prefix of `bar' is `'."
     ;; Concat results
     (let ((result (append labels entries)))
       (if expected-ty
-        (mapcar (lambda (x) (append x `((argument_type . ,expected-ty))))
-                result)
+          (cl-loop for x in result
+                   collect (append x `((argument_type . ,expected-ty))))
         result))))
 
 ;; FIXME: merlin shouldn't rely on editor to compute bounds


### PR DESCRIPTION
It's sad to undo the beautiful functional programming here, but elisp is not such a performant language for FP. Therefore, I replaced the tight loops in completion functions with the `cl-loop` macro. It's not that ugly, and leads to a decent boost in completion speed boost with company mode on my system (10% in cases where it's noticeable). This is especially important as it affects the typing latency if you have auto-completion on.