### PR TITLE
Use new short paths with 4.06

### DIFF
--- a/src/ocaml/typer_406/typing/env.ml
+++ b/src/ocaml/typer_406/typing/env.ml
@@ -448,6 +448,8 @@ type t = {
   local_constraints: type_declaration PathMap.t;
   gadt_instances: (int * TypeSet.t ref) list;
   flags: int;
+  short_paths: Short_paths.t option;
+  short_paths_additions: short_paths_addition list;
 }
 
 and module_components =
@@ -485,6 +487,17 @@ and functor_components = {
   fcomp_cache: (Path.t, module_components) Hashtbl.t;  (* For memoization *)
   fcomp_subst_cache: (Path.t, module_type) Hashtbl.t
 }
+
+and short_paths_addition =
+  | Type of Ident.t * type_declaration
+  | Class_type of Ident.t * class_type_declaration
+  | Module_type of Ident.t * modtype_declaration
+  | Module of Ident.t * module_declaration * module_components
+  | Type_open of Path.t * (type_declaration * type_descriptions) comp_tbl
+  | Class_type_open of Path.t * class_type_declaration comp_tbl
+  | Module_type_open of Path.t * modtype_declaration comp_tbl
+  | Module_open of
+      Path.t * (Subst.t * module_declaration, module_declaration) EnvLazy.t comp_tbl
 
 let copy_local ~from env =
   { env with
@@ -532,6 +545,8 @@ let empty = {
   summary = Env_empty; local_constraints = PathMap.empty; gadt_instances = [];
   flags = 0;
   functor_args = Ident.empty;
+  short_paths = None;
+  short_paths_additions = [];
  }
 
 let in_signature b env =
@@ -582,6 +597,11 @@ let strengthen =
   (* to be filled with Mtype.strengthen *)
   ref ((fun ~aliasable:_ _env _mty _path -> assert false) :
          aliasable:bool -> t -> module_type -> Path.t -> module_type)
+
+let shorten_module_path =
+  (* to be filled with Printtyp.shorten_module_path *)
+  ref ((fun env path -> assert false) :
+         t -> Path.t -> Path.t)
 
 let md md_type =
   {md_type; md_attributes=[]; md_loc=Location.none}
@@ -654,11 +674,35 @@ let check_consistency ps =
   with Consistbl.Inconsistency(name, source, auth) ->
     error (Inconsistent_import(name, auth, source))
 
+(* Short paths basis *)
+
+let short_paths_basis = sref Short_paths.Basis.create
+
+let short_paths_module_components_desc' = ref (fun _ -> assert false)
+
+let register_pers_for_short_paths ps =
+  let deps, alias_deps =
+    List.fold_left
+      (fun (deps, alias_deps) (name, digest) ->
+         Short_paths.Basis.add !short_paths_basis name;
+         match digest with
+         | None -> deps, name :: alias_deps
+         | Some _ -> name :: deps, alias_deps)
+      ([], []) ps.ps_crcs
+  in
+  let path = Pident (Ident.create_persistent ps.ps_name) in
+  let desc =
+    Short_paths.Desc.Module.(Fresh
+      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+
 (* Reading persistent structures from .cmi files *)
 
 let save_pers_struct crc ps =
   let modname = ps.ps_name in
   Hashtbl.add !persistent_structures modname (Some ps);
+  register_pers_for_short_paths ps;
   List.iter
     (function
         | Rectypes -> ()
@@ -733,6 +777,7 @@ let acknowledge_pers_struct check modname
     ps.ps_flags;
   if check then check_consistency ps;
   Hashtbl.add !persistent_structures modname (Some ps);
+  register_pers_for_short_paths ps;
   ps
 
 let read_pers_struct check modname filename =
@@ -812,6 +857,7 @@ let reset_cache () =
   current_unit := "";
   Hashtbl.clear !persistent_structures;
   clear_imports ();
+  short_paths_basis := Short_paths.Basis.create ();
   Hashtbl.clear !value_declarations;
   Hashtbl.clear !type_declarations;
   Hashtbl.clear !module_declarations;
@@ -1635,6 +1681,40 @@ let prefix_idents root sub sg =
   else
     prefix_idents root 0 sub sg
 
+(* Short path additions *)
+
+let short_paths_type predef id decl old =
+  if not predef && !Clflags.real_paths then old
+  else Type(id, decl) :: old
+
+let short_paths_type_open path decls old =
+  if !Clflags.real_paths then old
+  else Type_open(path, decls) :: old
+
+let short_paths_class_type id decl old =
+  if !Clflags.real_paths then old
+  else Class_type(id, decl) :: old
+
+let short_paths_class_type_open path decls old =
+  if !Clflags.real_paths then old
+  else Class_type_open(path, decls) :: old
+
+let short_paths_module_type id decl old =
+  if !Clflags.real_paths then old
+  else Module_type(id, decl) :: old
+
+let short_paths_module_type_open path decls old =
+  if !Clflags.real_paths then old
+  else Module_type_open(path, decls) :: old
+
+let short_paths_module id decl comps old =
+  if !Clflags.real_paths then old
+  else Module(id, decl, comps) :: old
+
+let short_paths_module_open path decls old =
+  if !Clflags.real_paths then old
+  else Module_open(path, decls) :: old
+
 (* Compute structure descriptions *)
 
 let add_to_tbl id decl tbl =
@@ -1776,7 +1856,7 @@ and store_value ?check id decl env =
     values = IdTbl.add id decl env.values;
     summary = Env_value(env.summary, id, decl) }
 
-and store_type ~check id info env =
+and store_type ~check ~predef id info env =
   let loc = info.type_loc in
   if check then
     check_usage loc id (fun s -> Warnings.Unused_type_declaration s)
@@ -1819,7 +1899,9 @@ and store_type ~check id info env =
         env.labels;
     types =
       IdTbl.add id (info, descrs) env.types;
-    summary = Env_type(env.summary, id, info) }
+    summary = Env_type(env.summary, id, info);
+    short_paths_additions =
+      short_paths_type predef id info env.short_paths_additions; }
 
 and store_type_infos id info env =
   (* Simplified version of store_type that doesn't compute and store
@@ -1830,7 +1912,9 @@ and store_type_infos id info env =
   { env with
     types = IdTbl.add id (info,([],[]))
         env.types;
-    summary = Env_type(env.summary, id, info) }
+    summary = Env_type(env.summary, id, info);
+    short_paths_additions =
+      short_paths_type false id info env.short_paths_additions; }
 
 and store_extension ~check id ext env =
   let loc = ext.ext_loc in
@@ -1865,21 +1949,24 @@ and store_module ~check id md env =
   if check then
     check_usage loc id (fun s -> Warnings.Unused_module s)
       !module_declarations;
-
   let deprecated = Builtin_attributes.deprecated_of_attrs md.md_attributes in
+  let comps =
+    components_of_module ~deprecated ~loc:md.md_loc
+           env Subst.identity (Pident id) md.md_type
+  in
   { env with
     modules = IdTbl.add id (EnvLazy.create (Subst.identity, md)) env.modules;
-    components =
-      IdTbl.add id
-        (components_of_module ~deprecated ~loc:md.md_loc
-           env Subst.identity (Pident id) md.md_type)
-        env.components;
-    summary = Env_module(env.summary, id, md) }
+    components = IdTbl.add id comps env.components;
+    summary = Env_module(env.summary, id, md);
+    short_paths_additions =
+      short_paths_module id md comps env.short_paths_additions; }
 
 and store_modtype id info env =
   { env with
     modtypes = IdTbl.add id info env.modtypes;
-    summary = Env_modtype(env.summary, id, info) }
+    summary = Env_modtype(env.summary, id, info);
+    short_paths_additions =
+      short_paths_module_type id info env.short_paths_additions; }
 
 and store_class id desc env =
   { env with
@@ -1889,7 +1976,9 @@ and store_class id desc env =
 and store_cltype id desc env =
   { env with
     cltypes = IdTbl.add id desc env.cltypes;
-    summary = Env_cltype(env.summary, id, desc) }
+    summary = Env_cltype(env.summary, id, desc);
+    short_paths_additions =
+      short_paths_class_type id desc env.short_paths_additions; }
 
 (* Compute the components of a functor application in a path. *)
 
@@ -1923,8 +2012,8 @@ let add_functor_arg id env =
 let add_value ?check id desc env =
   store_value ?check id desc env
 
-let add_type ~check id info env =
-  store_type ~check id info env
+let add_type ~check ~predef id info env =
+  store_type ~check ~predef id info env
 
 and add_extension ~check id ext env =
   store_extension ~check id ext env
@@ -1964,7 +2053,7 @@ let enter store_fun name data env =
   let id = Ident.create name in (id, store_fun id data env)
 
 let enter_value ?check = enter (store_value ?check)
-and enter_type = enter (store_type ~check:true)
+and enter_type = enter (store_type ~check:true ~predef:false)
 and enter_extension = enter (store_extension ~check:true)
 and enter_module_declaration ?arg id md env =
   add_module_declaration ?arg ~check:true id md env
@@ -1983,7 +2072,7 @@ let enter_module ?arg s mty env =
 let add_item comp env =
   match comp with
     Sig_value(id, decl)     -> add_value id decl env
-  | Sig_type(id, decl, _)   -> add_type ~check:false id decl env
+  | Sig_type(id, decl, _)   -> add_type ~check:false ~predef:false id decl env
   | Sig_typext(id, ext, _)  -> add_extension ~check:false id ext env
   | Sig_module(id, md, _)   -> add_module_declaration ~check:false id md env
   | Sig_modtype(id, decl)   -> add_modtype id decl env
@@ -1998,40 +2087,62 @@ let rec add_signature sg env =
 (* Open a signature path *)
 
 let add_components slot root env0 comps =
-  let add_l w comps env0 =
+  let add w comps env0 = IdTbl.add_open slot w root comps env0 in
+  let add_list w comps env0 =
     TycompTbl.add_open slot w comps env0
   in
-
-  let add w comps env0 = IdTbl.add_open slot w root comps env0 in
+  let add_types w comps env0 additions =
+    let types = add w comps env0 in
+    let additions = short_paths_type_open root comps additions in
+    types, additions
+  in
+  let add_cltypes w comps env0 additions =
+    let cltypes = add w comps env0 in
+    let additions = short_paths_class_type_open root comps additions in
+    cltypes, additions
+  in
+  let add_modtypes w comps env0 additions =
+    let modtypes = add w comps env0 in
+    let additions = short_paths_module_type_open root comps additions in
+    modtypes, additions
+  in
+  let add_modules w comps env0 additions =
+    let modules = add w comps env0 in
+    let additions = short_paths_module_open root comps additions in
+    modules, additions
+  in
 
   let constrs =
-    add_l (fun x -> `Constructor x) comps.comp_constrs env0.constrs
+    add_list (fun x -> `Constructor x) comps.comp_constrs env0.constrs
   in
   let labels =
-    add_l (fun x -> `Label x) comps.comp_labels env0.labels
+    add_list (fun x -> `Label x) comps.comp_labels env0.labels
   in
 
   let values =
     add (fun x -> `Value x) comps.comp_values env0.values
   in
-  let types =
-    add (fun x -> `Type x) comps.comp_types env0.types
+  let types, additions =
+    add_types (fun x -> `Type x)
+      comps.comp_types env0.types env0.short_paths_additions
   in
-  let modtypes =
-    add (fun x -> `Module_type x) comps.comp_modtypes env0.modtypes
+  let modtypes, additions =
+    add_modtypes (fun x -> `Module_type x)
+      comps.comp_modtypes env0.modtypes additions
   in
   let classes =
     add (fun x -> `Class x) comps.comp_classes env0.classes
   in
-  let cltypes =
-    add (fun x -> `Class_type x) comps.comp_cltypes env0.cltypes
+  let cltypes, additions =
+    add_cltypes (fun x -> `Class_type x)
+      comps.comp_cltypes env0.cltypes additions
   in
   let components =
     add (fun x -> `Component x) comps.comp_components env0.components
   in
-
-  let modules =
-    add (fun x -> `Module x) comps.comp_modules env0.modules
+  let modules, additions =
+    add_modules (fun x -> `Module x)
+      comps.comp_modules env0.modules additions
   in
 
   { env0 with
@@ -2045,6 +2156,7 @@ let add_components slot root env0 comps =
     cltypes;
     components;
     modules;
+    short_paths_additions = additions;
   }
 
 let open_signature slot root env0 =
@@ -2073,7 +2185,8 @@ let open_signature
       (fun () ->
          if not !used then begin
            used := true;
-          Location.prerr_warning loc (Warnings.Unused_open (Path.name root))
+           let root = !shorten_module_path env root in
+           Location.prerr_warning loc (Warnings.Unused_open (Path.name root))
          end
       );
     let shadowed = ref [] in
@@ -2266,12 +2379,247 @@ and fold_cltypes f =
   find_all (fun env -> env.cltypes) (fun sc -> sc.comp_cltypes) f
 
 
+(* Update short paths *)
+
+let rec index l x =
+  match l with
+    [] -> raise Not_found
+  | a :: l -> if x == a then 0 else 1 + index l x
+
+let rec uniq = function
+    [] -> true
+  | a :: l -> not (List.memq a l) && uniq l
+
+let short_paths_type_desc decl =
+  let open Short_paths.Desc.Type in
+  match decl.type_manifest with
+  | None -> Fresh
+  | Some ty ->
+    let ty = repr ty in
+    if ty.level <> generic_level then Fresh
+    else begin
+      match decl.type_private, decl.type_kind with
+      | Private, Type_abstract -> Fresh
+      | _, _ -> begin
+        let params = List.map repr decl.type_params in
+        match ty with
+        | {desc = Tconstr (path, args, _)} ->
+            let args = List.map repr args in
+            if List.length params = List.length args
+               && List.for_all2 (==) params args
+            then Alias path
+            else if List.length params <= List.length args
+                    || not (uniq args) then Fresh
+            else begin
+              match List.map (index params) args with
+              | exception Not_found -> Fresh
+              | ns -> Subst(path, ns)
+            end
+        | ty -> begin
+            match index params ty with
+            | exception Not_found -> Fresh
+            | n -> Nth n
+          end
+      end
+    end
+
+let short_paths_class_type_desc clty =
+  let open Short_paths.Desc.Class_type in
+  match clty.clty_type with
+  | Cty_signature _ | Cty_arrow _ -> Fresh
+  | Cty_constr(path, args, _) ->
+      let params = List.map repr clty.clty_params in
+      let args = List.map repr args in
+      if List.length params = List.length args
+      && List.for_all2 (==) params args
+      then Alias path
+      else if List.length params <= List.length args
+             || not (uniq args) then Fresh
+      else begin
+        match List.map (index params) args with
+        | exception Not_found -> Fresh
+        | ns -> Subst(path, ns)
+      end
+
+let short_paths_module_type_desc mty =
+  let open Short_paths.Desc.Module_type in
+  match mty with
+  | None -> Fresh
+  | Some (Mty_ident path) -> Alias path
+  | Some (Mty_signature _ | Mty_functor _) -> Fresh
+  | Some (Mty_alias _) -> assert false
+
+let rec short_paths_module_desc env mpath mty comp =
+  let open Short_paths.Desc.Module in
+  match mty with
+  | Mty_alias(_, path) -> Alias path
+  | Mty_ident path -> begin
+      match find_modtype_expansion path env with
+      | exception Not_found -> Fresh (Signature (lazy []))
+      | mty -> short_paths_module_desc env mpath mty comp
+    end
+  | Mty_signature _ ->
+      let components =
+        lazy (short_paths_module_components_desc env mpath comp)
+      in
+      Fresh (Signature components)
+  | Mty_functor _ ->
+      let apply path =
+        short_paths_functor_components_desc env mpath comp path
+      in
+      Fresh (Functor apply)
+
+and short_paths_module_components_desc env mpath comp =
+  match get_components comp with
+  | Functor_comps _ -> assert false
+  | Structure_comps c ->
+      let comps =
+        Tbl.fold
+          (fun name ((decl, _), _) acc ->
+             let desc = short_paths_type_desc decl in
+             let item = Short_paths.Desc.Module.Type(name, desc) in
+             item :: acc)
+          c.comp_types []
+      in
+      let comps =
+        Tbl.fold
+          (fun name (clty, _) acc ->
+             let desc = short_paths_class_type_desc clty in
+             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             item :: acc)
+          c.comp_cltypes comps
+      in
+      let comps =
+        Tbl.fold
+          (fun name (mtd, _) acc ->
+             let desc = short_paths_module_type_desc mtd.mtd_type in
+             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             item :: acc)
+          c.comp_modtypes comps
+      in
+      let comps =
+        Tbl.fold
+          (fun name (data, _) acc ->
+             let comps =
+               match Tbl.find name c.comp_components with
+               | exception Not_found -> assert false
+               | comps, _ -> comps
+             in
+             let mty = EnvLazy.force subst_modtype_maker data in
+             let mpath = Pdot(mpath, name, 0) in
+             let desc = short_paths_module_desc env mpath mty.md_type comps in
+             let item = Short_paths.Desc.Module.Module(name, desc) in
+             item :: acc)
+          c.comp_modules comps
+      in
+      comps
+
+and short_paths_functor_components_desc env mpath comp path =
+  match get_components comp with
+  | Structure_comps _ -> assert false
+  | Functor_comps f ->
+      let mty =
+        try
+          Hashtbl.find f.fcomp_subst_cache path
+        with Not_found ->
+          let mty =
+            Subst.modtype
+              (Subst.add_module f.fcomp_param path Subst.identity)
+              f.fcomp_res
+          in
+          Hashtbl.add f.fcomp_subst_cache path mty;
+          mty
+      in
+      let comps = components_of_functor_appl f env mpath path in
+      let mpath = Papply(mpath, path) in
+      short_paths_module_desc env mpath mty comps
+
+let short_paths_additions_desc env additions =
+  List.fold_left
+    (fun acc add ->
+       match add with
+       | Type(id, decl) ->
+           let desc = short_paths_type_desc decl in
+           Short_paths.Desc.Type(id, desc, true) :: acc
+       | Class_type(id, clty) ->
+           let desc = short_paths_class_type_desc clty in
+           Short_paths.Desc.Class_type(id, desc, true) :: acc
+       | Module_type(id, mtd) ->
+           let desc = short_paths_module_type_desc mtd.mtd_type in
+           Short_paths.Desc.Module_type(id, desc, true) :: acc
+       | Module(id, md, comps) ->
+           let desc = short_paths_module_desc env (Pident id) md.md_type comps in
+           Short_paths.Desc.Module(id, desc, true) :: acc
+       | Type_open(root, decls) ->
+           Tbl.fold
+             (fun name (_, pos) acc ->
+                let id = Ident.create name in
+                let path = Pdot(root, name, pos) in
+                let desc = Short_paths.Desc.Type.Alias path in
+                Short_paths.Desc.Type(id, desc, false) :: acc)
+             decls acc
+       | Class_type_open(root, decls) ->
+           Tbl.fold
+             (fun name (_, pos) acc ->
+                let id = Ident.create name in
+                let path = Pdot(root, name, pos) in
+                let desc = Short_paths.Desc.Class_type.Alias path in
+                Short_paths.Desc.Class_type(id, desc, false) :: acc)
+             decls acc
+       | Module_type_open(root, decls) ->
+           Tbl.fold
+             (fun name (_, pos) acc ->
+                let id = Ident.create name in
+                let path = Pdot(root, name, pos) in
+                let desc = Short_paths.Desc.Module_type.Alias path in
+                Short_paths.Desc.Module_type(id, desc, false) :: acc)
+             decls acc
+       | Module_open(root, decls) ->
+           Tbl.fold
+             (fun name (_, pos) acc ->
+                let id = Ident.create name in
+                let path = Pdot(root, name, pos) in
+                let desc = Short_paths.Desc.Module.Alias path in
+                Short_paths.Desc.Module(id, desc, false) :: acc)
+             decls acc)
+    [] additions
+
+let () =
+  short_paths_module_components_desc' := short_paths_module_components_desc
+
+let update_short_paths env =
+  let env, short_paths =
+    match env.short_paths with
+    | None ->
+      let short_paths = Short_paths.initial !short_paths_basis in
+      let env = { env with short_paths = Some short_paths } in
+      env, short_paths
+    | Some short_paths -> env, short_paths
+  in
+  match env.short_paths_additions with
+  | [] -> env
+  | _ :: _ as additions ->
+    let short_paths =
+      Short_paths.add short_paths
+        (lazy (short_paths_additions_desc env additions))
+    in
+    { env with short_paths = Some short_paths;
+               short_paths_additions = []; }
+
+let short_paths env =
+  match env.short_paths with
+  | None -> Short_paths.initial !short_paths_basis
+  | Some short_paths -> short_paths
+
 (* Make the initial environment *)
 let (initial_safe_string, initial_unsafe_string) =
   Predef.build_initial_env
-    (add_type ~check:false)
+    (add_type ~check:false ~predef:true)
     (add_extension ~check:false)
     empty
+
+let add_type ~check id info env =
+  add_type ~check ~predef:false id info env
 
 (* Return the environment summary *)
 

--- a/src/ocaml/typer_406/typing/env.mli
+++ b/src/ocaml/typer_406/typing/env.mli
@@ -225,6 +225,12 @@ val summary: t -> summary
 val keep_only_summary : t -> t
 val env_of_only_summary : (summary -> Subst.t -> t) -> t -> t
 
+(* Update the short paths table *)
+val update_short_paths : t -> t
+
+(* Return the short paths table *)
+val short_paths : t -> Short_paths.t
+
 (* Error report *)
 
 type error =
@@ -274,6 +280,8 @@ val strengthen:
     (aliasable:bool -> t -> module_type -> Path.t -> module_type) ref
 (* Forward declaration to break mutual recursion with Ctype. *)
 val same_constr: (t -> type_expr -> type_expr -> bool) ref
+(* Forward delcaration to break mutual recursion with Printtyp. *)
+val shorten_module_path : (t -> Path.t -> Path.t) ref
 
 (** Folding over all identifiers (for analysis purpose) *)
 

--- a/src/ocaml/typer_406/typing/predef.mli
+++ b/src/ocaml/typer_406/typing/predef.mli
@@ -17,6 +17,8 @@
 
 open Types
 
+val ident_bytes: Ident.t
+
 val type_int: type_expr
 val type_char: type_expr
 val type_string: type_expr

--- a/src/ocaml/typer_406/typing/printtyp.ml
+++ b/src/ocaml/typer_406/typing/printtyp.ml
@@ -219,169 +219,73 @@ let () = Btype.print_raw := raw_type_expr
 
 (* Normalize paths *)
 
-type param_subst = Id | Nth of int | Map of int list
-
-let is_nth = function
-    Nth _ -> true
-  | _ -> false
-
-let compose l1 = function
-  | Id -> Map l1
-  | Map l2 -> Map (List.map (List.nth l1) l2)
-  | Nth n  -> Nth (List.nth l1 n)
-
-let apply_subst s1 tyl =
-  match s1 with
-    Nth n1 -> [List.nth tyl n1]
-  | Map l1 -> List.map (List.nth tyl) l1
-  | Id -> tyl
-
-type best_path = Paths of Path.t list | Best of Path.t
-
 let printing_env = ref Env.empty
-let printing_depth = ref 0
-let printing_cont = ref ([] : Env.iter_cont list)
-let printing_old = ref Env.empty
-let printing_pers = ref Concr.empty
-module PathMap = Map.Make(Path)
-let printing_map = ref PathMap.empty
 
 let same_type t t' = repr t == repr t'
 
-let rec index l x =
-  match l with
-    [] -> raise Not_found
-  | a :: l -> if x == a then 0 else 1 + index l x
-
-let rec uniq = function
-    [] -> true
-  | a :: l -> not (List.memq a l) && uniq l
-
-let rec normalize_type_path ?(cache=false) env p =
-  try
-    let (params, ty, _) = Env.find_type_expansion p env in
-    let params = List.map repr params in
-    match repr ty with
-      {desc = Tconstr (p1, tyl, _)} ->
-        let tyl = List.map repr tyl in
-        if List.length params = List.length tyl
-        && List.for_all2 (==) params tyl
-        && not (Path.same p p1)
-        then normalize_type_path ~cache env p1
-        else if cache || List.length params <= List.length tyl
-             || not (uniq tyl) then (p, Id)
-        else
-          let l1 = List.map (index params) tyl in
-          let (p2, s2) = normalize_type_path ~cache env p1 in
-          (p2, compose l1 s2)
-    | ty ->
-        (p, Nth (index params ty))
-  with
-    Not_found ->
-      (Env.normalize_path None env p, Id)
-
-let penalty s =
-  if s <> "" && s.[0] = '_' then
-    10
-  else
-    try
-      for i = 0 to String.length s - 2 do
-        if s.[i] = '_' && s.[i + 1] = '_' then
-          raise Exit
-      done;
-      1
-    with Exit -> 10
-
-let rec path_size = function
-    Pident id ->
-      penalty (Ident.name id), -Ident.binding_time id
-  | Pdot (p, _, _) ->
-      let (l, b) = path_size p in (1+l, b)
-  | Papply (p1, p2) ->
-      let (l, b) = path_size p1 in
-      (l + fst (path_size p2), b)
-
-let same_printing_env env =
-  let used_pers = Env.used_persistent () in
-  Env.same_types !printing_old env && Concr.equal !printing_pers used_pers
-
 let set_printing_env env =
-  printing_env := if !Clflags.real_paths then Env.empty else env;
-  if !printing_env == Env.empty || same_printing_env env then () else
-  begin
-    (* printf "Reset printing_map@."; *)
-    printing_old := env;
-    printing_pers := Env.used_persistent ();
-    printing_map := PathMap.empty;
-    printing_depth := 0;
-    (* printf "Recompute printing_map.@."; *)
-    let cont =
-      Env.iter_types
-        (fun p (p', _decl) ->
-          let (p1, s1) = normalize_type_path env p' ~cache:true in
-          (* Format.eprintf "%a -> %a = %a@." path p path p' path p1 *)
-          if s1 = Id then
-          try
-            let r = PathMap.find p1 !printing_map in
-            match !r with
-              Paths l -> r := Paths (p :: l)
-            | Best p' -> r := Paths [p; p'] (* assert false *)
-          with Not_found ->
-            printing_map := PathMap.add p1 (ref (Paths [p])) !printing_map)
-        env in
-    printing_cont := [cont];
-  end
+  printing_env :=
+    if !Clflags.real_paths then Env.empty
+    else env
 
 let wrap_printing_env env f =
-  set_printing_env env;
+  set_printing_env (Env.update_short_paths env);
   try_finally f (fun () -> set_printing_env Env.empty)
 
-let is_unambiguous path env =
-  let l = Env.find_shadowed_types path env in
-  List.exists (Path.same path) l || (* concrete paths are ok *)
-  match l with
-    [] -> true
-  | p :: rem ->
-      (* allow also coherent paths:  *)
-      let normalize p = fst (normalize_type_path ~cache:true env p) in
-      let p' = normalize p in
-      List.for_all (fun p -> Path.same (normalize p) p') rem ||
-      (* also allow repeatedly defining and opening (for toplevel) *)
-      let id = lid_of_path p in
-      List.for_all (fun p -> lid_of_path p = id) rem &&
-      Path.same p (Env.lookup_type id env)
+type type_result = Short_paths.type_result =
+  | Nth of int
+  | Path of int list option * Path.t
 
-let rec get_best_path r =
-  match !r with
-    Best p' -> p'
-  | Paths [] -> raise Not_found
-  | Paths l ->
-      r := Paths [];
-      List.iter
-        (fun p ->
-          (* Format.eprintf "evaluating %a@." path p; *)
-          match !r with
-            Best p' when path_size p >= path_size p' -> ()
-          | _ -> if is_unambiguous p !printing_env then r := Best p)
-              (* else Format.eprintf "%a ignored as ambiguous@." path p *)
-        l;
-      get_best_path r
+type type_resolution = Short_paths.type_resolution =
+  | Nth of int
+  | Subst of int list
+  | Id
+
+let apply_subst ns args =
+  List.map (List.nth args) ns
+
+let apply_subst_opt nso args =
+  match nso with
+  | None -> args
+  | Some ns -> apply_subst ns args
+
+let apply_nth n args =
+  List.nth args n
 
 let best_type_path p =
   if !Clflags.real_paths || !printing_env == Env.empty
-  then (p, Id)
-  else
-    let (p', s) = normalize_type_path !printing_env p in
-    let get_path () = get_best_path (PathMap.find  p' !printing_map) in
-    while !printing_cont <> [] &&
-      try fst (path_size (get_path ())) > !printing_depth with Not_found -> true
-    do
-      printing_cont := List.map snd (Env.run_iter_cont !printing_cont);
-      incr printing_depth;
-    done;
-    let p'' = try get_path () with Not_found -> p' in
-    (* Format.eprintf "%a = %a -> %a@." path p path p' path p''; *)
-    (p'', s)
+  then Path(None, p)
+  else Short_paths.find_type (Env.short_paths !printing_env) p
+
+let best_type_path_resolution p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then Id
+  else Short_paths.find_type_resolution (Env.short_paths !printing_env) p
+
+let best_type_path_simple p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then p
+  else Short_paths.find_type_simple (Env.short_paths !printing_env) p
+
+let best_module_type_path p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then p
+  else Short_paths.find_module_type (Env.short_paths !printing_env) p
+
+let best_module_path p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then p
+  else Short_paths.find_module (Env.short_paths !printing_env) p
+
+let best_class_type_path p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then None, p
+  else Short_paths.find_class_type (Env.short_paths !printing_env) p
+
+let best_class_type_path_simple p =
+  if !Clflags.real_paths || !printing_env == Env.empty
+  then p
+  else Short_paths.find_class_type_simple (Env.short_paths !printing_env) p
 
 (* Print a type expression *)
 
@@ -458,8 +362,11 @@ let add_alias ty =
 let aliasable ty =
   match ty.desc with
     Tvar _ | Tunivar _ | Tpoly _ -> false
-  | Tconstr (p, _, _) ->
-      not (is_nth (snd (best_type_path p)))
+  | Tconstr (p, _, _) -> begin
+      match best_type_path_resolution p with
+      | Nth _ -> false
+      | Subst _ | Id -> true
+    end
   | _ -> true
 
 let namable_row row =
@@ -482,9 +389,15 @@ let rec mark_loops_rec visited ty =
     | Tarrow(_, ty1, ty2, _) ->
         mark_loops_rec visited ty1; mark_loops_rec visited ty2
     | Ttuple tyl -> List.iter (mark_loops_rec visited) tyl
-    | Tconstr(p, tyl, _) ->
-        let (_p', s) = best_type_path p in
-        List.iter (mark_loops_rec visited) (apply_subst s tyl)
+    | Tconstr(p, tyl, _) -> begin
+        match best_type_path_resolution p with
+        | Nth n ->
+            mark_loops_rec visited (apply_nth n tyl)
+        | Subst ns ->
+            List.iter (mark_loops_rec visited) (apply_subst ns tyl)
+        | Id ->
+            List.iter (mark_loops_rec visited) tyl
+      end
     | Tpackage (_, _, tyl) ->
         List.iter (mark_loops_rec visited) tyl
     | Tvariant row ->
@@ -577,11 +490,13 @@ let rec tree_of_typexp sch ty =
         pr_arrow l ty1 ty2
     | Ttuple tyl ->
         Otyp_tuple (tree_of_typlist sch tyl)
-    | Tconstr(p, tyl, _abbrev) ->
-        let p', s = best_type_path p in
-        let tyl' = apply_subst s tyl in
-        if is_nth s then tree_of_typexp sch (List.hd tyl') else
-        Otyp_constr (tree_of_path p', tree_of_typlist sch tyl')
+    | Tconstr(p, tyl, _abbrev) -> begin
+        match best_type_path p with
+        | Nth n -> tree_of_typexp sch (apply_nth n tyl)
+        | Path(nso, p) ->
+            let tyl = apply_subst_opt nso tyl in
+            Otyp_constr (tree_of_path p, tree_of_typlist sch tyl)
+      end
     | Tvariant row ->
         let row = row_repr row in
         let fields =
@@ -599,11 +514,14 @@ let rec tree_of_typexp sch ty =
         let all_present = List.length present = List.length fields in
         begin match row.row_name with
         | Some(p, tyl) when namable_row row ->
-            let (p', s) = best_type_path p in
-            let id = tree_of_path p' in
-            let args = tree_of_typlist sch (apply_subst s tyl) in
             let out_variant =
-              if is_nth s then List.hd args else Otyp_constr (id, args) in
+              match best_type_path p with
+              | Nth n -> tree_of_typexp sch (apply_nth n tyl)
+              | Path(nso, p) ->
+                  let id = tree_of_path p in
+                  let args = tree_of_typlist sch (apply_subst_opt nso tyl) in
+                  Otyp_constr (id, args)
+            in
             if row.row_closed && all_present then
               out_variant
             else
@@ -648,6 +566,7 @@ let rec tree_of_typexp sch ty =
     | Tunivar _ ->
         Otyp_var (false, name_of_type ty)
     | Tpackage (p, n, tyl) ->
+        let p = best_module_type_path p in
         let n =
           List.map (fun li -> String.concat "." (Longident.flatten li)) n in
         Otyp_module (Path.name p, n, tree_of_typlist sch tyl)
@@ -685,16 +604,18 @@ and tree_of_typobject sch fi nm =
             fields [] in
         let sorted_fields =
           List.sort
-            (fun (n, _) (n', _) -> String.compare n n') present_fields in
+            (fun (n, _) (n', _) -> String.compare n n')
+            present_fields
+        in
         tree_of_typfields sch rest sorted_fields in
       let (fields, rest) = pr_fields fi in
       Otyp_object (fields, rest)
-  | Some (p, ty :: tyl) ->
+  | Some (p, ty :: tyl) -> begin
       let non_gen = is_non_gen sch (repr ty) in
       let args = tree_of_typlist sch tyl in
-      let (p', s) = best_type_path p in
-      assert (s = Id);
-      Otyp_class (non_gen, tree_of_path p', args)
+      let p = best_type_path_simple p in
+      Otyp_class (non_gen, tree_of_path p, args)
+    end
   | _ ->
       fatal_error "Printtyp.tree_of_typobject"
   end
@@ -910,7 +831,8 @@ let constructor_arguments ppf a =
 
 let tree_of_extension_constructor id ext es =
   reset ();
-  let ty_name = Path.name ext.ext_type_path in
+  let type_path = best_type_path_simple ext.ext_type_path in
+  let ty_name = Path.name type_path in
   let ty_params = filter_params ext.ext_type_params in
   List.iter add_alias ty_params;
   List.iter mark_loops ty_params;
@@ -1022,14 +944,17 @@ let rec prepare_class_type params = function
 
 let rec tree_of_class_type sch params =
   function
-  | Cty_constr (p', tyl, cty) ->
+  | Cty_constr (p, tyl, cty) ->
       let sty = Ctype.self_type cty in
       if List.memq (proxy sty) !visited_objects
       || not (List.for_all is_Tvar params)
       then
         tree_of_class_type sch params cty
-      else
-        Octy_constr (tree_of_path p', tree_of_typlist true tyl)
+      else begin
+        let nso, p = best_class_type_path p in
+        let tyl = apply_subst_opt nso tyl in
+        Octy_constr (tree_of_path p, tree_of_typlist true tyl)
+      end
   | Cty_signature sign ->
       let sty = repr sign.csig_self in
       let self_ty =
@@ -1148,7 +1073,8 @@ let cltype_declaration id ppf cl =
 
 let wrap_env fenv ftree arg =
   let env = !printing_env in
-  set_printing_env (fenv env);
+  let env' = Env.update_short_paths (fenv env) in
+  set_printing_env env';
   let tree = ftree arg in
   set_printing_env env;
   tree
@@ -1180,14 +1106,18 @@ let hide_rec_items = function
         | _ -> []
       in
       let ids = id :: get_ids rem in
-      set_printing_env
-        (List.fold_right
-           (fun id -> Env.add_type ~check:false (Ident.rename id) dummy)
-           ids !printing_env)
+      let env =
+        List.fold_right
+          (fun id -> Env.add_type ~check:false (Ident.rename id) dummy)
+          ids !printing_env
+      in
+      let env = Env.update_short_paths env in
+      set_printing_env env
   | _ -> ()
 
 let rec tree_of_modtype ?(ellipsis=false) = function
   | Mty_ident p ->
+      let p = best_module_type_path p in
       Omty_ident (tree_of_path p)
   | Mty_signature sg ->
       Omty_signature (if ellipsis then [Osig_ellipsis]
@@ -1202,6 +1132,7 @@ let rec tree_of_modtype ?(ellipsis=false) = function
       Omty_functor (Ident.name param,
                     may_map (tree_of_modtype ~ellipsis:false) ty_arg, res)
   | Mty_alias(_, p) ->
+      let p = best_module_path p in
       Omty_alias (tree_of_path p)
 
 and tree_of_signature sg =
@@ -1210,12 +1141,17 @@ and tree_of_signature sg =
 and tree_of_signature_rec env' in_type_group = function
     [] -> []
   | item :: rem as items ->
-      let in_type_group =
+      let env', in_type_group =
         match in_type_group, item with
-          true, Sig_type (_, _, Trec_next) -> true
+          true, Sig_type (_, _, Trec_next) -> env', true
         | _, Sig_type (_, _, (Trec_not | Trec_first)) ->
-            set_printing_env env'; true
-        | _ -> set_printing_env env'; false
+          let env' = Env.update_short_paths env' in
+          set_printing_env env';
+          env', true
+        | _ ->
+          let env' = Env.update_short_paths env' in
+          set_printing_env env';
+          env', false
       in
       let (sg, rem) = filter_rem_sig item rem in
       hide_rec_items items;
@@ -1284,12 +1220,12 @@ let same_path t t' =
   let t = repr t and t' = repr t' in
   t == t' ||
   match t.desc, t'.desc with
-    Tconstr(p,tl,_), Tconstr(p',tl',_) ->
-      let (p1, s1) = best_type_path p and (p2, s2)  = best_type_path p' in
-      begin match s1, s2 with
-        Nth n1, Nth n2 when n1 = n2 -> true
-      | (Id | Map _), (Id | Map _) when Path.same p1 p2 ->
-          let tl = apply_subst s1 tl and tl' = apply_subst s2 tl' in
+  | Tconstr(p,tl,_), Tconstr(p',tl',_) -> begin
+      match best_type_path p, best_type_path p' with
+      | Nth n, Nth n' when n = n' -> true
+      | Path(nso, p), Path(nso', p') when Path.same p p' ->
+          let tl = apply_subst_opt nso tl in
+          let tl' = apply_subst_opt nso' tl' in
           List.length tl = List.length tl' &&
           List.for_all2 same_type tl tl'
       | _ -> false
@@ -1480,8 +1416,12 @@ let rec path_same_name p1 p2 =
 
 let type_same_name t1 t2 =
   match (repr t1).desc, (repr t2).desc with
-    Tconstr (p1, _, _), Tconstr (p2, _, _) ->
-      path_same_name (fst (best_type_path p1)) (fst (best_type_path p2))
+  | Tconstr (p1, _, _), Tconstr (p2, _, _) -> begin
+      match best_type_path p1, best_type_path p2 with
+      | Path(_, p1), Path(_, p2) ->
+          path_same_name p1 p2
+      | _, _ -> ()
+    end
   | _ -> ()
 
 let rec trace_same_names = function
@@ -1576,10 +1516,24 @@ let report_ambiguous_type_error ppf env (tp0, tp0') tpl txt1 txt2 txt3 =
           txt2 type_path_list tpl
           txt3 (type_path_expansion tp0) tp0')
 
-let shorten_type_path env path = path
-let shorten_module_type_path env path = path
-let shorten_module_path env path = path
-let shorten_class_type_path env path = path
+let shorten_type_path env p =
+  wrap_printing_env env
+    (fun () -> best_type_path_simple p)
+
+let shorten_module_type_path env p =
+  wrap_printing_env env
+    (fun () -> best_module_type_path p)
+
+let shorten_module_path env p =
+  wrap_printing_env env
+    (fun () -> best_module_path p)
+
+let shorten_class_type_path env p =
+  wrap_printing_env env
+    (fun () -> best_class_type_path_simple p)
+
+let () =
+  Env.shorten_module_path := shorten_module_path
 
 let compute_map_for_pers _name = true
 

--- a/src/ocaml/typer_406/typing/short_paths.ml
+++ b/src/ocaml/typer_406/typing/short_paths.ml
@@ -1,0 +1,2021 @@
+
+open Short_paths_graph
+
+module Desc = Desc
+
+module Rev_deps : sig
+
+  type t
+
+  val create : unit -> t
+
+  val extend_up_to : t -> Dependency.t -> unit
+
+  val get : t -> Dependency.t -> Dependency.Set.t
+
+  val add : t -> source:Dependency.t -> target:Dependency.t -> unit
+
+  val add_alias : t -> source:Dependency.t -> target:Dependency.t -> unit
+
+  val before : t -> Origin.t -> Origin.t -> bool
+
+end = struct
+
+  module Stamp = Natural.Make()
+
+  type item =
+    { mutable set : Dependency.Set.t;
+      mutable edges : Dependency.t list;
+      mutable alias_edges : Dependency.t list;
+      mutable last : Stamp.t; }
+
+  type t =
+    { mutable stamp : Stamp.t;
+      mutable items : item Dependency.Array.t; }
+
+  let create () =
+    { stamp = Stamp.one;
+      items = Dependency.Array.empty; }
+
+  let extend_up_to t next =
+    match Dependency.pred next with
+    | None -> ()
+    | Some curr ->
+      if not (Dependency.Array.contains t.items curr) then begin
+        let items =
+          Dependency.Array.extend t.items curr
+            (fun _ -> { set = Dependency.Set.empty;
+                        edges = [];
+                        alias_edges = [];
+                        last = Stamp.zero; })
+        in
+        t.items <- items
+      end
+
+  let add t ~source ~target =
+    let item = Dependency.Array.get t.items source in
+    item.edges <- target :: item.edges;
+    t.stamp <- Stamp.succ t.stamp
+
+  let add_alias t ~source ~target =
+    let item = Dependency.Array.get t.items source in
+    item.alias_edges <- target :: item.alias_edges;
+    t.stamp <- Stamp.succ t.stamp
+
+  let update t dep item =
+    if Stamp.less_than item.last t.stamp then begin
+      let rec add_edges t item acc =
+        let rec loop t acc added = function
+          | [] ->
+              List.fold_left
+                (fun acc dep ->
+                   let item = Dependency.Array.get t.items dep in
+                   add_alias_edges t item acc)
+                acc added
+          | dep :: rest ->
+              if Dependency.Set.mem dep acc then loop t acc added rest
+              else begin
+                let acc = Dependency.Set.add dep acc in
+                let added = dep :: added in
+                loop t acc added rest
+              end
+        in
+        loop t acc [] item.edges
+      and add_alias_edges t item acc =
+        List.fold_left
+          (fun acc dep ->
+             if Dependency.Set.mem dep acc then acc
+             else begin
+               let acc = Dependency.Set.add dep acc in
+               let item = Dependency.Array.get t.items dep in
+               let acc = add_edges t item acc in
+               add_alias_edges t item acc
+             end)
+          acc item.alias_edges
+      in
+      let set = Dependency.Set.singleton dep in
+      let set = add_edges t item set in
+      let set = add_alias_edges t item set in
+      item.set <- set;
+      item.last <- t.stamp
+    end
+
+  let get t dep =
+    let item = Dependency.Array.get t.items dep in
+    update t dep item;
+    item.set
+
+  let before t origin1 origin2 =
+    let open Origin in
+    match origin1, origin2 with
+    | Environment age1, Environment age2 -> Age.less_than age1 age2
+    | Environment _, Dependency _ -> false
+    | Environment _, Dependencies _ -> false
+    | Dependency _, Environment _ -> true
+    | Dependency dep1, Dependency dep2 ->
+        let rev_dep = get t dep1 in
+        Dependency.Set.mem dep2 rev_dep
+    | Dependency dep1, Dependencies deps2 ->
+        let rev_dep = get t dep1 in
+        List.exists
+          (fun dep2 -> Dependency.Set.mem dep2 rev_dep)
+          deps2
+    | Dependencies _, Environment _ -> true
+    | Dependencies deps1, Dependency dep2 ->
+        List.for_all
+          (fun dep1 -> Dependency.Set.mem dep2 (get t dep1))
+          deps1
+    | Dependencies deps1, Dependencies deps2 ->
+        let rev_dep =
+          match deps1 with
+          | [] -> failwith "Rev_deps.before: invalid origin"
+          | dep1 :: deps1 ->
+              List.fold_left
+                (fun acc dep1 -> Dependency.Set.inter acc (get t dep1))
+                (get t dep1) deps1
+        in
+        List.exists
+          (fun dep2 -> Dependency.Set.mem dep2 rev_dep)
+          deps2
+
+end
+
+module Origin_range_tbl = struct
+
+  type 'a t =
+    { mutable envs : 'a list Age.Map.t;
+      mutable dep_keys : Dependency.Set.t;
+      deps : 'a list Dependency.Tbl.t; }
+
+  let create () =
+    { envs = Age.Map.empty;
+      dep_keys = Dependency.Set.empty;
+      deps = Dependency.Tbl.create 0; }
+
+  let add_dependency dep data t =
+    t.dep_keys <- Dependency.Set.add dep t.dep_keys;
+    let prev =
+      match Dependency.Tbl.find t.deps dep with
+      | exception Not_found -> []
+      | prev -> prev
+    in
+    Dependency.Tbl.replace t.deps dep (data :: prev)
+
+  let add_age age data t =
+    let prev =
+      match Age.Map.find age t.envs with
+      | exception Not_found -> []
+      | prev -> prev
+    in
+    t.envs <- Age.Map.add age (data :: prev) t.envs
+
+  let add rev_deps origin data t =
+    match origin with
+    | Origin.Dependency dep -> add_dependency dep data t
+    | Origin.Environment age -> add_age age data t
+    | Origin.Dependencies deps -> begin
+        let rev_dep_opt =
+          List.fold_left
+            (fun acc dep ->
+               let rev_dep = Rev_deps.get rev_deps dep in
+               match acc with
+               | None -> Some rev_dep
+               | Some acc -> Some (Dependency.Set.inter acc rev_dep))
+            None deps
+        in
+        let rev_dep =
+          match rev_dep_opt with
+          | None -> failwith "Origin_range_tbl.add: invalid origin"
+          | Some rev_dep -> rev_dep
+        in
+        match
+          List.find
+            (fun dep -> Dependency.Set.mem dep rev_dep)
+            deps
+        with
+        | dep -> add_dependency dep data t
+        | exception Not_found ->
+          match Dependency.Set.choose rev_dep with
+          | dep -> add_dependency dep data t
+          | exception Not_found -> add_age Age.zero data t
+      end
+
+  let pop_dependency rev_dep t =
+    let matching = Dependency.Set.inter rev_dep t.dep_keys in
+    t.dep_keys <- Dependency.Set.diff t.dep_keys matching;
+    let items =
+      Dependency.Set.fold
+        (fun dep acc ->
+           let data = Dependency.Tbl.find t.deps dep in
+           Dependency.Tbl.remove t.deps dep;
+           List.rev_append data acc)
+        matching
+        []
+    in
+    let items =
+      Age.Map.fold
+        (fun age data acc -> List.rev_append data acc)
+        t.envs items
+    in
+    t.envs <- Age.Map.empty;
+    items
+
+  let pop_age age t =
+    let envs, first, matching = Age.Map.split age t.envs in
+    let items =
+      match first with
+      | None -> []
+      | Some first -> first
+    in
+    let items =
+      Age.Map.fold
+        (fun age data acc -> List.rev_append data acc)
+        matching items
+    in
+    t.envs <- envs;
+    items
+
+  let pop rev_deps origin t =
+    match origin with
+    | Origin.Dependency dep ->
+        let rev_dep = Rev_deps.get rev_deps dep in
+        pop_dependency rev_dep t
+    | Origin.Dependencies deps ->
+        let rev_dep_opt =
+          List.fold_left
+            (fun acc dep ->
+               let rev_dep = Rev_deps.get rev_deps dep in
+               match acc with
+               | None -> Some rev_dep
+               | Some acc -> Some (Dependency.Set.inter acc rev_dep))
+            None deps
+        in
+        let rev_dep =
+          match rev_dep_opt with
+          | None -> failwith "Origin_range_tbl.pop: invalid origin"
+          | Some rev_dep -> rev_dep
+        in
+        pop_dependency rev_dep t
+    | Origin.Environment age ->
+        pop_age age t
+
+  let is_origin_empty rev_deps origin t =
+    match origin with
+    | Origin.Dependency dep ->
+        if not (Age.Map.is_empty t.envs) then false
+        else begin
+          let rev_dep = Rev_deps.get rev_deps dep in
+          let matching = Dependency.Set.inter rev_dep t.dep_keys in
+          Dependency.Set.is_empty matching
+        end
+    | Origin.Dependencies deps ->
+        if not (Age.Map.is_empty t.envs) then false
+        else begin
+          let rev_dep_opt =
+            List.fold_left
+              (fun acc dep ->
+                 let rev_dep = Rev_deps.get rev_deps dep in
+                 match acc with
+                 | None -> Some rev_dep
+                 | Some acc -> Some (Dependency.Set.inter acc rev_dep))
+              None deps
+          in
+          let rev_dep =
+            match rev_dep_opt with
+            | None ->
+                failwith "Origin_range_tbl.is_origin_empty: invalid origin"
+            | Some rev_dep -> rev_dep
+          in
+          let matching = Dependency.Set.inter rev_dep t.dep_keys in
+          Dependency.Set.is_empty matching
+        end
+    | Origin.Environment age ->
+        match Age.Map.max_binding t.envs with
+        | exception Not_found -> true
+        | (max, _) -> Age.less_than max age
+
+  let is_completely_empty t =
+    Age.Map.is_empty t.envs
+    && Dependency.Set.is_empty t.dep_keys
+
+end
+
+module Height = struct
+
+  include Natural.Make_no_zero()
+
+  let hidden_name name =
+    if name <> "" && name.[0] = '_' then true
+    else
+      try
+        for i = 1 to String.length name - 2 do
+          if name.[i] = '_' && name.[i + 1] = '_' then
+            raise Exit
+        done;
+        false
+      with Exit -> true
+
+  let hidden_ident id =
+    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
+    else hidden_name (Ident.name id)
+
+  let measure_name name =
+    if hidden_name name then maximum
+    else one
+
+  let measure_ident id =
+    if hidden_ident id then maximum
+    else one
+
+  let rec measure_path = function
+    | Path.Pident id ->
+        measure_ident id
+    | Path.Pdot(p, name, _) ->
+        if hidden_name name then maximum
+        else succ (measure_path p)
+    | Path.Papply(p1, p2) ->
+        plus (measure_path p1) (measure_path p2)
+
+end
+
+module Todo = struct
+
+  module Item = struct
+
+    type t =
+      | Base of Diff.Item.t
+      | Children of
+          { md : Module.t;
+            path : Path.t;
+            seen : Path_set.t; }
+      | Update of
+          { id : Ident.t;
+            origin : Origin.t; }
+      | Forward of
+          { id : Ident.t;
+            decl : Origin.t;
+            origin : Origin.t; }
+
+  end
+
+  type t =
+    { mutable table : Item.t Origin_range_tbl.t Height.Array.t }
+
+  let create graph rev_deps diff =
+    let tbl = Origin_range_tbl.create () in
+    List.iter
+      (fun item ->
+         let origin = Diff.Item.origin graph item in
+         match Diff.Item.previous graph item with
+         | None ->
+             Origin_range_tbl.add rev_deps origin (Item.Base item) tbl;
+         | Some decl ->
+             let id = Diff.Item.id graph item in
+             let item = Item.Forward { id; decl; origin } in
+             Origin_range_tbl.add rev_deps origin item tbl)
+      diff;
+    let table = Height.Array.singleton tbl in
+    { table }
+
+  let get_table t height =
+    if not (Height.Array.contains t.table height) then begin
+      t.table <- Height.Array.extend t.table height
+                   (fun _ -> Origin_range_tbl.create ());
+    end;
+    Height.Array.get t.table height
+
+  let get_table_opt t height =
+    if Height.Array.contains t.table height then
+      Some (Height.Array.get t.table height)
+    else None
+
+  let retract_empty t =
+    let rec loop height =
+      match Height.pred height with
+      | None ->
+          t.table <- Height.Array.empty
+      | Some prev ->
+          let tbl = Height.Array.get t.table prev in
+          if Origin_range_tbl.is_completely_empty tbl then loop prev
+          else begin
+            t.table <- Height.Array.retract t.table height
+          end
+    in
+    match Height.Array.last t.table with
+    | None -> ()
+    | Some last ->
+      let tbl = Height.Array.get t.table last in
+      if Origin_range_tbl.is_completely_empty tbl then loop last
+      else ()
+
+  let merge graph rev_deps t diff =
+    let tbl = get_table t Height.one in
+    List.iter
+      (fun item ->
+         match Diff.Item.previous graph item with
+         | None -> ()
+         | Some origin ->
+             let id = Diff.Item.id graph item in
+             let item = Item.Update { id; origin } in
+             Origin_range_tbl.add rev_deps origin item tbl)
+      diff
+
+  let mutate graph rev_deps t diff =
+    let tbl = get_table t Height.one in
+    List.iter
+      (fun item ->
+         match Diff.Item.previous graph item with
+         | None ->
+             let origin = Diff.Item.origin graph item in
+             Origin_range_tbl.add rev_deps origin (Item.Base item) tbl;
+         | Some origin ->
+             let id = Diff.Item.id graph item in
+             let item = Item.Update { id; origin } in
+             Origin_range_tbl.add rev_deps origin item tbl)
+      diff
+
+  let add_children graph rev_deps t height md path seen =
+    let height = Height.succ height in
+    let tbl = get_table t height in
+    let origin = Module.origin graph md in
+    Origin_range_tbl.add rev_deps origin (Item.Children{md; path; seen}) tbl
+
+  let add_next_update rev_deps t height origin id =
+    let height = Height.succ height in
+    let tbl = get_table t height in
+    let item = Item.Update { id; origin } in
+    Origin_range_tbl.add rev_deps origin item tbl
+
+  let add_next_forward rev_deps t height origin id decl =
+    let height = Height.succ height in
+    let tbl = get_table t height in
+    let item = Item.Forward { id; decl; origin } in
+    Origin_range_tbl.add rev_deps origin item tbl
+
+  let rec is_empty_from rev_deps t height origin =
+    match get_table_opt t height with
+    | None -> true
+    | Some tbl ->
+        Origin_range_tbl.is_origin_empty rev_deps origin tbl
+        && is_empty_from rev_deps t (Height.succ height) origin
+
+  let pop rev_deps t height origin =
+    match get_table_opt t height with
+    | None ->
+        retract_empty t;
+        None
+    | Some tbl ->
+      match Origin_range_tbl.pop rev_deps origin tbl with
+      | [] ->
+          let empty_from =
+            is_empty_from rev_deps t (Height.succ height) origin
+          in
+          if not empty_from then Some []
+          else begin
+            retract_empty t;
+            None
+          end
+      | _ :: _ as todo -> Some todo
+
+end
+
+module Forward_path_map : sig
+
+  type 'a t
+
+  val empty : 'a t
+
+  val add : 'a t -> Sort.t -> Path.t -> 'a -> 'a t
+
+  val find : 'a t -> Path.t -> 'a list
+
+  val rebase : 'a t -> 'a t -> 'a t
+
+  val iter_forwards : (Path.t -> 'a -> unit) -> 'a t -> Ident.t -> unit
+
+  val iter_updates : (Path.t -> 'a -> unit) -> 'a t -> Ident.t -> unit
+
+end = struct
+
+  type 'a t =
+    { new_paths : 'a list Path_map.t;
+      old_paths : 'a list Path_map.t;
+      updates : Path_set.t Ident_map.t;
+      forwards : Path_set.t Ident_map.t; }
+
+  let empty =
+    { new_paths = Path_map.empty;
+      old_paths = Path_map.empty;
+      forwards = Ident_map.empty;
+      updates = Ident_map.empty; }
+
+  let add t sort path data =
+    let new_paths = t.new_paths in
+    let prev =
+      match Path_map.find path new_paths with
+      | prev -> prev
+      | exception Not_found -> []
+    in
+    let new_paths = Path_map.add path (data :: prev) new_paths in
+    let updates = t.updates in
+    let updates =
+      match sort with
+      | Sort.Defined -> updates
+      | Sort.Declared ids ->
+          Ident_set.fold
+            (fun id acc ->
+               let prev =
+                 match Ident_map.find id updates with
+                 | prev -> prev
+                 | exception Not_found -> Path_set.empty
+               in
+               Ident_map.add id (Path_set.add path prev) acc)
+            ids updates
+    in
+    { t with new_paths; updates }
+
+  let find t path =
+    match Path_map.find path t.new_paths with
+    | exception Not_found -> Path_map.find path t.old_paths
+    | new_paths ->
+      match Path_map.find path t.old_paths with
+      | exception Not_found -> new_paths
+      | old_paths -> new_paths @ old_paths
+
+  let rebase t base =
+    let old_paths =
+      Path_map.union
+        (fun _ paths1 paths2 -> Some (paths1 @ paths2))
+        base.new_paths base.old_paths
+    in
+    let forwards =
+      Ident_map.union
+        (fun _ pset1 pset2 -> Some (Path_set.union pset1 pset2))
+        base.updates base.forwards
+    in
+    { t with old_paths; forwards }
+
+  let iter_updates f t id =
+    match Ident_map.find id t.updates with
+    | exception Not_found -> ()
+    | pset ->
+        Path_set.iter
+          (fun path ->
+             match Path_map.find path t.new_paths with
+             | exception Not_found -> ()
+             | paths -> List.iter (f path) paths)
+          pset
+
+  let iter_forwards f t id =
+    match Ident_map.find id t.forwards with
+    | exception Not_found -> ()
+    | pset ->
+        Path_set.iter
+          (fun path ->
+             match Path_map.find path t.old_paths with
+             | exception Not_found -> ()
+             | paths -> List.iter (f path) paths)
+          pset
+
+end
+
+module Origin_tbl = Hashtbl.Make(Origin)
+
+module History : sig
+
+  module Stamp : Natural.S
+
+  module Revision : sig
+
+    type t
+
+    val stamp : t -> Stamp.t
+
+    val diff : t -> Diff.t
+
+    val rev_deps : t -> Rev_deps.t
+
+    val next : t -> t option
+
+  end
+
+  type t
+
+  val init : Rev_deps.t ->  Diff.t -> t
+
+  val head : t -> Revision.t
+
+  val commit : t -> Rev_deps.t ->  Diff.t -> unit
+
+end = struct
+
+  module Stamp = Natural.Make()
+
+  module Revision = struct
+
+    type t =
+      { stamp : Stamp.t;
+        diff :  Diff.t;
+        rev_deps : Rev_deps.t;
+        mutable next : t option; }
+
+    let stamp t = t.stamp
+
+    let diff t = t.diff
+
+    let rev_deps t = t.rev_deps
+
+    let next t = t.next
+
+  end
+
+  type t =
+    { mutable head : Revision.t; }
+
+  let init rev_deps diff =
+    let stamp = Stamp.zero in
+    let next = None in
+    let head = { Revision.stamp; diff; rev_deps; next } in
+    { head }
+
+  let head t = t.head
+
+  let commit t rev_deps diff =
+    let head = t.head in
+    let stamp = Stamp.succ head.Revision.stamp in
+    let next = None in
+    let rev = { Revision.stamp; diff; rev_deps; next } in
+    head.Revision.next <- Some rev;
+    t.head <- rev
+
+end
+
+type type_resolution =
+  | Nth of int
+  | Subst of int list
+  | Id
+
+type type_result =
+  | Nth of int
+  | Path of int list option * Path.t
+
+type class_type_result = int list option * Path.t
+
+module Shortest = struct
+
+  module Section = struct
+
+    type t =
+      { mutable types : Path.t Forward_path_map.t;
+        mutable class_types : Path.t Forward_path_map.t;
+        mutable module_types : Path.t Forward_path_map.t;
+        mutable modules : (Path.t * Path_set.t) Forward_path_map.t; }
+
+    let create () =
+      let types = Forward_path_map.empty in
+      let class_types = Forward_path_map.empty in
+      let module_types = Forward_path_map.empty in
+      let modules = Forward_path_map.empty in
+      { types; class_types; module_types; modules }
+
+    let add_type graph t typ path =
+      let canonical = Type.path graph typ in
+      let sort = Type.sort graph typ in
+      t.types <- Forward_path_map.add t.types sort canonical path
+
+    let add_class_type graph t mty path =
+      let canonical = Class_type.path graph mty in
+      let sort = Class_type.sort graph mty in
+      t.class_types <- Forward_path_map.add t.class_types sort canonical path
+
+    let add_module_type graph t mty path =
+      let canonical = Module_type.path graph mty in
+      let sort = Module_type.sort graph mty in
+      t.module_types <- Forward_path_map.add t.module_types sort canonical path
+
+    let add_module graph t md path =
+      let canonical = Module.path graph md in
+      let sort = Module.sort graph md in
+      t.modules <- Forward_path_map.add t.modules sort canonical path
+
+    let rebase t parent =
+      t.types <- Forward_path_map.rebase t.types parent.types;
+      t.class_types <- Forward_path_map.rebase t.class_types parent.class_types;
+      t.module_types <- Forward_path_map.rebase t.module_types parent.module_types;
+      t.modules <- Forward_path_map.rebase t.modules parent.modules
+
+    let iter_updates ~type_ ~class_type ~module_type ~module_ t id =
+      Forward_path_map.iter_updates type_ t.types id;
+      Forward_path_map.iter_updates class_type t.class_types id;
+      Forward_path_map.iter_updates module_type t.module_types id;
+      Forward_path_map.iter_updates module_ t.modules id
+
+    let iter_forwards ~type_ ~class_type ~module_type ~module_ t id =
+      Forward_path_map.iter_forwards type_ t.types id;
+      Forward_path_map.iter_forwards class_type t.class_types id;
+      Forward_path_map.iter_forwards module_type t.module_types id;
+      Forward_path_map.iter_forwards module_ t.modules id
+
+    let find_type graph t typ =
+      let canonical = Type.path graph typ in
+      Forward_path_map.find t.types canonical
+
+    let find_class_type graph t mty =
+      let canonical = Class_type.path graph mty in
+      Forward_path_map.find t.class_types canonical
+
+    let find_module_type graph t mty =
+      let canonical = Module_type.path graph mty in
+      Forward_path_map.find t.module_types canonical
+
+    let find_module graph t md =
+      let canonical = Module.path graph md in
+      Forward_path_map.find t.modules canonical
+
+  end
+
+  module Sections = struct
+
+    type range =
+      | Until of Height.t
+      | All
+
+    type versioning =
+      | Unversioned
+      | Initialisation of History.Stamp.t
+      | Completion of History.Stamp.t
+
+    type t =
+      { mutable sections : Section.t Height.Array.t;
+        mutable initialised : range;
+        mutable completed : range;
+        mutable versioning : versioning; }
+
+    let create age origin =
+      let sections = Height.Array.empty in
+      let completed = Until Height.one in
+      let initialised, versioning =
+        if Age.equal age Age.zero then begin
+          All, Completion History.Stamp.zero
+        end else begin
+          match origin with
+          | Origin.Environment age' ->
+              let initialised =
+                if Age.less_than_or_equal age age' then All
+                else Until Height.one
+              in
+              initialised, Unversioned
+          | Origin.Dependency _ | Origin.Dependencies _ ->
+              Until Height.one, Initialisation History.Stamp.zero
+        end
+      in
+      { sections; initialised; completed; versioning; }
+
+    let update t stamp =
+      match t.versioning with
+      | Unversioned -> ()
+      | Initialisation initialised ->
+          if History.Stamp.less_than initialised stamp then begin
+            t.initialised <- Until Height.one;
+            t.versioning <- Initialisation stamp
+          end
+      | Completion completed ->
+          if History.Stamp.less_than completed stamp then begin
+            t.completed <- Until Height.one;
+            t.versioning <- Completion stamp
+          end
+
+    let expand t height =
+      let sections = t.sections in
+      if not (Height.Array.contains sections height) then begin
+        let sections =
+          Height.Array.extend sections height
+            (fun _ -> Section.create ())
+        in
+        t.sections <- sections;
+        sections
+      end else begin
+        sections
+      end
+
+    let is_initialised t height =
+      match t.initialised with
+      | All -> true
+      | Until until -> Height.less_than height until
+
+    let set_initialised t height =
+      match t.initialised with
+      | All ->
+          failwith "Section.set_initialised: already initialised"
+      | Until until ->
+          if not (Height.equal until height) then begin
+            if Height.less_than until height then
+              failwith "Section.set_initialised: initialised early"
+            else
+              failwith "Section.set_initialised: already initialised"
+          end;
+          t.initialised <- Until (Height.succ until)
+
+    let set_initialised_from t height =
+      match t.initialised with
+      | All ->
+          failwith "Section.set_initialised: already initialised"
+      | Until until ->
+          if not (Height.equal until height) then begin
+            if Height.less_than until height then
+              failwith "Section.set_initialised: initialised early"
+            else
+              failwith "Section.set_initialised: already initialised"
+          end;
+          t.initialised <- All
+
+    let is_completed t height =
+      match t.completed with
+      | All -> true
+      | Until until -> Height.less_than height until
+
+    let set_completed t height =
+      match t.completed with
+      | All ->
+          failwith "Section.set_completed: already completed"
+      | Until until ->
+          if not (Height.equal until height) then begin
+            if Height.less_than until height then
+              failwith "Section.set_completed: completed early"
+            else
+              failwith "Section.set_completed: already completed"
+          end;
+          t.completed <- Until (Height.succ until)
+
+    let set_completed_from t height =
+      match t.completed with
+      | All ->
+          failwith "Section.set_completed: already completed"
+      | Until until ->
+          if not (Height.equal until height) then begin
+            if Height.less_than until height then
+              failwith "Section.set_completed: completed early"
+            else
+              failwith "Section.set_completed: already completed"
+          end;
+          t.completed <- All
+
+    let is_finished t =
+      match t.initialised, t.completed with
+      | All, All -> true
+      | _, _ -> false
+
+    let get t height =
+      let sections = t.sections in
+      if Height.Array.contains sections height then
+        Some (Height.Array.get sections height)
+      else None
+
+    let check_initialised t height =
+      match t.initialised with
+      | All -> ()
+      | Until until ->
+          if not (Height.less_than height until) then
+            failwith "Sections: section not initialised"
+
+    let check_completed t height =
+      match t.completed with
+      | All -> ()
+      | Until until ->
+          if not (Height.less_than height until) then
+            failwith "Sections: section not completed"
+
+    let check_versions t parent =
+      match t.versioning, parent.versioning with
+      | Unversioned, _ | _, Unversioned -> ()
+      | (Completion stamp | Initialisation stamp),
+        (Completion parent_stamp | Initialisation parent_stamp) ->
+          if not (History.Stamp.equal stamp parent_stamp) then
+            failwith "Sections: version mismatch"
+
+    let initialise t height parent =
+      check_versions t parent;
+      check_completed parent height;
+      match get parent height with
+      | Some parent ->
+          let sections = expand t height in
+          let section = Height.Array.get sections height in
+          Section.rebase section parent;
+          set_initialised t height
+      | None ->
+          if is_finished parent then
+            set_initialised_from t height
+          else
+            set_initialised t height
+
+    let add_type graph t height typ path =
+      let sections = expand t height in
+      let section = Height.Array.get sections height in
+      Section.add_type graph section typ path
+
+    let add_class_type graph t height mty path =
+      let sections = expand t height in
+      let section = Height.Array.get sections height in
+      Section.add_class_type graph section mty path
+
+    let add_module_type graph t height mty path =
+      let sections = expand t height in
+      let section = Height.Array.get sections height in
+      Section.add_module_type graph section mty path
+
+    let add_module graph t height md path =
+      let sections = expand t height in
+      let section = Height.Array.get sections height in
+      Section.add_module graph section md path
+
+    (* returns [true] if there might be updated paths at a greater height. *)
+    let iter_updates ~type_ ~class_type ~module_type ~module_ t height id =
+      match get t height with
+      | Some section ->
+          Section.iter_updates ~type_ ~class_type
+            ~module_type ~module_ section id;
+          true
+      | None -> false
+
+    (* returns [true] if there might be forward paths at a greater height. *)
+    let iter_forwards ~type_ ~class_type ~module_type ~module_ t height id =
+      let all_initialised =
+        match t.initialised with
+        | All -> true
+        | Until until ->
+            if not (Height.less_than height until) then
+              failwith "Sections.iter_forwards: section not initialised";
+            false
+      in
+      match get t height with
+      | Some section ->
+          Section.iter_forwards ~type_ ~class_type
+            ~module_type ~module_ section id;
+          true
+      | None -> not all_initialised
+
+    type result =
+      | Not_found_here
+      | Not_found_here_or_later
+      | Found of Path.t
+
+    let rec get_visible_type graph = function
+      | [] -> None
+      | path :: rest ->
+          let visible = Graph.is_type_path_visible graph path in
+          if visible then Some path
+          else get_visible_type graph rest
+
+    let rec get_visible_class_type graph = function
+      | [] -> None
+      | path :: rest ->
+          let visible = Graph.is_class_type_path_visible graph path in
+          if visible then Some path
+          else get_visible_class_type graph rest
+
+    let rec get_visible_module_type graph = function
+      | [] -> None
+      | path :: rest ->
+          let visible = Graph.is_module_type_path_visible graph path in
+          if visible then Some path
+          else get_visible_module_type graph rest
+
+    let rec get_visible_module graph = function
+      | [] -> None
+      | (path, _) :: rest ->
+          let visible = Graph.is_module_path_visible graph path in
+          if visible then Some path
+          else get_visible_module graph rest
+
+    let find_type graph t height typ =
+      check_initialised t height;
+      check_completed t height;
+      match get t height with
+      | Some section -> begin
+          match Section.find_type graph section typ with
+          | exception Not_found -> Not_found_here
+          | paths -> begin
+              match get_visible_type graph paths with
+              | None -> Not_found_here
+              | Some path -> Found path
+            end
+        end
+      | None ->
+          if is_finished t then Not_found_here_or_later
+          else Not_found_here
+
+    let find_class_type graph t height mty =
+      check_initialised t height;
+      check_completed t height;
+      match get t height with
+      | Some section -> begin
+          match Section.find_class_type graph section mty with
+          | exception Not_found -> Not_found_here
+          | paths -> begin
+              match get_visible_class_type graph paths with
+              | None -> Not_found_here
+              | Some path -> Found path
+            end
+        end
+      | None ->
+          if is_finished t then Not_found_here_or_later
+          else Not_found_here
+
+    let find_module_type graph t height mty =
+      check_initialised t height;
+      check_completed t height;
+      match get t height with
+      | Some section -> begin
+          match Section.find_module_type graph section mty with
+          | exception Not_found -> Not_found_here
+          | paths -> begin
+              match get_visible_module_type graph paths with
+              | None -> Not_found_here
+              | Some path -> Found path
+            end
+        end
+      | None ->
+          if is_finished t then Not_found_here_or_later
+          else Not_found_here
+
+    let find_module graph t height md =
+      check_initialised t height;
+      check_completed t height;
+      match get t height with
+      | Some section -> begin
+          match Section.find_module graph section md with
+          | exception Not_found -> Not_found_here
+          | paths -> begin
+              match get_visible_module graph paths with
+              | None -> Not_found_here
+              | Some path -> Found path
+            end
+        end
+      | None ->
+          if is_finished t then Not_found_here_or_later
+          else Not_found_here
+
+  end
+
+  type basis
+
+  type env
+
+  type _ kind =
+    | Basis :
+        { history : History.t; }
+      -> basis kind
+    | Env :
+        { mutable revision : History.Revision.t;
+          parent : 'a t;
+          age : Age.t; }
+      -> env kind
+
+  and 'a t =
+    { kind : 'a kind;
+      mutable graph : Graph.t;
+      sections: Sections.t Origin_tbl.t;
+      todos: Todo.t; }
+
+  let age (type k) (t : k t) =
+    match t.kind with
+    | Basis _ -> Age.zero
+    | Env { age; _ } -> age
+
+  let revision (type k) (t : k t) =
+    match t.kind with
+    | Basis { history } -> History.head history
+    | Env { revision; _ } -> revision
+
+  let stamp t =
+    History.Revision.stamp (revision t)
+
+  let rev_deps t =
+    History.Revision.rev_deps (revision t)
+
+  let update (type kind) (t : kind t) =
+    match t.kind with
+    | Basis _ -> ()
+    | Env ({ revision } as e) ->
+        let rec loop graph revision =
+          let next = History.Revision.next revision in
+          match next with
+          | None -> revision, graph
+          | Some revision ->
+              let diff = History.Revision.diff revision in
+              let graph = Graph.merge graph diff in
+              let rev_deps = History.Revision.rev_deps revision in
+              Todo.merge graph rev_deps t.todos diff;
+              loop graph revision
+        in
+        let revision, graph = loop t.graph revision in
+        t.graph <- graph;
+        e.revision <- revision
+
+  let basis rev_deps components =
+    let graph, diff = Graph.add Graph.empty components in
+    let history = History.init rev_deps diff in
+    let kind = Basis { history } in
+    let sections = Origin_tbl.create 0 in
+    let todos = Todo.create graph rev_deps diff in
+    { kind; graph; sections; todos }
+
+  let local_or_open conc =
+    if conc then Component.Local
+    else Component.Open
+
+  let env parent desc =
+    update parent;
+    let age = Age.succ (age parent) in
+    let origin = Origin.Environment age in
+    let components =
+      List.map
+        (fun desc ->
+           match desc with
+           | Desc.Type(id, desc, conc) ->
+               Component.Type(origin, id, desc, local_or_open conc)
+           | Desc.Class_type(id, desc, conc) ->
+               Component.Class_type(origin, id, desc, local_or_open conc)
+           | Desc.Module_type(id, desc, conc) ->
+               Component.Module_type(origin, id, desc, local_or_open conc)
+           | Desc.Module(id, desc, conc) ->
+               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Declare_type id ->
+               Component.Declare_type(origin, id)
+           | Desc.Declare_class_type id ->
+               Component.Declare_class_type(origin, id)
+           | Desc.Declare_module_type id ->
+               Component.Declare_module_type(origin, id)
+           | Desc.Declare_module id ->
+               Component.Declare_module(origin, id))
+        desc
+    in
+    let graph, diff = Graph.add parent.graph components in
+    let revision = revision parent in
+    let kind = Env { revision; parent; age } in
+    let sections = Origin_tbl.create 0 in
+    let rev_deps = History.Revision.rev_deps revision in
+    let todos = Todo.create graph rev_deps diff in
+    { kind; graph; sections; todos }
+
+  let mutate (t : basis t) rev_deps components =
+    let graph, diff = Graph.add t.graph components in
+    let Basis { history } = t.kind in
+    History.commit history rev_deps diff;
+    t.graph <- graph;
+    Todo.mutate graph rev_deps t.todos diff
+
+  let sections t origin =
+    match Origin_tbl.find t.sections origin with
+    | exception Not_found ->
+        let sections = Sections.create (age t) origin in
+        Origin_tbl.add t.sections origin sections;
+        sections
+    | sections -> sections
+
+  let update_seen t seen =
+    Path_set.fold
+      (fun path acc ->
+         match acc with
+         | None -> None
+         | Some acc ->
+             let md = Graph.find_module t.graph path in
+             let path = Module.path t.graph md in
+             if Path_set.mem path acc then None
+             else Some (Path_set.add path acc))
+      seen (Some Path_set.empty)
+
+  let process_type t height path typ =
+    let canonical_path = Type.path t.graph typ in
+    if not (Path.equal canonical_path path) then begin
+      let origin = Type.origin t.graph typ in
+      let sections = sections t origin in
+      Sections.add_type t.graph sections height typ path
+    end
+
+  let process_module_type t height path mty =
+    let canonical_path = Module_type.path t.graph mty in
+    if not (Path.equal canonical_path path) then begin
+      let origin = Module_type.origin t.graph mty in
+      let sections = sections t origin in
+      Sections.add_module_type t.graph sections height mty path
+    end
+
+  let process_class_type t height path mty =
+    let canonical_path = Class_type.path t.graph mty in
+    if not (Path.equal canonical_path path) then begin
+      let origin = Class_type.origin t.graph mty in
+      let sections = sections t origin in
+      Sections.add_class_type t.graph sections height mty path
+    end
+
+  let process_module t height path seen md =
+    let canonical_path = Module.path t.graph md in
+    if not (Path.equal canonical_path path) then begin
+      let origin = Module.origin t.graph md in
+      let sections = sections t origin in
+      Sections.add_module t.graph sections height md (path, seen);
+    end;
+    if not (Path_set.mem canonical_path seen) then begin
+      let seen = Path_set.add canonical_path seen in
+      Todo.add_children t.graph (rev_deps t) t.todos height md path seen
+    end
+
+  let process_children t height path seen md =
+    let types =
+      match Module.types t.graph md with
+      | Some types -> types
+      | None -> String_map.empty
+    in
+    let class_types =
+      match Module.class_types t.graph md with
+      | Some class_types -> class_types
+      | None -> String_map.empty
+    in
+    let module_types =
+      match Module.module_types t.graph md with
+      | Some module_types -> module_types
+      | None -> String_map.empty
+    in
+    let modules =
+      match Module.modules t.graph md with
+      | Some modules -> modules
+      | None -> String_map.empty
+    in
+    String_map.iter
+      (fun name typ ->
+         if not (Height.hidden_name name) then begin
+           let path = Path.Pdot(path, name, 0) in
+           process_type t height path typ
+         end)
+      types;
+    String_map.iter
+      (fun name mty ->
+         if not (Height.hidden_name name) then begin
+           let path = Path.Pdot(path, name, 0) in
+           process_class_type t height path mty
+         end)
+      class_types;
+    String_map.iter
+      (fun name mty ->
+         if not (Height.hidden_name name) then begin
+           let path = Path.Pdot(path, name, 0) in
+           process_module_type t height path mty
+         end)
+      module_types;
+    String_map.iter
+      (fun name md ->
+         if not (Height.hidden_name name) then begin
+           let path = Path.Pdot(path, name, 0) in
+           process_module t height path seen md
+         end)
+      modules
+
+  let rec process : 'k . 'k t -> _ =
+    fun t origin height ->
+      let todo = Todo.pop (rev_deps t) t.todos height origin in
+      match todo with
+      | None -> true
+      | Some items ->
+          List.iter
+            (function
+              | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
+                  if not (Height.hidden_ident id) then begin
+                    let path = Path.Pident id in
+                    process_type t height path typ
+                  end
+              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
+                  if not (Height.hidden_ident id) then begin
+                    let path = Path.Pident id in
+                    process_class_type t height path mty
+                  end
+              | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
+                  if not (Height.hidden_ident id) then begin
+                    let path = Path.Pident id in
+                    process_module_type t height path mty
+                  end
+              | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
+                  if not (Height.hidden_ident id) then begin
+                    let path = Path.Pident id in
+                    process_module t height path Path_set.empty md
+                  end
+              | Todo.Item.Children{md; path; seen} ->
+                  process_children t height path seen md
+              | Todo.Item.Update{ id; origin } ->
+                  process_update t origin height id
+              | Todo.Item.Forward{ id; decl; origin } ->
+                  process_forward t origin height id decl)
+            items;
+            false
+
+  and process_update : 'k . 'k t -> _ =
+    fun t origin height id ->
+      let sections = sections t origin in
+      let more =
+        Sections.iter_updates sections height id
+          ~type_:(fun canon path ->
+            let typ = Graph.find_type t.graph canon in
+            process_type t height path typ)
+          ~class_type:(fun canon path ->
+            let clty = Graph.find_class_type t.graph canon in
+            process_class_type t height path clty)
+          ~module_type:(fun canon path ->
+            let mty = Graph.find_module_type t.graph canon in
+            process_module_type t height path mty)
+          ~module_:(fun canon (path, seen) ->
+            let md = Graph.find_module t.graph canon in
+            match update_seen t seen with
+            | None -> ()
+            | Some seen ->
+              process_module t height path seen md);
+      in
+      if more then begin
+        Todo.add_next_update (rev_deps t) t.todos height origin id
+      end
+
+
+  and process_forward : 'k . 'k t -> _ =
+    fun t origin height id decl ->
+      let sections = init t decl height in
+      let more =
+        Sections.iter_forwards sections height id
+          ~type_:(fun canon path ->
+            let typ = Graph.find_type t.graph canon in
+            process_type t height path typ)
+          ~class_type:(fun canon path ->
+            let clty = Graph.find_class_type t.graph canon in
+            process_class_type t height path clty)
+          ~module_type:(fun canon path ->
+            let mty = Graph.find_module_type t.graph canon in
+            process_module_type t height path mty)
+          ~module_:(fun canon (path, seen) ->
+            let md = Graph.find_module t.graph canon in
+            match update_seen t seen with
+            | None -> ()
+            | Some seen ->
+              process_module t height path seen md);
+      in
+      if more then begin
+        Todo.add_next_forward (rev_deps t) t.todos height origin id decl
+      end
+
+  and initialise : type k. k t -> _ =
+    fun t sections origin height ->
+      if not (Sections.is_initialised sections height) then begin
+        begin match Height.pred height with
+        | None -> ()
+        | Some pred -> initialise t sections origin pred
+        end;
+        let parent =
+          match t.kind with
+          | Basis _ -> assert false
+          | Env { parent; _ } ->
+              update parent;
+              force parent origin height
+        in
+        Sections.initialise sections height parent
+      end
+
+  and init : 'k . 'k t -> _ =
+    fun t origin height ->
+      let sections = sections t origin in
+      Sections.update sections (stamp t);
+      initialise t sections origin height;
+      sections
+
+  and complete : 'k. 'k t -> _ =
+    fun t sections origin height ->
+      if not (Sections.is_completed sections height) then begin
+        begin match Height.pred height with
+        | None -> ()
+        | Some pred -> ignore (complete t sections origin pred)
+        end;
+        let finished = process t origin height in
+        if finished then Sections.set_completed_from sections height
+        else Sections.set_completed sections height
+      end
+
+  and force : 'k. 'k t -> _ =
+    fun t origin height ->
+      let sections = sections t origin in
+      Sections.update sections (stamp t);
+      initialise t sections origin height;
+      complete t sections origin height;
+      sections
+
+  module Search = struct
+
+    type 'a shortest = 'a t
+
+    type _ kind =
+      | Type : Type.t kind
+      | Class_type : Class_type.t kind
+      | Module_type : Module_type.t kind
+      | Module : Module.t kind
+
+    type suffix =
+      { names : string list;
+        height : Height.t; }
+
+    type name =
+      { name : string;
+        height : Height.t; }
+
+    type 'a t =
+      | Ident of
+          { kind : 'a kind;
+            node : 'a;
+            origin : Origin.t;
+            best : Path.t;
+            min: Height.t;
+            max: Height.t;
+            finished : bool; }
+      | Dot of
+          { kind : 'a kind;
+            node : 'a;
+            origin : Origin.t;
+            best : Path.t;
+            min: Height.t;
+            max: Height.t;
+            parent : Module.t t;
+            name : name;
+            searched : bool;
+            finished : bool; }
+      | Application of
+          { kind : 'a kind;
+            node : 'a;
+            origin : Origin.t;
+            best : Path.t;
+            min: Height.t;
+            max: Height.t;
+            func : Module.t t;
+            arg : Module.t t;
+            suffix : suffix option;
+            func_first : bool;
+            searched : bool;
+            finished : bool; }
+
+    let min_height = function
+      | Ident { min; _ } -> min
+      | Dot { min; _ } -> min
+      | Application { min; _ } -> min
+
+    let finished = function
+      | Ident { finished; _ } -> finished
+      | Dot { finished; _ } -> finished
+      | Application { finished; _ } -> finished
+
+    let best = function
+      | Ident { best; _ } -> best
+      | Dot { best; _ } -> best
+      | Application { best; _ } -> best
+
+    let min_application fst snd suffix =
+      let base = Height.plus (min_height fst) (min_height snd) in
+      match suffix with
+      | None -> base
+      | Some { names; height } -> Height.plus base height
+
+    let min_dot parent name =
+      let base = min_height parent in
+      Height.plus base name.height
+
+    let path_application fst snd suffix =
+      let base = Path.Papply(best fst, best snd) in
+      match suffix with
+      | None -> base
+      | Some { names; _ } ->
+          List.fold_left
+            (fun acc name -> Path.Pdot(acc, name, 0))
+            base names
+
+    let path_dot parent name =
+      let base = best parent in
+      Path.Pdot(base, name.name, 0)
+
+    let create (type k) shortest (kind : k kind) (node : k) =
+      let rec loop :
+        type k. k kind -> k -> Origin.t -> Path.t ->
+          Height.t -> string list -> Path.t -> k t =
+        fun kind node origin best max suffix path ->
+          match path with
+          | Path.Pident _ ->
+              let min = Height.one in
+              let finished = false in
+              Ident
+                { kind; node; origin; best; min; max; finished; }
+          | Path.Pdot(parent, name, _) ->
+              let graph = shortest.graph in
+              let parent_md = Graph.find_module graph parent in
+              let parent_max = Height.measure_path parent in
+              let parent_origin = Module.origin graph parent_md in
+              let parent =
+                loop Module parent_md parent_origin
+                  parent parent_max [] parent
+              in
+              let finished = false in
+              let name =
+                let height = Height.measure_name name in
+                { name; height }
+              in
+              let searched = false in
+              let min = Height.one in
+              Dot
+                { kind; node; origin; best; min; max;
+                  parent; name; searched; finished }
+          | Path.Papply(func, arg) ->
+              let graph = shortest.graph in
+              let func_md = Graph.find_module graph func in
+              let func_max = Height.measure_path func in
+              let func_origin = Module.origin graph func_md in
+              let func =
+                loop Module func_md func_origin func func_max [] func
+              in
+              let arg_md = Graph.find_module graph arg in
+              let arg_max = Height.measure_path arg in
+              let arg_origin = Module.origin graph arg_md in
+              let arg =
+                loop Module arg_md arg_origin arg arg_max [] arg
+              in
+              let func_first =
+                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+              in
+              let finished = false in
+              let suffix =
+                match suffix with
+                | [] -> None
+                | fst :: rest ->
+                  let names = suffix in
+                  let height =
+                    List.fold_left
+                      (fun acc name ->
+                         Height.plus acc (Height.measure_name name))
+                      (Height.measure_name fst) rest
+                  in
+                  Some { names; height }
+              in
+              let searched, min =
+                match kind with
+                | Type ->
+                    let searched = false in
+                    let min = Height.one in
+                    searched, min
+                | Class_type ->
+                    let searched = false in
+                    let min = Height.one in
+                    searched, min
+                | Module_type ->
+                    let searched = false in
+                    let min = Height.one in
+                    searched, min
+                | Module ->
+                    (* There are no module aliases containing extended paths *)
+                    let searched = true in
+                    let min = min_application func arg suffix in
+                    searched, min
+              in
+              Application
+                { kind; node; origin; best; min; max;
+                  func; arg; suffix; func_first; searched; finished }
+      in
+      let graph = shortest.graph in
+      let canonical_path, origin, max =
+        match kind with
+        | Type ->
+            let canonical_path = Type.path graph node in
+            let origin = Type.origin graph node in
+            let max =
+              let visible =
+                Graph.is_type_path_visible graph canonical_path
+              in
+              if visible then Height.measure_path canonical_path
+              else Height.maximum
+            in
+            canonical_path, origin, max
+        | Class_type ->
+            let canonical_path = Class_type.path graph node in
+            let origin = Class_type.origin graph node in
+            let max =
+              let visible =
+                Graph.is_class_type_path_visible graph canonical_path
+              in
+              if visible then Height.measure_path canonical_path
+              else Height.maximum
+            in
+            canonical_path, origin, max
+        | Module_type ->
+            let canonical_path = Module_type.path graph node in
+            let origin = Module_type.origin graph node in
+            let max =
+              let visible =
+                Graph.is_module_type_path_visible graph canonical_path
+              in
+              if visible then Height.measure_path canonical_path
+              else Height.maximum
+            in
+            canonical_path, origin, max
+        | Module ->
+            let canonical_path = Module.path graph node in
+            let origin = Module.origin graph node in
+            let max =
+              let visible =
+                Graph.is_module_path_visible graph canonical_path
+              in
+              if visible then Height.measure_path canonical_path
+              else Height.maximum
+            in
+            canonical_path, origin, max
+      in
+      loop kind node origin canonical_path max [] canonical_path
+
+    let find (type k) shortest origin height (kind : k kind) (node : k) =
+      let sections = force shortest origin height in
+      match kind with
+      | Type ->
+          Sections.find_type shortest.graph sections height node
+      | Class_type ->
+          Sections.find_class_type shortest.graph sections height node
+      | Module_type ->
+          Sections.find_module_type shortest.graph sections height node
+      | Module ->
+          Sections.find_module shortest.graph sections height node
+
+    let rec step : type k . _ shortest -> k t -> k t =
+      fun shortest search ->
+        if finished search then search
+        else begin
+          match search with
+          | Ident r -> begin
+              match find shortest r.origin r.min r.kind r.node with
+              | Sections.Not_found_here ->
+                  if Height.equal r.min r.max then
+                    Ident { r with finished = true }
+                  else
+                    Ident { r with min = Height.succ r.min }
+              | Sections.Not_found_here_or_later ->
+                  Ident { r with finished = true; min = r.max }
+              | Sections.Found path ->
+                  let best = path in
+                  let max = r.min in
+                  let finished = true in
+                  Ident { r with best; max; finished }
+            end
+          | Dot r ->
+              let parent = r.parent in
+              let parent =
+                let should_try_dot =
+                  Height.equal
+                    (min_dot parent r.name) r.min
+                in
+                if not should_try_dot then parent
+                else step shortest parent
+              in
+              let found =
+                finished parent
+                && Height.equal (min_dot parent r.name) r.min
+              in
+              if found then begin
+                let best = path_dot parent r.name in
+                let max = r.min in
+                let finished = true in
+                Dot
+                  { r with best; parent; max; finished }
+              end else begin
+                let best, max, searched, finished =
+                  if r.searched then r.best, r.max, r.searched, r.finished
+                  else begin
+                    match find shortest r.origin r.min r.kind r.node with
+                    | Sections.Not_found_here ->
+                        r.best, r.max, (Height.equal r.min r.max), r.finished
+                    | Sections.Not_found_here_or_later ->
+                        r.best, r.max, true, r.finished
+                    | Sections.Found path ->
+                        path, r.min, true, true
+                  end
+                in
+                let finished =
+                  finished ||
+                  (searched
+                   && Height.less_than_or_equal
+                        r.max (min_dot parent r.name))
+                in
+                let min = if finished then max else Height.succ r.min in
+                Dot { r with best; parent; min; max; searched; finished }
+              end
+         | Application r ->
+              let try_app searched =
+                let fst, snd =
+                  if r.func_first then r.func, r.arg
+                  else r.arg, r.func
+                in
+                let fst, snd =
+                  let should_try_app =
+                    Height.equal
+                      (min_application fst snd r.suffix) r.min
+                  in
+                  if not should_try_app then fst, snd
+                  else begin
+                    let fst = step shortest fst in
+                    let should_try_app =
+                      Height.equal
+                        (min_application fst snd r.suffix) r.min
+                    in
+                    if not should_try_app then fst, snd
+                    else fst, step shortest snd
+                  end
+                in
+                let func, arg =
+                  if r.func_first then fst, snd
+                  else snd, fst
+                in
+                let found =
+                  finished func && finished arg
+                  && Height.equal
+                       (min_application fst snd r.suffix) r.min
+                in
+                if found then begin
+                  let best = path_application func arg r.suffix in
+                  let max = r.min in
+                  let finished = true in
+                  Application
+                    { r with best; func; arg; max; searched; finished }
+                end else begin
+                  let finished =
+                    searched
+                    && Height.less_than_or_equal
+                         r.max (min_application fst snd r.suffix)
+                  in
+                  let min = if finished then r.max else Height.succ r.min in
+                  Application
+                    { r with func; arg; min; searched; finished }
+                end
+              in
+              if r.searched then try_app true
+              else begin
+                match find shortest r.origin r.min r.kind r.node with
+                | Sections.Not_found_here ->
+                    try_app (Height.equal r.min r.max)
+                | Sections.Not_found_here_or_later ->
+                    try_app true
+                | Sections.Found path ->
+                    let best = path in
+                    let max = r.min in
+                    let searched = true in
+                    let finished = true in
+                    Application { r with best; max; searched; finished }
+              end
+        end
+
+    let rec perform shortest search =
+      if finished search then best search
+      else perform shortest (step shortest search)
+
+  end
+
+  let find_type t path =
+    update t;
+    let typ = Graph.find_type t.graph path in
+    match Type.resolve t.graph typ with
+    | Type.Nth n -> Nth n
+    | Type.Path(subst, typ) ->
+      let search = Search.create t Search.Type typ in
+      let path = Search.perform t search in
+      Path(subst, path)
+
+  let find_type_resolution t path : type_resolution =
+    update t;
+    let typ = Graph.find_type t.graph path in
+    match Type.resolve t.graph typ with
+    | Type.Nth n -> Nth n
+    | Type.Path(Some ns, _) -> Subst ns
+    | Type.Path(None, _) -> Id
+
+  let find_type_simple t path =
+    update t;
+    let typ = Graph.find_type t.graph path in
+    let search = Search.create t Search.Type typ in
+    Search.perform t search
+
+  let find_class_type t path =
+    update t;
+    let clty = Graph.find_class_type t.graph path in
+    let subst, clty = Class_type.resolve t.graph clty in
+    let search = Search.create t Search.Class_type clty in
+    let path = Search.perform t search in
+    (subst, path)
+
+  let find_class_type_simple t path =
+    update t;
+    let clty = Graph.find_class_type t.graph path in
+    let search = Search.create t Search.Class_type clty in
+    Search.perform t search
+
+  let find_module_type t path =
+    update t;
+    let mty = Graph.find_module_type t.graph path in
+    let search = Search.create t Search.Module_type mty in
+    Search.perform t search
+
+  let find_module t path =
+    update t;
+    let md = Graph.find_module t.graph path in
+    let search = Search.create t Search.Module md in
+    Search.perform t search
+
+end
+
+module String_set = Set.Make(String)
+
+module Basis = struct
+
+  type load =
+    { name : string;
+      depends : string list;
+      alias_depends : string list;
+      desc : Desc.Module.t; }
+
+  type t =
+    { mutable next_dep : Dependency.t;
+      mutable pending_additions : String_set.t;
+      mutable pending_loads : load list;
+      mutable assignment : Dependency.t String_map.t;
+      rev_deps : Rev_deps.t;
+      mutable shortest : Shortest.basis Shortest.t option; }
+
+  let create () =
+    { next_dep = Dependency.zero;
+      pending_additions = String_set.empty;
+      pending_loads = [];
+      assignment = String_map.empty;
+      rev_deps = Rev_deps.create ();
+      shortest = None; }
+
+  let update_assignments t additions =
+    String_set.iter
+      (fun name ->
+         if not (String_map.mem name t.assignment) then begin
+           t.assignment <- String_map.add name t.next_dep t.assignment;
+           t.next_dep <- Dependency.succ t.next_dep
+         end)
+      additions
+
+  let update_rev_deps t loads =
+    Rev_deps.extend_up_to t.rev_deps t.next_dep;
+    List.iter
+      (fun { name; depends; alias_depends; _ } ->
+         let index = String_map.find name t.assignment in
+         List.iter
+           (fun dep_name ->
+              let dep_index = String_map.find dep_name t.assignment in
+              Rev_deps.add t.rev_deps ~source:dep_index ~target:index)
+           depends;
+         List.iter
+           (fun dep_name ->
+              let dep_index = String_map.find dep_name t.assignment in
+              Rev_deps.add_alias t.rev_deps ~source:dep_index ~target:index)
+           alias_depends)
+      loads
+
+  let update_shortest t additions loads =
+    let components =
+      List.map
+        (fun { name; desc; _ } ->
+           let index = String_map.find name t.assignment in
+           let origin = Origin.Dependency index in
+           let id = Ident.global name in
+           Component.Module(origin, id, desc, Component.Global))
+        loads
+    in
+    let components =
+      String_set.fold
+        (fun name acc ->
+           let index = String_map.find name t.assignment in
+           let origin = Origin.Dependency index in
+           let id = Ident.global name in
+           Component.Declare_module(origin, id) :: acc)
+        additions
+        components
+    in
+    match t.shortest with
+    | None ->
+        t.shortest <- Some (Shortest.basis t.rev_deps components)
+    | Some shortest ->
+        Shortest.mutate shortest t.rev_deps components
+
+  let update t =
+    let loads = t.pending_loads in
+    let additions = t.pending_additions in
+    match loads, String_set.is_empty additions with
+    | [], true -> ()
+    | _, _ ->
+      t.pending_loads <- [];
+      t.pending_additions <- String_set.empty;
+      let loads = List.rev loads in
+      update_assignments t additions;
+      update_rev_deps t loads;
+      update_shortest t additions loads
+
+  let shortest t =
+    update t;
+    match t.shortest with
+    | None ->
+        let shortest = Shortest.basis t.rev_deps [] in
+        t.shortest <- Some shortest;
+        shortest
+    | Some shortest -> shortest
+
+  let add t name =
+    t.pending_additions <- String_set.add name t.pending_additions
+
+  let load t name depends alias_depends desc =
+    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+
+end
+
+type state =
+  | Initial of Basis.t
+  | Unforced of
+      { parent : t;
+        desc : Desc.t list Lazy.t; }
+  | Forced of
+      { basis : Basis.t;
+        shortest : Shortest.env Shortest.t; }
+
+and t = state ref
+
+let rec force t =
+  match !t with
+  | Initial _ | Forced _ as state -> state
+  | Unforced { parent; desc } ->
+    let desc = Lazy.force desc in
+    let state =
+      match force parent with
+      | Unforced _ -> assert false
+      | Initial basis ->
+        let shortest = Shortest.env (Basis.shortest basis) desc in
+        Forced { basis; shortest }
+      | Forced { basis; shortest } ->
+        let shortest = Shortest.env shortest desc in
+        Forced { basis; shortest }
+    in
+    t := state;
+    state
+
+let initial basis = ref (Initial basis)
+
+let add parent desc =
+  ref (Unforced { parent; desc })
+
+type ext_shortest = Shortest : 'k Shortest.t -> ext_shortest
+
+let shortest t =
+  match force t with
+  | Unforced _ -> assert false
+  | Initial basis ->
+      Basis.update basis;
+      Shortest (Basis.shortest basis)
+  | Forced { basis; shortest } ->
+      Basis.update basis;
+      Shortest shortest
+
+let find_type t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_type shortest path with
+  | exception Not_found -> Path(None, path)
+  | result -> result
+
+let find_type_resolution t path : type_resolution =
+  let Shortest shortest = shortest t in
+  match Shortest.find_type_resolution shortest path with
+  | exception Not_found -> Id
+  | subst -> subst
+
+let find_type_simple t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_type_simple shortest path with
+  | exception Not_found -> path
+  | path -> path
+
+let find_class_type t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_class_type shortest path with
+  | exception Not_found -> (None, path)
+  | result -> result
+
+let find_class_type_simple t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_class_type_simple shortest path with
+  | exception Not_found -> path
+  | path -> path
+
+let find_module_type t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_module_type shortest path with
+  | exception Not_found -> path
+  | path -> path
+
+let find_module t path =
+  let Shortest shortest = shortest t in
+  match Shortest.find_module shortest path with
+  | exception Not_found -> path
+  | path -> path

--- a/src/ocaml/typer_406/typing/short_paths.mli
+++ b/src/ocaml/typer_406/typing/short_paths.mli
@@ -1,0 +1,45 @@
+
+module Desc = Short_paths_graph.Desc
+
+module Basis : sig
+
+  type t
+
+  val create : unit -> t
+
+  val add : t -> string -> unit
+
+  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+
+end
+
+type t
+
+val initial : Basis.t -> t
+
+val add : t -> Desc.t list Lazy.t -> t
+
+type type_result =
+  | Nth of int
+  | Path of int list option * Path.t
+
+val find_type : t -> Path.t -> type_result
+
+type type_resolution =
+  | Nth of int
+  | Subst of int list
+  | Id
+
+val find_type_resolution : t -> Path.t -> type_resolution
+
+val find_type_simple : t -> Path.t -> Path.t
+
+type class_type_result = int list option * Path.t
+
+val find_class_type : t -> Path.t -> class_type_result
+
+val find_class_type_simple : t -> Path.t -> Path.t
+
+val find_module_type : t -> Path.t -> Path.t
+
+val find_module : t -> Path.t -> Path.t

--- a/src/ocaml/typer_406/typing/short_paths_graph.ml
+++ b/src/ocaml/typer_406/typing/short_paths_graph.ml
@@ -1,0 +1,1489 @@
+
+module String_map = Map.Make(String)
+
+module Ident = struct
+
+  type t = Ident.t
+
+  open Ident
+
+  let equal t1 t2 =
+    if t1.stamp = 0 then
+      t2.stamp = 0
+      && String.equal t1.name t2.name
+    else t1.stamp = t2.stamp
+
+  let compare t1 t2 =
+    if t1.stamp = 0 then
+      if t2.stamp = 0 then
+        String.compare t1.name t2.name
+      else -1
+    else Pervasives.compare t1.stamp t2.stamp
+
+  let name = Ident.name
+
+  let global name =
+    Ident.create_persistent name
+
+end
+
+module Ident_map = Map.Make(Ident)
+module Ident_set = Set.Make(Ident)
+
+module Path = struct
+
+  type t = Path.t =
+    | Pident of Ident.t
+    | Pdot of t * string * int
+    | Papply of t * t
+
+  open Path
+
+  let rec equal t1 t2 =
+    match t1, t2 with
+    | Pident id1, Pident id2 -> Ident.equal id1 id2
+    | Pident _, Pdot _ -> false
+    | Pident _, Papply _ -> false
+    | Pdot _, Pident _ -> false
+    | Pdot(parent1, name1, _), Pdot(parent2, name2, _) ->
+        equal parent1 parent2
+        && String.equal name1 name2
+    | Pdot _, Papply _ -> false
+    | Papply _, Pident _ -> false
+    | Papply _, Pdot _ -> false
+    | Papply(func1, arg1), Papply(func2, arg2) ->
+        equal func1 func2
+        && equal arg1 arg2
+
+  let rec compare t1 t2 =
+    match t1, t2 with
+    | Pident id1, Pident id2 -> Ident.compare id1 id2
+    | Pident _, Pdot _ -> -1
+    | Pident _, Papply _ -> -1
+    | Pdot _, Pident _ -> 1
+    | Pdot(parent1, name1, _), Pdot(parent2, name2, _) ->
+        let c = compare parent1 parent2 in
+        if c <> 0 then c
+        else String.compare name1 name2
+    | Pdot _, Papply _ -> -1
+    | Papply _, Pident _ -> 1
+    | Papply _, Pdot _ -> 1
+    | Papply(func1, arg1), Papply(func2, arg2) ->
+        let c = compare func1 func2 in
+        if c <> 0 then c
+        else compare arg1 arg2
+
+end
+
+module Path_map = Map.Make(Path)
+module Path_set = Set.Make(Path)
+
+module Desc = struct
+
+  module Type = struct
+
+    type t =
+      | Fresh
+      | Nth of int
+      | Subst of Path.t * int list
+      | Alias of Path.t
+
+  end
+
+  module Module_type = struct
+
+    type t =
+      | Fresh
+      | Alias of Path.t
+
+  end
+
+  module Class_type = struct
+
+    type t =
+      | Fresh
+      | Subst of Path.t * int list
+      | Alias of Path.t
+
+  end
+
+  module Module = struct
+
+    type component =
+      | Type of string * Type.t
+      | Class_type of string * Class_type.t
+      | Module_type of string * Module_type.t
+      | Module of string * t
+
+    and components = component list
+
+    and kind =
+      | Signature of components Lazy.t
+      | Functor of (Path.t -> t)
+
+    and t =
+      | Fresh of kind
+      | Alias of Path.t
+
+  end
+
+  type t =
+    | Type of Ident.t * Type.t * bool
+    | Class_type of Ident.t * Class_type.t * bool
+    | Module_type of Ident.t * Module_type.t * bool
+    | Module of Ident.t * Module.t * bool
+    | Declare_type of Ident.t
+    | Declare_class_type of Ident.t
+    | Declare_module_type of Ident.t
+    | Declare_module of Ident.t
+
+end
+
+module Sort = struct
+
+  type t =
+    | Defined
+    | Declared of Ident_set.t
+
+  let application t1 t2 =
+    match t1, t2 with
+    | Defined, Defined -> Defined
+    | Defined, Declared _ -> t2
+    | Declared _, Defined -> t1
+    | Declared ids1, Declared ids2 -> Declared (Ident_set.union ids1 ids2)
+
+end
+
+module Age = Natural.Make()
+
+module Dependency = Natural.Make()
+
+module Origin = struct
+
+  type t =
+    | Dependency of Dependency.t
+    | Dependencies of Dependency.t list
+    | Environment of Age.t
+
+  let rec deps_add dep deps =
+    match deps with
+    | [] -> [dep]
+    | dep' :: rest ->
+      if Dependency.equal dep dep' then
+        deps
+      else if Dependency.less_than dep dep' then
+        dep :: deps
+      else
+        dep' :: deps_add dep rest
+
+  let rec deps_union deps1 deps2 =
+    match deps1, deps2 with
+    | [], _ -> deps2
+    | _, [] -> deps1
+    | dep1 :: rest1, dep2 :: rest2 ->
+        if Dependency.equal dep1 dep2 then
+          dep1 :: deps_union rest1 rest2
+        else if Dependency.less_than dep1 dep2 then
+          dep1 :: deps_union rest1 deps2
+        else
+          dep2 :: deps_union deps1 rest2
+
+  let rec deps_equal deps1 deps2 =
+    match deps1, deps2 with
+    | [], [] -> true
+    | [], _ :: _ -> false
+    | _ :: _, [] -> false
+    | dep1 :: rest1, dep2 :: rest2 ->
+        Dependency.equal dep1 dep2
+        && deps_equal rest1 rest2
+
+  let application t1 t2 =
+    match t1, t2 with
+    | Dependency dep1, Dependency dep2 ->
+        if Dependency.equal dep1 dep2 then t1
+        else if Dependency.less_than dep1 dep2 then
+          Dependencies [dep1; dep2]
+        else
+          Dependencies [dep2; dep1]
+    | Dependency dep1, Dependencies deps2 ->
+        Dependencies (deps_add dep1 deps2)
+    | Dependency _, Environment _ -> t2
+    | Dependencies deps1, Dependency dep2 ->
+        Dependencies (deps_add dep2 deps1)
+    | Dependencies deps1, Dependencies deps2 ->
+        Dependencies (deps_union deps1 deps2)
+    | Dependencies _, Environment _ -> t2
+    | Environment _, Dependency _ -> t1
+    | Environment _, Dependencies _ -> t1
+    | Environment age1, Environment age2 ->
+        Environment (Age.max age1 age2)
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Dependency dep1, Dependency dep2 -> Dependency.equal dep1 dep2
+    | Dependency _, Dependencies _ -> false
+    | Dependency _, Environment _ -> false
+    | Dependencies _, Dependency _ -> false
+    | Dependencies deps1, Dependencies deps2 -> deps_equal deps1 deps2
+    | Dependencies _, Environment _ -> false
+    | Environment _, Dependency _ -> false
+    | Environment _, Dependencies _ -> false
+    | Environment env1, Environment env2 -> Age.equal env1 env2
+
+  let hash = Hashtbl.hash
+
+end
+
+(* CR lwhite: Should probably short-circuit indirections if they are to
+    canonical entries older than the indirection. *)
+module rec Type : sig
+
+  type t
+
+  val base : Origin.t -> Ident.t -> Desc.Type.t option -> t
+
+  val child : Module.normalized -> string -> Desc.Type.t option -> t
+
+  val declare : Origin.t -> Ident.t -> t
+
+  val declaration : t -> Origin.t option
+
+  val origin : Graph.t -> t -> Origin.t
+
+  val path : Graph.t -> t -> Path.t
+
+  val sort : Graph.t -> t -> Sort.t
+
+  type normalized
+
+  val normalize : Graph.t -> t -> normalized
+
+  val unnormalize : normalized -> t
+
+  val raw_origin : normalized -> Origin.t
+
+  val raw_path : normalized -> Path.t
+
+  val raw_sort : normalized -> Sort.t
+
+  type resolved =
+    | Nth of int
+    | Path of int list option * t
+
+  val resolve : Graph.t -> t -> resolved
+
+end = struct
+
+  open Desc.Type
+
+  type definition =
+    | Indirection of Path.t
+    | Defined
+    | Nth of int
+    | Subst of Path.t * int list
+    | Unknown
+
+  type t =
+    | Declaration of
+        { origin : Origin.t;
+          id : Ident.t; }
+    | Definition of
+        { origin : Origin.t;
+          path : Path.t;
+          sort : Sort.t;
+          definition : definition; }
+
+  let definition_of_desc (desc : Desc.Type.t option) =
+    match desc with
+    | None -> Unknown
+    | Some Fresh -> Defined
+    | Some (Nth n) -> Nth n
+    | Some (Subst(p, ns)) -> Subst(p, ns)
+    | Some (Alias alias) -> Indirection alias
+
+  let base origin id desc =
+    let path = Path.Pident id in
+    let sort = Sort.Defined in
+    let definition = definition_of_desc desc in
+    Definition { origin; path; sort; definition }
+
+  let child md name desc =
+    let origin = Module.raw_origin md in
+    let sort = Module.raw_sort md in
+    let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let definition = definition_of_desc desc in
+    Definition { origin; path; sort; definition }
+
+  let declare origin id =
+    Declaration { origin; id }
+
+  let declaration t =
+    match t with
+    | Definition _ -> None
+    | Declaration { origin; _} -> Some origin
+
+  let raw_origin t =
+    match t with
+    | Declaration { origin; _ }
+    | Definition { origin; _ } -> origin
+
+  let raw_path t =
+    match t with
+    | Declaration { id; _ } -> Path.Pident id
+    | Definition { path; _ } -> path
+
+  let raw_sort t =
+    match t with
+    | Declaration { id; _ } -> Sort.Declared (Ident_set.singleton id)
+    | Definition { sort; _ } -> sort
+
+  type normalized = t
+
+  let rec normalize_loop root t =
+    match t with
+    | Declaration _ -> t
+    | Definition { definition = Defined | Unknown | Nth _ | Subst _ } -> t
+    | Definition ({ definition = Indirection alias } as r) -> begin
+        match Graph.find_type root alias with
+        | exception Not_found -> Definition { r with definition = Unknown }
+        | aliased -> normalize_loop root aliased
+      end
+
+  let normalize root t =
+    match t with
+    | Definition { sort = Sort.Defined } -> normalize_loop root t
+    | Definition { sort = Sort.Declared _ } | Declaration _ ->
+        match Graph.find_type root (raw_path t) with
+        | exception Not_found -> normalize_loop root t
+        | t -> normalize_loop root t
+
+  let unnormalize t = t
+
+  let origin root t =
+    raw_origin (normalize root t)
+
+  let path root t =
+    raw_path (normalize root t)
+
+  let sort root t =
+    raw_sort (normalize root t)
+
+  type resolved =
+    | Nth of int
+    | Path of int list option * t
+
+  let subst ns = function
+    | Nth n -> Nth (List.nth ns n)
+    | Path(None, p) -> Path(Some ns, p)
+    | Path(Some ms, p) -> Path(Some (List.map (List.nth ns) ms), p)
+
+  let rec resolve root t =
+    match normalize root t with
+    | Declaration _ -> Path(None, t)
+    | Definition { definition = Defined | Unknown } -> Path(None, t)
+    | Definition { definition = Nth n } -> Nth n
+    | Definition { definition = Subst(p, ns) } -> begin
+        match Graph.find_type root p with
+        | exception Not_found -> Path(None, t)
+        | aliased -> subst ns (resolve root aliased)
+      end
+    | Definition { definition = Indirection _ } -> assert false
+
+end
+
+and Class_type : sig
+
+  type t
+
+  val base : Origin.t -> Ident.t -> Desc.Class_type.t option -> t
+
+  val child : Module.normalized -> string -> Desc.Class_type.t option -> t
+
+  val declare : Origin.t -> Ident.t -> t
+
+  val declaration : t -> Origin.t option
+
+  val origin : Graph.t -> t -> Origin.t
+
+  val path : Graph.t -> t -> Path.t
+
+  val sort : Graph.t -> t -> Sort.t
+
+  type normalized
+
+  val normalize : Graph.t -> t -> normalized
+
+  val unnormalize : normalized -> t
+
+  val raw_origin : normalized -> Origin.t
+
+  val raw_path : normalized -> Path.t
+
+  val raw_sort : normalized -> Sort.t
+
+  type resolved = int list option * t
+
+  val resolve : Graph.t -> t -> resolved
+
+end = struct
+
+  open Desc.Class_type
+
+  type definition =
+    | Indirection of Path.t
+    | Defined
+    | Subst of Path.t * int list
+    | Unknown
+
+  type t =
+    | Declaration of
+        { origin : Origin.t;
+          id : Ident.t; }
+    | Definition of
+        { origin : Origin.t;
+          path : Path.t;
+          sort : Sort.t;
+          definition : definition; }
+
+  let definition_of_desc (desc : Desc.Class_type.t option) =
+    match desc with
+    | None -> Unknown
+    | Some Fresh -> Defined
+    | Some (Subst(p, ns)) -> Subst(p, ns)
+    | Some (Alias alias) -> Indirection alias
+
+  let base origin id desc =
+    let path = Path.Pident id in
+    let sort = Sort.Defined in
+    let definition = definition_of_desc desc in
+    Definition { origin; path; sort; definition }
+
+  let child md name desc =
+    let origin = Module.raw_origin md in
+    let sort = Module.raw_sort md in
+    let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let definition = definition_of_desc desc in
+    Definition { origin; path; sort; definition }
+
+  let declare origin id =
+    Declaration { origin; id }
+
+  let declaration t =
+    match t with
+    | Definition _ -> None
+    | Declaration { origin; _} -> Some origin
+
+  let raw_origin t =
+    match t with
+    | Declaration { origin; _ }
+    | Definition { origin; _ } -> origin
+
+  let raw_path t =
+    match t with
+    | Declaration { id; _ } -> Path.Pident id
+    | Definition { path; _ } -> path
+
+  let raw_sort t =
+    match t with
+    | Declaration { id; _ } -> Sort.Declared (Ident_set.singleton id)
+    | Definition { sort; _ } -> sort
+
+  type normalized = t
+
+  let rec normalize_loop root t =
+    match t with
+    | Declaration _ -> t
+    | Definition { definition = Defined | Unknown | Subst _ } -> t
+    | Definition ({ definition = Indirection alias } as r) -> begin
+        match Graph.find_class_type root alias with
+        | exception Not_found -> Definition { r with definition = Unknown }
+        | aliased -> normalize_loop root aliased
+      end
+
+  let normalize root t =
+    match t with
+    | Definition { sort = Sort.Defined } -> normalize_loop root t
+    | Definition { sort = Sort.Declared _ } | Declaration _ ->
+        match Graph.find_class_type root (raw_path t) with
+        | exception Not_found -> normalize_loop root t
+        | t -> normalize_loop root t
+
+  let unnormalize t = t
+
+  let origin root t =
+    raw_origin (normalize root t)
+
+  let path root t =
+    raw_path (normalize root t)
+
+  let sort root t =
+    raw_sort (normalize root t)
+
+  type resolved = int list option * t
+
+  let subst ns = function
+    | (None, p) -> (Some ns, p)
+    | (Some ms, p) -> (Some (List.map (List.nth ns) ms), p)
+
+  let rec resolve root t =
+    match normalize root t with
+    | Declaration _ -> (None, t)
+    | Definition { definition = Defined | Unknown } -> (None, t)
+    | Definition { definition = Subst(p, ns) } -> begin
+        match Graph.find_class_type root p with
+        | exception Not_found -> (None, t)
+        | aliased -> subst ns (resolve root aliased)
+      end
+    | Definition { definition = Indirection _ } -> assert false
+
+end
+
+and Module_type : sig
+
+  type t
+
+  val base : Origin.t -> Ident.t -> Desc.Module_type.t option -> t
+
+  val child : Module.normalized -> string -> Desc.Module_type.t option -> t
+
+  val declare : Origin.t -> Ident.t -> t
+
+  val declaration : t -> Origin.t option
+
+  val origin : Graph.t -> t -> Origin.t
+
+  val path : Graph.t -> t -> Path.t
+
+  val sort : Graph.t -> t -> Sort.t
+
+  type normalized
+
+  val normalize : Graph.t -> t -> normalized
+
+  val unnormalize : normalized -> t
+
+  val raw_origin : normalized -> Origin.t
+
+  val raw_path : normalized -> Path.t
+
+  val raw_sort : normalized -> Sort.t
+
+end = struct
+
+  open Desc.Module_type
+
+  type definition =
+    | Indirection of Path.t
+    | Defined
+    | Unknown
+
+  type t =
+    | Declaration of
+        { origin : Origin.t;
+          id : Ident.t; }
+    | Definition of
+        { origin : Origin.t;
+          path : Path.t;
+          sort : Sort.t;
+          definition : definition; }
+
+  let base origin id desc =
+    let path = Path.Pident id in
+    let sort = Sort.Defined in
+    let definition =
+      match desc with
+      | None -> Unknown
+      | Some Fresh -> Defined
+      | Some (Alias alias) -> Indirection alias
+    in
+    Definition { origin; path; sort; definition }
+
+  let child md name desc =
+    let origin = Module.raw_origin md in
+    let sort = Module.raw_sort md in
+    let path = Path.Pdot (Module.raw_path md, name, 0) in
+    let definition =
+      match desc with
+      | None -> Unknown
+      | Some Fresh -> Defined
+      | Some (Alias alias) -> Indirection alias
+    in
+    Definition { origin; path; sort; definition }
+
+  let declare origin id =
+    Declaration { origin; id }
+
+  let declaration t =
+    match t with
+    | Definition _ -> None
+    | Declaration { origin; _} -> Some origin
+
+  let raw_origin t =
+    match t with
+    | Declaration { origin; _ } | Definition { origin; _ } ->
+        origin
+
+  let raw_path t =
+    match t with
+    | Declaration { id; _ } -> Path.Pident id
+    | Definition { path; _ } -> path
+
+  let raw_sort t =
+    match t with
+    | Declaration { id; _ } -> Sort.Declared (Ident_set.singleton id)
+    | Definition { sort; _ } -> sort
+
+  type normalized = t
+
+  let rec normalize_loop root t =
+    match t with
+    | Declaration _ -> t
+    | Definition { definition = Defined | Unknown } -> t
+    | Definition ({ definition = Indirection alias } as r) -> begin
+        match Graph.find_module_type root alias with
+        | exception Not_found -> Definition { r with definition = Unknown }
+        | aliased -> normalize_loop root aliased
+      end
+
+  let normalize root t =
+    match t with
+    | Definition { sort = Sort.Defined } -> normalize_loop root t
+    | Definition { sort = Sort.Declared _ } | Declaration _ ->
+        match Graph.find_module_type root (raw_path t) with
+        | exception Not_found -> normalize_loop root t
+        | t -> normalize_loop root t
+
+  let unnormalize t = t
+
+  let origin root t =
+    raw_origin (normalize root t)
+
+  let path root t =
+    raw_path (normalize root t)
+
+  let sort root t =
+    raw_sort (normalize root t)
+
+end
+
+and Module : sig
+
+  type t
+
+  type normalized
+
+  val base : Origin.t -> Ident.t -> Desc.Module.t option -> t
+
+  val child : normalized -> string -> Desc.Module.t option -> t
+
+  val application : normalized -> t -> Desc.Module.t option -> t
+
+  val declare : Origin.t -> Ident.t -> t
+
+  val declaration : t -> Origin.t option
+
+  val origin : Graph.t -> t -> Origin.t
+
+  val path : Graph.t -> t -> Path.t
+
+  val sort : Graph.t -> t -> Sort.t
+
+  val types : Graph.t -> t -> Type.t String_map.t option
+
+  val class_types : Graph.t -> t -> Class_type.t String_map.t option
+
+  val module_types : Graph.t -> t -> Module_type.t String_map.t option
+
+  val modules : Graph.t -> t -> Module.t String_map.t option
+
+  val find_type : Graph.t -> t -> string -> Type.t
+
+  val find_class_type : Graph.t -> t -> string -> Class_type.t
+
+  val find_module_type : Graph.t -> t -> string -> Module_type.t
+
+  val find_module : Graph.t -> t -> string -> Module.t
+
+  val find_application : Graph.t -> t -> Path.t -> Module.t
+
+  val normalize : Graph.t -> t -> normalized
+
+  val unnormalize : normalized -> t
+
+  val raw_origin : normalized -> Origin.t
+
+  val raw_path : normalized -> Path.t
+
+  val raw_sort : normalized -> Sort.t
+
+end = struct
+
+  open Desc.Module
+
+  type components =
+    | Unforced of Desc.Module.components Lazy.t
+    | Forced of
+        { types : Type.t String_map.t;
+          class_types : Class_type.t String_map.t;
+          module_types : Module_type.t String_map.t;
+          modules : t String_map.t; }
+
+  and definition =
+    | Indirection of Path.t
+    | Signature of
+        { mutable components : components }
+    | Functor of
+        { apply : Path.t -> Desc.Module.t;
+          mutable applications : t Path_map.t; }
+    | Unknown
+
+  and t =
+    | Declaration of
+        { origin : Origin.t;
+          id : Ident.t; }
+    | Definition of
+        { origin : Origin.t;
+          path : Path.t;
+          sort : Sort.t;
+          definition : definition; }
+
+  let base origin id desc =
+    let path = Path.Pident id in
+    let sort = Sort.Defined in
+    let definition =
+      match desc with
+      | None -> Unknown
+      | Some (Fresh (Signature components)) ->
+          let components = Unforced components in
+          Signature { components }
+      | Some (Fresh (Functor apply)) ->
+          let applications = Path_map.empty in
+          Functor { apply; applications }
+      | Some (Alias alias) ->
+          Indirection alias
+    in
+    Definition { origin; path; sort; definition }
+
+  let child md name desc =
+    let origin = Module.raw_origin md in
+    let sort = Module.raw_sort md in
+    let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let definition =
+      match desc with
+      | None -> Unknown
+      | Some (Fresh (Signature components)) ->
+          let components = Unforced components in
+          Signature { components }
+      | Some (Fresh (Functor apply)) ->
+          let applications = Path_map.empty in
+          Functor { apply; applications }
+      | Some (Alias alias) ->
+          Indirection alias
+    in
+    Definition { origin; path; sort; definition }
+
+  let application func arg desc =
+    let func_origin = Module.raw_origin func in
+    let arg_origin = Module.raw_origin arg in
+    let origin = Origin.application func_origin arg_origin in
+    let func_sort = Module.raw_sort func in
+    let arg_sort = Module.raw_sort arg in
+    let sort = Sort.application func_sort arg_sort in
+    let func_path = Module.raw_path func in
+    let arg_path = Module.raw_path arg in
+    let path = Path.Papply(func_path, arg_path) in
+    let definition =
+      match desc with
+      | None -> Unknown
+      | Some (Fresh (Signature components)) ->
+          let components = Unforced components in
+          Signature { components }
+      | Some (Fresh (Functor apply)) ->
+          let applications = Path_map.empty in
+          Functor { apply; applications }
+      | Some (Alias alias) ->
+          Indirection alias
+    in
+    Definition { origin; path; sort; definition }
+
+  let declare origin id =
+    Declaration { origin; id }
+
+  let declaration t =
+    match t with
+    | Definition _ -> None
+    | Declaration { origin; _} -> Some origin
+
+  let raw_origin t =
+    match t with
+    | Declaration { origin; _ } | Definition { origin; _ } ->
+        origin
+
+  let raw_path t =
+    match t with
+    | Declaration { id; _ } -> Path.Pident id
+    | Definition { path; _ } -> path
+
+  let raw_sort t =
+    match t with
+    | Declaration { id; _ } -> Sort.Declared (Ident_set.singleton id)
+    | Definition { sort; _ } -> sort
+
+  type normalized = t
+
+  let rec normalize_loop root t =
+    match t with
+    | Declaration _ -> t
+    | Definition { definition = Signature _ | Functor _ | Unknown } -> t
+    | Definition ({ definition = Indirection alias } as r) -> begin
+        match Graph.find_module root alias with
+        | exception Not_found -> Definition { r with definition = Unknown }
+        | aliased -> normalize_loop root aliased
+      end
+
+  let normalize root t =
+    match t with
+    | Definition { sort = Sort.Defined } -> normalize_loop root t
+    | Definition { sort = Sort.Declared _ } | Declaration _ ->
+        match Graph.find_module root (raw_path t) with
+        | exception Not_found -> normalize_loop root t
+        | t -> normalize_loop root t
+
+  let unnormalize t = t
+
+  let origin root t =
+    raw_origin (normalize root t)
+
+  let path root t =
+    raw_path (normalize root t)
+
+  let sort root t =
+    raw_sort (normalize root t)
+
+  let definition t =
+    match Module.unnormalize t with
+    | Declaration _ -> Unknown
+    | Definition { definition; _ } -> definition
+
+  let force root t =
+    let t = Module.normalize root t in
+    match definition t with
+    | Indirection _ -> assert false
+    | Unknown
+    | Functor _
+    | Signature { components = Forced _ } -> t
+    | Signature ({ components = Unforced components; _} as r) -> begin
+        let rec loop types class_types module_types modules = function
+          | [] -> Forced { types; class_types; module_types; modules }
+          | Type(name, desc) :: rest ->
+              let typ = Type.child t name (Some desc) in
+              let types = String_map.add name typ types in
+              loop types class_types module_types modules rest
+          | Class_type(name, desc) :: rest ->
+              let clty = Class_type.child t name (Some desc) in
+              let class_types = String_map.add name clty class_types in
+              loop types class_types module_types modules rest
+          | Module_type(name, desc) :: rest ->
+              let mty = Module_type.child t name (Some desc) in
+              let module_types = String_map.add name mty module_types in
+              loop types class_types module_types modules rest
+          | Module(name, desc) :: rest ->
+              let md = Module.child t name (Some desc) in
+              let modules = String_map.add name md modules in
+              loop types class_types module_types modules rest
+        in
+        let empty = String_map.empty in
+        let components = loop empty empty empty empty (Lazy.force components) in
+        r.components <- components;
+        t
+      end
+
+  let types root t =
+    let t = force root t in
+    match definition t with
+    | Indirection _ | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown | Functor _ ->
+        None
+    | Signature { components = Forced { types; _ }; _ } ->
+        Some types
+
+  let class_types root t =
+    let t = force root t in
+    match definition t with
+    | Indirection _ | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown | Functor _ ->
+        None
+    | Signature { components = Forced { class_types; _ } } ->
+        Some class_types
+
+  let module_types root t =
+    let t = force root t in
+    match definition t with
+    | Indirection _ | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown | Functor _ ->
+        None
+    | Signature { components = Forced { module_types; _ } } ->
+        Some module_types
+
+  let modules root t =
+    let t = force root t in
+    match definition t with
+    | Indirection _ | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown | Functor _ ->
+        None
+    | Signature { components = Forced { modules; _ } } ->
+        Some modules
+
+  let find_type root t name =
+    let t = force root t in
+    match definition t with
+    | Indirection _
+    | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown ->
+        Type.child t name None
+    | Functor _ ->
+        raise Not_found
+    | Signature { components = Forced { types; _ }; _ } ->
+        String_map.find name types
+
+  let find_class_type root t name =
+    let t = force root t in
+    match definition t with
+    | Indirection _
+    | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown ->
+        Class_type.child t name None
+    | Functor _ ->
+        raise Not_found
+    | Signature { components = Forced { class_types; _ }; _ } ->
+        String_map.find name class_types
+
+  let find_module_type root t name =
+    let t = force root t in
+    match definition t with
+    | Indirection _
+    | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown ->
+        Module_type.child t name None
+    | Functor _ ->
+        raise Not_found
+    | Signature { components = Forced { module_types; _ }; _ } ->
+        String_map.find name module_types
+
+  let find_module root t name =
+    let t = force root t in
+    match definition t with
+    | Indirection _
+    | Signature { components = Unforced _ } ->
+        assert false
+    | Unknown ->
+        Module.child t name None
+    | Functor _ ->
+        raise Not_found
+    | Signature { components = Forced { modules; _ }; _ } ->
+        String_map.find name modules
+
+  let find_application root t path =
+    let t = Module.normalize root t in
+    match definition t with
+    | Indirection _ -> assert false
+    | Signature _ -> raise Not_found
+    | Unknown ->
+        let arg = Graph.find_module root path in
+        Module.application t arg None
+    | Functor ({ apply; applications } as r)->
+        let arg = Graph.find_module root path in
+        let arg_path = Module.path root arg in
+        match Path_map.find arg_path applications with
+        | md -> md
+        | exception Not_found ->
+            let md = Module.application t arg (Some (apply arg_path)) in
+            r.applications <- Path_map.add arg_path md applications;
+            md
+
+end
+
+and Diff : sig
+
+  module Item : sig
+
+    type t =
+      | Type of Ident.t * Type.t * Origin.t option
+      | Class_type of Ident.t * Class_type.t * Origin.t option
+      | Module_type of Ident.t * Module_type.t * Origin.t option
+      | Module of Ident.t * Module.t * Origin.t option
+
+    val origin : Graph.t -> t -> Origin.t
+
+    val id : Graph.t -> t -> Ident.t
+
+    val previous : Graph.t -> t -> Origin.t option
+
+  end
+
+  type t = Item.t list
+
+end = struct
+
+  module Item = struct
+
+    type t =
+      | Type of Ident.t * Type.t * Origin.t option
+      | Class_type of Ident.t * Class_type.t * Origin.t option
+      | Module_type of Ident.t * Module_type.t * Origin.t option
+      | Module of Ident.t * Module.t * Origin.t option
+
+    let origin root = function
+      | Type(_, typ, _) -> Type.origin root typ
+      | Class_type(_, clty, _) -> Class_type.origin root clty
+      | Module_type(_, mty, _) -> Module_type.origin root mty
+      | Module(_, md, _) -> Module.origin root md
+
+    let id _root = function
+      | Type(id, _, _) -> id
+      | Class_type(id, _, _) -> id
+      | Module_type(id, _, _) -> id
+      | Module(id, _, _) -> id
+
+    let previous _root = function
+      | Type(_, _, prev) -> prev
+      | Class_type(_, _, prev) -> prev
+      | Module_type(_, _, prev) -> prev
+      | Module(_, _, prev) -> prev
+
+  end
+
+  type t = Item.t list
+
+end
+
+and Component : sig
+
+  type source =
+    | Global
+    | Local
+    | Open
+
+  type t =
+    | Type of Origin.t * Ident.t * Desc.Type.t * source
+    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
+    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
+    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Declare_type of Origin.t * Ident.t
+    | Declare_class_type of Origin.t * Ident.t
+    | Declare_module_type of Origin.t * Ident.t
+    | Declare_module of Origin.t * Ident.t
+
+end = Component
+
+and Graph : sig
+
+  type t
+
+  val empty : t
+
+  val add : t -> Component.t list -> t * Diff.t
+
+  val merge : t -> Diff.t -> t
+
+  val find_type : t -> Path.t -> Type.t
+
+  val find_class_type : t -> Path.t -> Class_type.t
+
+  val find_module_type : t -> Path.t -> Module_type.t
+
+  val find_module : t -> Path.t -> Module.t
+
+  val is_type_path_visible : t -> Path.t -> bool
+
+  val is_class_type_path_visible : t -> Path.t -> bool
+
+  val is_module_type_path_visible : t -> Path.t -> bool
+
+  val is_module_path_visible : t -> Path.t -> bool
+
+end = struct
+
+  type defs =
+    | Global of Ident.t
+    | Local of Ident.t
+    | Unambiguous of Ident.t
+    | Ambiguous of Ident.t * Ident.t list
+
+  type t =
+    { types : Type.t Ident_map.t;
+      class_types : Class_type.t Ident_map.t;
+      module_types : Module_type.t Ident_map.t;
+      modules : Module.t Ident_map.t;
+      type_names : defs String_map.t;
+      class_type_names : defs String_map.t;
+      module_type_names : defs String_map.t;
+      module_names : defs String_map.t; }
+
+  let empty =
+    { types = Ident_map.empty;
+      class_types = Ident_map.empty;
+      module_types = Ident_map.empty;
+      modules = Ident_map.empty;
+      type_names = String_map.empty;
+      class_type_names = String_map.empty;
+      module_type_names = String_map.empty;
+      module_names = String_map.empty; }
+
+  let previous_type t id =
+    match Ident_map.find id t.types with
+    | exception Not_found -> None
+    | prev ->
+      match Type.declaration prev with
+      | None -> failwith "Graph.add: type already defined"
+      | Some _ as o -> o
+
+  let previous_class_type t id =
+    match Ident_map.find id t.class_types with
+    | exception Not_found -> None
+    | prev ->
+      match Class_type.declaration prev with
+      | None -> failwith "Graph.add: class type already defined"
+      | Some _ as o -> o
+
+  let previous_module_type t id =
+    match Ident_map.find id t.module_types with
+    | exception Not_found -> None
+    | prev ->
+      match Module_type.declaration prev with
+      | None -> failwith "Graph.add: module type already defined"
+      | Some _ as o -> o
+
+  let previous_module t id =
+    match Ident_map.find id t.modules with
+    | exception Not_found -> None
+    | prev ->
+      match Module.declaration prev with
+      | None -> failwith "Graph.add: module already defined"
+      | Some _ as o -> o
+
+  let add_name source id names =
+    let name = Ident.name id in
+    let defs =
+      match source with
+      | Component.Global -> Global id
+      | Component.Local -> Local id
+      | Component.Open -> begin
+        match String_map.find name names with
+        | exception Not_found -> Unambiguous id
+        | Global id' -> Unambiguous id
+        | Local id' -> Ambiguous(id, [id'])
+        | Unambiguous id' -> Ambiguous(id, [id'])
+        | Ambiguous(id', ids) -> Ambiguous(id, id' :: ids)
+      end
+    in
+    String_map.add name defs names
+
+  let merge_name id names =
+    let name = Ident.name id in
+    match String_map.find name names with
+    | exception Not_found ->
+        String_map.add name (Global id) names
+    | _ -> names
+
+  let add t descs =
+    let rec loop acc diff declarations = function
+      | [] -> loop_declarations acc diff declarations
+      | Component.Type(origin, id, desc, source) :: rest ->
+          let prev = previous_type acc id in
+          let typ = Type.base origin id (Some desc) in
+          let types = Ident_map.add id typ acc.types in
+          let type_names = add_name source id acc.type_names in
+          let item = Diff.Item.Type(id, typ, prev) in
+          let diff = item :: diff in
+          let acc = { acc with types; type_names } in
+          loop acc diff declarations rest
+      | Component.Class_type(origin,id, desc, source) :: rest ->
+          let prev = previous_class_type acc id in
+          let clty = Class_type.base origin id (Some desc) in
+          let class_types = Ident_map.add id clty acc.class_types in
+          let class_type_names = add_name source id acc.class_type_names in
+          let item = Diff.Item.Class_type(id, clty, prev) in
+          let diff = item :: diff in
+          let acc = { acc with class_types; class_type_names } in
+          loop acc diff declarations rest
+      | Component.Module_type(origin,id, desc, source) :: rest ->
+          let prev = previous_module_type acc id in
+          let mty = Module_type.base origin id (Some desc) in
+          let module_types = Ident_map.add id mty acc.module_types in
+          let module_type_names = add_name source id acc.module_type_names in
+          let item = Diff.Item.Module_type(id, mty, prev) in
+          let diff = item :: diff in
+          let acc = { acc with module_types; module_type_names } in
+          loop acc diff declarations rest
+      | Component.Module(origin,id, desc, source) :: rest ->
+          let prev = previous_module acc id in
+          let md = Module.base origin id (Some desc) in
+          let modules = Ident_map.add id md acc.modules in
+          let module_names = add_name source id acc.module_names in
+          let item = Diff.Item.Module(id, md, prev) in
+          let diff = item :: diff in
+          let acc = { acc with modules; module_names } in
+          loop acc diff declarations rest
+      | Component.Declare_type(_, id) as decl :: rest ->
+          let declarations = decl :: declarations in
+          let type_names =
+            (* CR lwhite: This should probably not always be [Global] *)
+            add_name Component.Global id acc.type_names
+          in
+          let acc = { acc with type_names } in
+          loop acc diff declarations rest
+      | Component.Declare_class_type(_, id) as decl :: rest ->
+          let declarations = decl :: declarations in
+          let class_type_names =
+            (* CR lwhite: This should probably not always be [Global] *)
+            add_name Component.Global id acc.class_type_names
+          in
+          let acc = { acc with class_type_names } in
+          loop acc diff declarations rest
+      | Component.Declare_module_type(_, id) as decl :: rest ->
+          let declarations = decl :: declarations in
+          let module_type_names =
+            (* CR lwhite: This should probably not always be [Global] *)
+            add_name Component.Global id acc.module_type_names
+          in
+          let acc = { acc with module_type_names } in
+          loop acc diff declarations rest
+      | Component.Declare_module(_, id) as decl :: rest ->
+          let declarations = decl :: declarations in
+          let module_names =
+            (* CR lwhite: This should probably not always be [Global] *)
+            add_name Component.Global id acc.module_names
+          in
+          let acc = { acc with module_names } in
+          loop acc diff declarations rest
+    and loop_declarations acc diff = function
+      | [] -> acc, diff
+      | Component.Declare_type(origin, id) :: rest ->
+          if Ident_map.mem id acc.types then begin
+            loop_declarations acc diff rest
+          end else begin
+            let typ = Type.declare origin id in
+            let types = Ident_map.add id typ acc.types in
+            let acc = { acc with types } in
+            loop_declarations acc diff rest
+          end
+      | Component.Declare_class_type(origin, id) :: rest ->
+          if Ident_map.mem id acc.class_types then begin
+            loop_declarations acc diff rest
+          end else begin
+            let clty = Class_type.declare origin id in
+            let class_types = Ident_map.add id clty acc.class_types in
+            let acc = { acc with class_types } in
+            loop_declarations acc diff rest
+          end
+      | Component.Declare_module_type(origin, id) :: rest ->
+          if Ident_map.mem id acc.module_types then begin
+            loop_declarations acc diff rest
+          end else begin
+            let mty = Module_type.declare origin id in
+            let module_types = Ident_map.add id mty acc.module_types in
+            let acc = { acc with module_types } in
+            loop_declarations acc diff rest
+          end
+      | Component.Declare_module(origin, id) :: rest ->
+          if Ident_map.mem id acc.modules then begin
+            loop_declarations acc diff rest
+          end else begin
+            let md = Module.declare origin id in
+            let modules = Ident_map.add id md acc.modules in
+            let acc = { acc with modules } in
+            loop_declarations acc diff rest
+          end
+      | ( Component.Type _
+        | Component.Class_type _
+        | Component.Module_type _
+        | Component.Module _) :: _ -> assert false
+    in
+    loop t [] [] descs
+
+  let merge t diff =
+    let rec loop acc = function
+      | [] -> acc
+      | Diff.Item.Type(id, typ, _) :: rest ->
+          let types = Ident_map.add id typ acc.types in
+          let type_names = merge_name id acc.type_names in
+          let acc = { acc with types; type_names } in
+          loop acc rest
+      | Diff.Item.Class_type(id, clty, _) :: rest ->
+          let class_types = Ident_map.add id clty acc.class_types in
+          let class_type_names = merge_name id acc.class_type_names in
+          let acc = { acc with class_types; class_type_names } in
+          loop acc rest
+      | Diff.Item.Module_type(id, mty, _) :: rest ->
+          let module_types = Ident_map.add id mty acc.module_types in
+          let module_type_names = merge_name id acc.module_type_names in
+          let acc = { acc with module_types; module_type_names } in
+          loop acc rest
+      | Diff.Item.Module(id, md, _) :: rest ->
+          let modules = Ident_map.add id md acc.modules in
+          let module_names = merge_name id acc.module_names in
+          let acc = { acc with modules; module_names } in
+          loop acc rest
+    in
+    loop t diff
+
+  let rec find_module t path =
+    match path with
+    | Path.Pident id ->
+        Ident_map.find id t.modules
+    | Path.Pdot(p, name, _) ->
+        let md = find_module t p in
+        Module.find_module t md name
+    | Path.Papply(p, arg) ->
+        let md = find_module t p in
+        Module.find_application t md arg
+
+  let find_type t path =
+    match path with
+    | Path.Pident id ->
+        Ident_map.find id t.types
+    | Path.Pdot(p, name, _) ->
+        let md = find_module t p in
+        Module.find_type t md name
+    | Path.Papply _ ->
+        raise Not_found
+
+  let find_class_type t path =
+    match path with
+    | Path.Pident id ->
+        Ident_map.find id t.class_types
+    | Path.Pdot(p, name, _) ->
+        let md = find_module t p in
+        Module.find_class_type t md name
+    | Path.Papply _ ->
+        raise Not_found
+
+  let find_module_type t path =
+    match path with
+    | Path.Pident id ->
+        Ident_map.find id t.module_types
+    | Path.Pdot(p, name, _) ->
+        let md = find_module t p in
+        Module.find_module_type t md name
+    | Path.Papply _ ->
+        raise Not_found
+
+  let canonical_type_path t id =
+    match Ident_map.find id t.types with
+    | exception Not_found -> Path.Pident id
+    | md -> Type.path t md
+
+  let canonical_class_type_path t id =
+    match Ident_map.find id t.class_types with
+    | exception Not_found -> Path.Pident id
+    | md -> Class_type.path t md
+
+  let canonical_module_type_path t id =
+    match Ident_map.find id t.module_types with
+    | exception Not_found -> Path.Pident id
+    | md -> Module_type.path t md
+
+  let canonical_module_path t id =
+    match Ident_map.find id t.modules with
+    | exception Not_found -> Path.Pident id
+    | md -> Module.path t md
+
+  let rec is_module_path_visible t = function
+    | Path.Pident id -> begin
+        let name = Ident.name id in
+        match String_map.find name t.module_names with
+        | exception Not_found -> false
+        | Local id' -> Ident.equal id id'
+        | Global id' -> Ident.equal id id'
+        | Unambiguous id' -> Ident.equal id id'
+        | Ambiguous(id', ids) ->
+          if not (Ident.equal id id') then false
+          else begin
+            let paths = List.map (canonical_module_path t) ids in
+            let path = canonical_module_path t id in
+            List.for_all (Path.equal path) paths
+          end
+      end
+    | Path.Pdot(path, _, _) ->
+        is_module_path_visible t path
+    | Path.Papply(path1, path2) ->
+        is_module_path_visible t path1
+        && is_module_path_visible t path2
+
+  let is_type_path_visible t = function
+    | Path.Pident id -> begin
+        let name = Ident.name id in
+        match String_map.find name t.type_names with
+        | exception Not_found -> false
+        | Local id' -> Ident.equal id id'
+        | Global id' -> Ident.equal id id'
+        | Unambiguous id' -> Ident.equal id id'
+        | Ambiguous(id', ids) ->
+          if not (Ident.equal id id') then false
+          else begin
+            let paths = List.map (canonical_type_path t) ids in
+            let path = canonical_type_path t id in
+            List.for_all (Path.equal path) paths
+          end
+      end
+    | Path.Pdot(path, _, _) -> is_module_path_visible t path
+    | Path.Papply _ ->
+        failwith
+          "Short_paths_graph.Graph.is_type_path_visible: \
+           invalid type path"
+
+  let is_class_type_path_visible t = function
+    | Path.Pident id -> begin
+        let name = Ident.name id in
+        match String_map.find name t.class_type_names with
+        | exception Not_found -> false
+        | Local id' -> Ident.equal id id'
+        | Global id' -> Ident.equal id id'
+        | Unambiguous id' -> Ident.equal id id'
+        | Ambiguous(id', ids) ->
+          if not (Ident.equal id id') then false
+          else begin
+            let paths = List.map (canonical_class_type_path t) ids in
+            let path = canonical_class_type_path t id in
+            List.for_all (Path.equal path) paths
+          end
+      end
+    | Path.Pdot(path, _, _) -> is_module_path_visible t path
+    | Path.Papply _ ->
+        failwith
+          "Short_paths_graph.Graph.is_class_type_path_visible: \
+           invalid class type path"
+
+  let is_module_type_path_visible t = function
+    | Path.Pident id -> begin
+        let name = Ident.name id in
+        match String_map.find name t.module_type_names with
+        | exception Not_found -> false
+        | Local id' -> Ident.equal id id'
+        | Global id' -> Ident.equal id id'
+        | Unambiguous id' -> Ident.equal id id'
+        | Ambiguous(id', ids) ->
+          if not (Ident.equal id id') then false
+          else begin
+            let paths = List.map (canonical_module_type_path t) ids in
+            let path = canonical_module_type_path t id in
+            List.for_all (Path.equal path) paths
+          end
+      end
+    | Path.Pdot(path, _, _) -> is_module_path_visible t path
+    | Path.Papply _ ->
+        failwith
+          "Short_paths_graph.Graph.is_module_type_path_visible: \
+           invalid module type path"
+
+end
+
+type graph = Graph.t

--- a/src/ocaml/typer_406/typing/short_paths_graph.mli
+++ b/src/ocaml/typer_406/typing/short_paths_graph.mli
@@ -1,0 +1,280 @@
+(** [Short_path_graph] is a representation of the environment (as a graph,
+    using [Graph.t]) that is more suitable to answer short path queries.
+
+    The only structures shared with the typechecker are [Ident.t] and [Path.t].
+    [Graph.t] is pure and doesn't hook into the [Env.t].
+    Context has to be rebuilt by outside code using [Graph.add].
+*)
+
+(* Generic definitions *)
+
+module String_map : Map.S with type key = string
+
+module Ident : sig
+
+  type t = Ident.t
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+
+  val name : t -> string
+
+  val global : string -> t
+
+end
+
+module Ident_map : Map.S with type key = Ident.t
+
+module Ident_set : Set.S with type elt = Ident.t
+
+module Path : sig
+
+  type t = Path.t =
+    | Pident of Ident.t
+    | Pdot of t * string * int
+    | Papply of t * t
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+
+end
+
+module Path_map : Map.S with type key = Path.t
+
+module Path_set : Set.S with type elt = Path.t
+
+(* Subset of the type algebra that is relevant to short path *)
+
+module Desc : sig
+
+  module Type : sig
+
+    type t =
+      | Fresh
+      (** type t *)
+      | Nth of int
+      (** The n'th projection of type parameters.
+          E.g. for n < m, [type ('x_0,'x_1,...,'x_m-1) t = 'x_n]
+          is represented as [Nth n]. *)
+      | Subst of Path.t * int list
+      (** An alias to some other type after substitution of type parameters.
+          E.g. [type ('x_0, 'x_1', 'x_2, 'x_3) t = ('x_3, 'x_2) p]
+          is represented as [Subst (p, [3,2])]. *)
+      | Alias of Path.t
+      (** A direct alias to another type, preserving parameters.
+          E.g [type t = p], [type 'a t = 'a p], ...
+          are represented as [Alias p]. *)
+  end
+
+  module Class_type : sig
+
+    type t =
+      | Fresh
+      | Subst of Path.t * int list
+      | Alias of Path.t
+
+  end
+
+  module Module_type : sig
+
+    type t =
+      | Fresh
+      | Alias of Path.t
+
+  end
+
+  module Module : sig
+
+    type component =
+      | Type of string * Type.t
+      | Class_type of string * Class_type.t
+      | Module_type of string * Module_type.t
+      | Module of string * t
+
+    and components = component list
+
+    and kind =
+      | Signature of components Lazy.t
+      | Functor of (Path.t -> t)
+
+    and t =
+      | Fresh of kind
+      | Alias of Path.t
+
+  end
+
+  type t =
+    | Type of Ident.t * Type.t * bool
+    | Class_type of Ident.t * Class_type.t * bool
+    | Module_type of Ident.t * Module_type.t * bool
+    | Module of Ident.t * Module.t * bool
+    | Declare_type of Ident.t
+    | Declare_class_type of Ident.t
+    | Declare_module_type of Ident.t
+    | Declare_module of Ident.t
+
+end
+
+module Sort : sig
+
+  type t =
+    | Defined
+    | Declared of Ident_set.t
+
+end
+
+module Age : Natural.S
+
+module Dependency : Natural.S
+
+module Origin : sig
+
+  type t =
+    | Dependency of Dependency.t
+    | Dependencies of Dependency.t list
+    | Environment of Age.t
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
+end
+
+type graph
+
+module Type : sig
+
+  type t
+
+  val origin : graph -> t -> Origin.t
+
+  val path : graph -> t -> Path.t
+
+  val sort : graph -> t -> Sort.t
+
+  type resolved =
+    | Nth of int
+    | Path of int list option * t
+
+  val resolve : graph -> t -> resolved
+
+end
+
+module Class_type : sig
+
+  type t
+
+  val origin : graph -> t -> Origin.t
+
+  val path : graph -> t -> Path.t
+
+  val sort : graph -> t -> Sort.t
+
+  type resolved = int list option * t
+
+  val resolve : graph -> t -> resolved
+
+end
+
+module Module_type : sig
+
+  type t
+
+  val origin : graph -> t -> Origin.t
+
+  val path : graph -> t -> Path.t
+
+  val sort : graph -> t -> Sort.t
+
+end
+
+module Module : sig
+
+  type t
+
+  val origin : graph -> t -> Origin.t
+
+  val path : graph -> t -> Path.t
+
+  val sort : graph -> t -> Sort.t
+
+  val types : graph -> t -> Type.t String_map.t option
+
+  val class_types : graph -> t -> Class_type.t String_map.t option
+
+  val module_types : graph -> t -> Module_type.t String_map.t option
+
+  val modules : graph -> t -> t String_map.t option
+
+end
+
+module Diff : sig
+
+  module Item : sig
+
+    type t =
+      | Type of Ident.t * Type.t * Origin.t option
+      | Class_type of Ident.t * Class_type.t * Origin.t option
+      | Module_type of Ident.t * Module_type.t * Origin.t option
+      | Module of Ident.t * Module.t * Origin.t option
+
+    val origin : graph -> t -> Origin.t
+
+    val id : graph -> t -> Ident.t
+
+    val previous : graph -> t -> Origin.t option
+
+  end
+
+  type t = Item.t list
+
+end
+
+module Component : sig
+
+  type source =
+    | Global
+    | Local
+    | Open
+
+  type t =
+    | Type of Origin.t * Ident.t * Desc.Type.t * source
+    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
+    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
+    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Declare_type of Origin.t * Ident.t
+    | Declare_class_type of Origin.t * Ident.t
+    | Declare_module_type of Origin.t * Ident.t
+    | Declare_module of Origin.t * Ident.t
+
+end
+
+module Graph : sig
+
+  type t = graph
+
+  val empty : t
+
+  val add : t -> Component.t list -> t * Diff.t
+
+  val merge : t -> Diff.t -> t
+
+  val find_type : t -> Path.t -> Type.t
+
+  val find_class_type : t -> Path.t -> Class_type.t
+
+  val find_module_type : t -> Path.t -> Module_type.t
+
+  val find_module : t -> Path.t -> Module.t
+
+  val is_type_path_visible : t -> Path.t -> bool
+
+  val is_class_type_path_visible : t -> Path.t -> bool
+
+  val is_module_type_path_visible : t -> Path.t -> bool
+
+  val is_module_path_visible : t -> Path.t -> bool
+
+end

--- a/src/ocaml/typer_406/typing/typeclass.ml
+++ b/src/ocaml/typer_406/typing/typeclass.ml
@@ -302,7 +302,9 @@ let inheritance self_type env ovf concr_meths warn_vals loc parent =
         Some Fresh ->
           let cname =
             match parent with
-              Cty_constr (p, _, _) -> Path.name p
+              Cty_constr (p, _, _) ->
+                let p = Printtyp.shorten_class_type_path env p in
+                Path.name p
             | _ -> "inherited"
           in
           if not (Concr.is_empty over_meths) then
@@ -1700,16 +1702,16 @@ let type_classes define_class approx kind env cls =
   in
   Ctype.init_def (Ident.current_time ());
   Ctype.begin_class_def ();
-  let (res, env) =
+  let (res, newenv) =
     List.fold_left (initial_env define_class approx) ([], env) cls
   in
-  let (res, env) =
-    List.fold_right (class_infos define_class kind) res ([], env)
+  let (res, newenv) =
+    List.fold_right (class_infos define_class kind) res ([], newenv)
   in
   Ctype.end_def ();
-  let res = List.rev_map (final_decl env define_class) res in
+  let res = List.rev_map (final_decl newenv define_class) res in
   let decls = List.fold_right extract_type_decls res [] in
-  let decls = Typedecl.compute_variance_decls env decls in
+  let decls = Typedecl.compute_variance_decls newenv decls in
   let res = List.map2 merge_type_decls res decls in
   let env = List.fold_left (final_env define_class) env res in
   let res = List.map (check_coercions env) res in

--- a/src/ocaml/typer_406/typing/typedecl.ml
+++ b/src/ocaml/typer_406/typing/typedecl.ml
@@ -1729,6 +1729,7 @@ let check_unboxable env loc ty =
   | Tconstr (p, _, _) ->
     let tydecl = Env.find_type p env in
     if tydecl.type_unboxed.unboxed then
+      let p = Printtyp.shorten_type_path env p in
       Location.prerr_warning loc
         (Warnings.Unboxable_type_in_prim_decl (Path.name p))
   | _ -> ()

--- a/src/ocaml/typer_406/typing/typemod.ml
+++ b/src/ocaml/typer_406/typing/typemod.ml
@@ -46,6 +46,8 @@ type error =
   | Recursive_module_require_explicit_type
   | Apply_generative
   | Cannot_scrape_alias of Path.t
+  | Package_type_missing of Path.t * module_type * Longident.t
+  | Package_type_arity of Path.t * module_type * Longident.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -615,7 +617,7 @@ let check_recmod_typedecls env sdecls decls =
 (* Auxiliaries for checking uniqueness of names in signatures and structures *)
 
 module StringSet =
-  Set.Make(struct type t = string let compare (x:t) y = String.compare x y end)
+  Set.Make(struct type t = string let compare = String.compare end)
 
 let check cl loc set_ref name =
   if StringSet.mem name !set_ref
@@ -780,6 +782,7 @@ and transl_signature ?(keep_warnings = false) env sg =
               Typedecl.transl_type_decl env rec_flag sdecls
             with
             | (decls, newenv) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_type (rec_flag, decls)) env loc :: trem,
               map_rec_type_with_row_types ~rec_flag
@@ -839,6 +842,7 @@ and transl_signature ?(keep_warnings = false) env sg =
               }
               in
               let newenv = Env.enter_module_declaration id md env in
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_module {md_id=id; md_name=pmd.pmd_name; md_type=tmty;
                                   md_loc=pmd.pmd_loc;
@@ -858,6 +862,7 @@ and transl_signature ?(keep_warnings = false) env sg =
               transl_recmodule_modtypes env sdecls
             with
             | (decls, newenv) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_recmodule decls) env loc :: trem,
               map_rec (fun rs md ->
@@ -877,6 +882,7 @@ and transl_signature ?(keep_warnings = false) env sg =
               transl_modtype_decl names env pmtd
             with
             | (newenv, mtd, sg) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_modtype mtd) env loc :: trem,
               sg :: rem,
@@ -888,6 +894,7 @@ and transl_signature ?(keep_warnings = false) env sg =
         | Psig_open sod ->
           begin match type_open env sod with
             | (_path, newenv, od) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_open od) env loc :: trem,
               rem, final_env
@@ -914,6 +921,7 @@ and transl_signature ?(keep_warnings = false) env sg =
             with
             | incl, sg ->
               let newenv = Env.add_signature sg env in
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem  in
               mksig (Tsig_include incl) env loc :: trem,
               sg @ rem,
@@ -930,6 +938,7 @@ and transl_signature ?(keep_warnings = false) env sg =
               Typeclass.class_descriptions env cl
             with
             | (classes, newenv) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem, rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_class
                        (List.map (fun decr ->
@@ -957,6 +966,7 @@ and transl_signature ?(keep_warnings = false) env sg =
             Typeclass.class_type_declarations env cl
             with
             | (classes, newenv) ->
+              let newenv = Env.update_short_paths newenv in
               let (trem,rem, final_env) = transl_sig newenv srem in
               mksig (Tsig_class_type
                        (List.map (fun decl -> decl.Typeclass.clsty_info) classes))
@@ -1524,6 +1534,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
           (fun decl -> check_name check_type names decl.ptype_name)
           sdecls;
         let (decls, newenv) = Typedecl.transl_type_decl env rec_flag sdecls in
+        let newenv = Env.update_short_paths newenv in
         Tstr_type (rec_flag, decls),
         map_rec_type_with_row_types ~rec_flag
           (fun rs info -> Sig_type(info.typ_id, info.typ_type, rs))
@@ -1568,6 +1579,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
         (*prerr_endline (Ident.unique_toplevel_name id);*)
         Mtype.lower_nongen (Ident.binding_time id - 1) md.md_type;
         let newenv = Env.enter_module_declaration id md env in
+        let newenv = Env.update_short_paths newenv in
         Tstr_module {mb_id=id; mb_name=name; mb_expr=modl;
                      mb_attributes=attrs;  mb_loc=pmb_loc;
                     },
@@ -1602,6 +1614,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
                  {pmd_name=name; pmd_type=smty;
                   pmd_attributes=attrs; pmd_loc=loc}) sbind
             ) in
+        let newenv = Env.update_short_paths newenv in
         let bindings1 =
           List.map2
             (fun {md_id=id; md_type=mty} (name, _, smodl, attrs, loc) ->
@@ -1631,6 +1644,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
             )
             env decls
         in
+        let newenv = Env.update_short_paths newenv in
         let bindings2 =
           check_recmodule_inclusion newenv bindings1 in
         Tstr_recmodule bindings2,
@@ -1647,15 +1661,18 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
         let newenv, mtd, sg =
           transl_modtype_decl names env pmtd
         in
+        let newenv = Env.update_short_paths newenv in
         Tstr_modtype mtd, [sg], newenv
     | Pstr_open sod ->
         let (_path, newenv, od) = type_open ~toplevel env sod in
+        let newenv = Env.update_short_paths newenv in
         Tstr_open od, [], newenv
     | Pstr_class cl ->
         List.iter
           (fun {pci_name} -> check_name check_type names pci_name)
           cl;
-        let (classes, new_env) = Typeclass.class_declarations env cl in
+        let (classes, newenv) = Typeclass.class_declarations env cl in
+        let newenv = Env.update_short_paths newenv in
         Tstr_class
           (List.map (fun cls ->
                (cls.Typeclass.cls_info,
@@ -1677,12 +1694,13 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
                Sig_type(cls.cls_obj_id, cls.cls_obj_abbr, rs);
                Sig_type(cls.cls_typesharp_id, cls.cls_abbr, rs)])
              classes []),
-        new_env
+        newenv
     | Pstr_class_type cl ->
         List.iter
           (fun {pci_name} -> check_name check_type names pci_name)
           cl;
-        let (classes, new_env) = Typeclass.class_type_declarations env cl in
+        let (classes, newenv) = Typeclass.class_type_declarations env cl in
+        let newenv = Env.update_short_paths newenv in
         Tstr_class_type
           (List.map (fun cl ->
                (cl.Typeclass.clsty_ty_id,
@@ -1701,7 +1719,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
                  Sig_type(decl.clsty_obj_id, decl.clsty_obj_abbr, rs);
                  Sig_type(decl.clsty_typesharp_id, decl.clsty_abbr, rs)])
              classes []),
-        new_env
+        newenv
     | Pstr_include sincl ->
         let smodl = sincl.pincl_mod in
         let modl =
@@ -1712,7 +1730,8 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
         let sg = Subst.signature Subst.identity
             (extract_sig_open env smodl.pmod_loc modl.mod_type) in
         List.iter (check_sig_item names loc) sg;
-        let new_env = Env.add_signature sg env in
+        let newenv = Env.add_signature sg env in
+        let newenv = Env.update_short_paths newenv in
         let incl =
           { incl_mod = modl;
             incl_type = sg;
@@ -1720,7 +1739,7 @@ and type_structure ?(toplevel = false) ?(keep_warnings = false) funct_body ancho
             incl_loc = sincl.pincl_loc;
           }
         in
-        Tstr_include incl, sg, new_env
+        Tstr_include incl, sg, newenv
     | Pstr_extension (ext, _attrs) ->
         raise (Error_forward (Builtin_attributes.error_of_extension ext))
     | Pstr_attribute x ->
@@ -1836,10 +1855,21 @@ let type_package env m p nl =
   in
   let tl' =
     List.map
-      (fun name -> Btype.newgenty (Tconstr (mkpath mp name,[],ref Mnil)))
-      (* beware of interactions with Printtyp and short-path:
-         mp.name may have an arity > 0, cf. PR#7534 *)
-      nl in
+      (fun name ->
+         let path = mkpath mp name in
+         match Env.find_type path env with
+         | decl -> begin
+             match decl.type_params with
+             | [] -> Btype.newgenty (Tconstr (path, [], ref Mnil))
+             | _ ->
+               raise (Error(m.pmod_loc, env,
+                            Package_type_arity(p, modl.mod_type, name)))
+           end
+         | exception Not_found ->
+             raise (Error(m.pmod_loc, env,
+                          Package_type_missing(p, modl.mod_type, name))))
+      nl
+  in
   (* go back to original level *)
   Ctype.end_def ();
   if nl = [] then
@@ -2108,6 +2138,16 @@ let report_error ppf = function
       fprintf ppf
         "This is an alias for module %a, which is missing"
         path p
+  | Package_type_missing(p, mty, lid) ->
+      fprintf ppf
+        "@[<v>Signature mismatch:@ @[<hv 2>Modules do not match:@ \
+        %a@;<1 -2>is not included in@ %a@]@ Type %a is missing.@]"
+        Printtyp.modtype mty path p longident lid
+  | Package_type_arity(p, mty, lid) ->
+      fprintf ppf
+        "@[<v>Signature mismatch:@ @[<hv 2>Modules do not match:@ \
+        %a@;<1 -2>is not included in@ %a@]@ Type %a has a different arity.@]"
+        Printtyp.modtype mty path p longident lid
 
 let report_error env ppf err =
   Printtyp.wrap_printing_env env (fun () -> report_error ppf err)

--- a/src/ocaml/typer_406/typing/typemod.mli
+++ b/src/ocaml/typer_406/typing/typemod.mli
@@ -77,6 +77,8 @@ type error =
   | Recursive_module_require_explicit_type
   | Apply_generative
   | Cannot_scrape_alias of Path.t
+  | Package_type_missing of Path.t * module_type * Longident.t
+  | Package_type_arity of Path.t * module_type * Longident.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
Needed some changes to work with the new approach to `open`, but otherwise it's the same as the patch for 4.05.