### PR TITLE
Emacs: call merlin-command if it is a function

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1635,8 +1635,9 @@ Empty string defaults to jumping to all these."
   (unless merlin-buffer-configuration
     (setq merlin-buffer-configuration (merlin--configuration)))
   (let ((command (merlin-lookup 'command merlin-buffer-configuration)))
-    (unless command (setq command merlin-command))
-    (if (functionp command) (setq command (funcall command)))
+    (unless command
+      (setq command (if (functionp merlin-command) (funcall merlin-command)
+                      merlin-command)))
     (when (equal command 'opam)
       (with-temp-buffer
         (if (eq (call-process-shell-command


### PR DESCRIPTION
In documentation of `merlin-command`, it is written that it can be a function, a path, or a constant.

```elisp
(defcustom merlin-command 'opam
  "The path to merlin in your installation."
  :group 'merlin :type '(choice (file :tag "Filename (default binary is \"ocamlmerlin\")")
                                (function :tag "Function returning path to the binary")
                                (const :tag "Use current opam switch" opam)))
```

However I didn't succeed to set it as a function by doing something like `(setq merlin-command (lambda () "ocamlmerlin")`. I don't know if I am supposed to use `fset` rather than `setq`, but I don't think so as I didn't see any place where `merlin-command` is actually called. So I added a call if `merlin-command` contains a function.

I think it also mean that the `command` set by `merlin-configuration-function` can be a function, but I didn't test that and didn't updated the documentation `merlin-buffer-configuration`. I can do it if necessary.