### PR TITLE
Remove hard ocamlfind dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ ocamlmerlin-test.exe
 config.iss
 ._d
 ._ncdi
+src/utils/findlib_stub.ml
 
 # Ignore garbage files from editors
 *.un~

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ VIM_DIR := $(DESTDIR)$(VIM_DIR)
 #### Invocation of OCamlMakefile
 
 OCAMLMAKEFILE= $(MAKE) -f Makefile.ocamlmakefile \
-							 WITH_BIN_ANNOT="$(WITH_BIN_ANNOT)" WITHOUT_DEBUG="$(WITHOUT_DEBUG)"
+							 WITH_BIN_ANNOT="$(WITH_BIN_ANNOT)" WITH_FINDLIB="$(WITH_FINDLIB)" WITHOUT_DEBUG="$(WITHOUT_DEBUG)"
 
 ifdef VERBOSE
 	OCAMLMAKEFILE += REALLY_QUIET=0
@@ -119,7 +119,7 @@ message:
 	@echo "-------------------"
 	@echo "Add $(VIM_DIR) to your runtime path, e.g.:"
 	@echo "  :set rtp+=$(VIM_DIR)"
-	@echo 
+	@echo
 	@echo "Quick setup for EMACS"
 	@echo "-------------------"
 	@echo "Add $(SHARE_DIR)/emacs/site-lisp to your runtime path, e.g.:"

--- a/Makefile.ocamlmakefile
+++ b/Makefile.ocamlmakefile
@@ -15,6 +15,11 @@ ifdef WITH_BIN_ANNOT
 	OCAMLFLAGS += -bin-annot
 endif
 
+FINDLIB_PACKAGE=
+ifdef WITH_FINDLIB
+	FINDLIB_PACKAGE=findlib
+endif
+
 ifndef WITHOUT_DEBUG
 	OCAMLFLAGS += -g
 	OCAMLLDFLAGS += -g
@@ -27,6 +32,7 @@ THREADS  = $(MERLIN_NEED_THREADS)
 CONFIG_FILES = src/config/my_config.ml src/ocaml
 
 SOURCES_LIB = \
+	src/utils/findlib_stub.ml         \
 	src/config/my_config.ml           \
 	src/platform/platform_misc.c      \
 	src/platform/os_ipc_stub.c        \
@@ -260,16 +266,16 @@ SOURCES_LIB = \
 	src/frontend/query_commands.mli   \
 	src/frontend/query_commands.ml
 
-PACKS = str findlib yojson unix $(MERLIN_STURGEON_PACKAGE)
+PACKS = str $(FINDLIB_PACKAGE) yojson unix $(MERLIN_STURGEON_PACKAGE)
 
 ifeq ($(PROJECT),test)
 	RESULT = ocamlmerlin-test
-	
+
 	SOURCES = $(SOURCES_LIB) \
 	          src/frontend/test/ocamlmerlin_test.ml
 else
 	RESULT = ocamlmerlin-server$(RESULT_SUFFIX)
-	
+
 	SOURCES = $(SOURCES_LIB)                    \
 						src/frontend/old/old_IO.mli       \
 						src/frontend/old/old_IO.ml        \

--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@
 # ===============
 
 # [check_package $pkg $msg]
-# - succeeds if findlib package $pkg is installed 
+# - succeeds if findlib package $pkg is installed
 # - or sets EXIT=1 and displays $msg
 check_package()
 {
@@ -58,6 +58,8 @@ The options available for better control are as follow:
                                     merlin when called with -version or -vnum.
 
     --force-caml-version <str>      will link ocaml/typer to ocaml/typer_<str>
+
+    --without-findlib       Disable findlib support.
 END
 }
 
@@ -87,6 +89,7 @@ SHARE_DIR=/usr/local/share
 VIM_DIR=/usr/local/share/ocamlmerlin/vim
 WITH_BIN_ANNOT=""
 VERSION_STRING=""
+WITH_FINDLIB=1
 CAML_VERSION=
 EXIT=0
 
@@ -127,6 +130,10 @@ while [ -n "$1" ]; do
     --force-caml-version)
       shift 1
       CAML_VERSION="$1"
+      ;;
+    --without-findlib)
+      shift 1
+      WITH_FINDLIB=""
       ;;
     --help|-help|-h)
       usage
@@ -170,15 +177,15 @@ case "$CMI_NUMBER" in
     if [ "x$FULL_VERSION" = "x4.02.0" ]; then
       OCAML_VERSION_MESSAGE="OCaml 4.02.0"
       filter_file src/ocaml/typer_402/typing/typecore.ml \
-        grep -v -F '| Scan_next_char 
-| Ignored_scan_next_char 
-| Any_ty 
+        grep -v -F '| Scan_next_char
+| Ignored_scan_next_char
+| Any_ty
 | Custom '
       OCAML_VERSION_VAL='`OCaml_4_02_0'
     elif [ "x$FULL_VERSION" = "x4.02.1" ]; then
       OCAML_VERSION_MESSAGE="OCaml 4.02.1"
       filter_file src/ocaml/typer_402/typing/typecore.ml \
-        grep -v -F '| Any_ty 
+        grep -v -F '| Any_ty
 | Custom '
       OCAML_VERSION_VAL='`OCaml_4_02_1'
     elif [ "x$FULL_VERSION" = "x4.02.2" ]; then
@@ -225,8 +232,8 @@ fi
 
 if [ "x1.5.1" = "x$(ocamlfind query findlib -format '%v' | tr -d '\015')" ]; then
   printf "\nOld version of findlib detected (1.5.1), patching\n"
-  filter_file src/kernel/mconfig_dot.ml \
-     sed -e 's/Findlib\.resolve_path ~base:d ~explicit:true/Findlib.resolve_path ~base:d/'
+  filter_file src/utils/findlib_stub.ml.ok \
+     sed -e 's/Findlib\.resolve_path ~explicit:true/Findlib.resolve_path/'
 fi
 
 if ocamlfind ocamlopt; then
@@ -234,6 +241,14 @@ if ocamlfind ocamlopt; then
 else
   NATIVE=false
 fi
+
+if [ -z $WITH_FINDLIB ]; then
+    FINDLIB_STUB_VERSION=dummy
+else
+    FINDLIB_STUB_VERSION=ok
+fi
+echo "# 1 \"findlib_stub.ml.$FINDLIB_STUB_VERSION\"" > src/utils/findlib_stub.ml
+cat src/utils/findlib_stub.ml.$FINDLIB_STUB_VERSION >> src/utils/findlib_stub.ml
 
 ## Sturgeon version check
 ## ======================
@@ -253,7 +268,7 @@ else
 fi
 
 MERLIN_CONFIG_ENV="
-export MERLIN_NEED_THREADS=${NEED_THREADS} 
+export MERLIN_NEED_THREADS=${NEED_THREADS}
 export MERLIN_STURGEON_PACKAGE=${STURGEON_PACKAGE}
 "
 
@@ -306,6 +321,7 @@ System config:
   Native code: $NATIVE
   Sturgeon version: $STURGEON_VERSION_MESSAGE
   Need threads: $NEED_THREADS_MESSAGE
+  findlib support: $(if [ -z $WITH_FINDLIB ]; then echo no; else echo yes; fi)
 
 Will install:
   ocamlmerlin binary in: $BIN_DIR
@@ -330,6 +346,7 @@ SHARE_DIR=$SHARE_DIR
 VIM_DIR=$VIM_DIR
 NATIVE=$NATIVE
 WITH_BIN_ANNOT=$WITH_BIN_ANNOT
+WITH_FINDLIB=$WITH_FINDLIB
 ENABLE_COMPILED_EMACS_MODE=$ENABLE_COMPILED_EMACS_MODE
 export EXE=$EXE
 CCOMP_TYPE=$CCOMP_TYPE

--- a/src/frontend/old/old_IO.ml
+++ b/src/frontend/old/old_IO.ml
@@ -160,7 +160,7 @@ let with_failures failures assoc = match failures with
         fun (pkgs, flgs, exts) (str,exn) ->
           let str = "\"" ^ str ^ "\"" in
           match exn with
-          | Fl_package_base.No_such_package _ -> str :: pkgs, flgs, exts
+          | Findlib_stub.No_such_package _ -> str :: pkgs, flgs, exts
           | Arg.Bad _ -> pkgs, str :: flgs, exts
           | Extension.Unknown -> pkgs, flgs, str :: exts
           | e -> (str ^ " (" ^ Printexc.to_string e ^ ")") :: pkgs, flgs, exts

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -268,7 +268,7 @@ let load ~stdlib filenames =
 (* FIXME: Move elsewhere, processing of findlib packages*)
 
 let ppx_of_package ?(predicates=[]) setup pkg =
-  let d = Findlib.package_directory pkg in
+  let d = Findlib_stub.package_directory pkg in
   (* Determine the 'ppx' property: *)
   let in_words ~comma s =
     (* splits s in words separated by commas and/or whitespace *)
@@ -286,9 +286,9 @@ let ppx_of_package ?(predicates=[]) setup pkg =
     in
     split 0 0
   in
-  let resolve_path = Findlib.resolve_path ~base:d ~explicit:true in
+  let resolve_path = Findlib_stub.resolve_path ~base:d in
   let ppx =
-    try Some(resolve_path (Findlib.package_property predicates pkg "ppx"))
+    try Some(resolve_path (Findlib_stub.package_property predicates pkg "ppx"))
     with Not_found -> None
   and ppxopts =
     try
@@ -348,13 +348,13 @@ let set_findlib_path =
         "findlib_conf = %s; findlib_path = %s\n"
         conf
         (String.concat ~sep:path_separator path);
-      Findlib.init ?env_ocamlpath ?config ?toolchain ();
+      Findlib_stub.init ?env_ocamlpath ?config ?toolchain ();
       findlib_cache := key
     end
 
 let standard_library ?conf ?path ?toolchain () =
   set_findlib_path ?conf ?path ?toolchain ();
-  Findlib.ocaml_stdlib ()
+  Findlib_stub.ocaml_stdlib ()
 
 let is_package_optional name =
   let last = String.length name - 1 in
@@ -369,7 +369,7 @@ let path_of_packages ?conf ?path ?toolchain packages =
   let recorded_packages, invalid_packages =
     List.partition packages
       ~f:(fun name ->
-          match Findlib.package_directory (remove_option name) with
+          match Findlib_stub.package_directory (remove_option name) with
           | _ -> true
           | exception _ -> false)
   in
@@ -388,16 +388,16 @@ let path_of_packages ?conf ?path ?toolchain packages =
   in
   let recorded_packages = List.map ~f:remove_option recorded_packages in
   let packages, failures =
-    match Findlib.package_deep_ancestors [] recorded_packages with
+    match Findlib_stub.package_deep_ancestors [] recorded_packages with
     | packages -> packages, failures
     | exception exn ->
       [], (sprintf "Findlib failure: %S" (Printexc.to_string exn) :: failures)
   in
   let packages = List.filter_dup packages in
-  let path = List.map ~f:Findlib.package_directory packages in
+  let path = List.map ~f:Findlib_stub.package_directory packages in
   let ppxs = List.fold_left ~f:ppx_of_package packages ~init:Ppxsetup.empty in
   path, ppxs, failures
 
 let list_packages ?conf ?path ?toolchain () =
   set_findlib_path ?conf ?path ?toolchain ();
-  Fl_package_base.list_packages ()
+  Findlib_stub.list_packages ()

--- a/src/utils/findlib_stub.ml.dummy
+++ b/src/utils/findlib_stub.ml.dummy
@@ -1,0 +1,12 @@
+exception No_such_package of string * string
+let err pkg = raise (No_such_package (pkg, "no findlib support"))
+let init
+    ?env_ocamlpath:_ ?env_ocamlfind_destdir:_ ?env_ocamlfind_metadir:_
+    ?env_ocamlfind_commands:_ ?env_ocamlfind_ignore_dups_in:_
+    ?env_camllib:_ ?env_ldconf:_ ?config:_ ?toolchain:_ () = ()
+let ocaml_stdlib () = ""
+let package_directory pkg = err pkg
+let resolve_path ?base:_ pkg = err pkg
+let package_property _ pkg _ = err pkg
+let package_deep_ancestors _ = function [] -> [] | pkg :: _ -> err pkg
+let list_packages () = []

--- a/src/utils/findlib_stub.ml.ok
+++ b/src/utils/findlib_stub.ml.ok
@@ -1,0 +1,8 @@
+exception No_such_package = Findlib.No_such_package
+let init = Findlib.init
+let ocaml_stdlib = Findlib.ocaml_stdlib
+let package_directory = Findlib.package_directory
+let resolve_path = Findlib.resolve_path ~explicit:true
+let package_property = Findlib.package_property
+let package_deep_ancestors = Findlib.package_deep_ancestors
+let list_packages = Fl_package_base.list_packages

--- a/src/utils/misc.ml
+++ b/src/utils/misc.ml
@@ -15,7 +15,7 @@
 
 open Std
 
-let () = Findlib.init ()
+let () = Findlib_stub.init ()
 
 (* Errors *)
 


### PR DESCRIPTION
We are using `merlin` under Windows without `ocamlfind`.

Currently, `merlin` does not work if `findlib` is not installed at run-time. This patch adds a stub module `Findlib_stub` and a configure-time option `--disable-findlib` to disable the runtime dependency on `findlib`.

Note that `ocamlfind` is still necessary for **building** `merlin`. In this direction, I have another patch that switches the build system to `jbuilder` (which supports OCaml all the way back to 4.02.3). This removes the compile-time dependency on `ocamlfind` and makes it trivial to build on Windows (our motivation). Do let me know if you would be interested in this patch, I can submit it for consideration as a PR as well.

Thanks!