### PR TITLE
emacs: support reason-mode in *merlin-types* buffer

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1763,7 +1763,7 @@ Short cuts:
   (if merlin-mode
     ;; When enabling merlin
     (progn
-      (when (member major-mode '(tuareg-mode caml-mode))
+      (when (member major-mode '(tuareg-mode caml-mode reason-mode))
 	(setq merlin-guessed-favorite-caml-mode major-mode))
       (if (merlin-can-handle-buffer)
           (merlin-setup)


### PR DESCRIPTION
Correctly set face of content of `*merlin-types*` when type comes from reason file.