### PR TITLE
Fix change of viewport after MerlinTypeOf in neovim

### DIFF
--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -33,7 +33,7 @@ function! merlin_type#ShowTypeHistory()
   if l:win <# 0
     let t:merlin_restore_windows = winrestcmd()
     silent execute "bot " . g:merlin_type_history_height . "split"
-    execute "buffer" g:merlin_type_history
+    silent execute "buffer" g:merlin_type_history
   elseif winnr() !=# l:win
     exe l:win . "wincmd w"
   endif

--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -60,6 +60,8 @@ function! s:RecordType(type)
     exe t:merlin_restore_windows
   endif
 
+  let l:view = winsaveview()
+
   " vimscript can't append to a buffer without a refresh (?!)
   MerlinPy << EOF
 
@@ -95,6 +97,8 @@ else:
 # it is apparently the desired behavior.
 cw.cursor = cursor
 EOF
+
+  call winrestview(l:view)
 endfunction
 
 function! merlin_type#Show(type, tail_info)


### PR DESCRIPTION
In newer versions of neovim, assigning to`vim.current.window.cursor`causes a change in the viewport (#820). In these versions, changing the cursor isn't necessary in the first place, as it was a workaround for older versions of neovim.

This PR also contains an unrelated fix for unnecessary filling of the `:messages` buffer due to an unsilenced `buffer` command.