### PR TITLE
Various locate improvements

### DIFF
--- a/Makefile.ocamlmakefile
+++ b/Makefile.ocamlmakefile
@@ -8,7 +8,7 @@ ifndef OVERRIDE_ENV
 	OCAMLDEP := ocamldep
 endif
 
-OCAMLFLAGS += -w -3
+OCAMLFLAGS += -w -3-40
 REALLY_QUIET ?= 1
 
 ifndef WITHOUT_BIN_ANNOT

--- a/Makefile.ocamlmakefile
+++ b/Makefile.ocamlmakefile
@@ -141,6 +141,8 @@ SOURCES_LIB = \
 	$(TYPER)/typing/tast_mapper.ml    \
 	$(TYPER)/typing/cmt_format.mli    \
 	$(TYPER)/typing/cmt_format.ml     \
+	src/analysis/namespaced_path.mli  \
+	src/analysis/namespaced_path.ml   \
 	src/ocaml/support/cmt_cache.ml    \
 	$(TYPER)/typing/ctype.mli         \
 	$(TYPER)/typing/ctype.ml          \

--- a/Makefile.ocamlmakefile
+++ b/Makefile.ocamlmakefile
@@ -243,8 +243,8 @@ SOURCES_LIB = \
 	src/analysis/typedtrie.mli        \
 	src/analysis/typedtrie.ml         \
 	src/analysis/ocamldoc.ml          \
-	src/analysis/track_definition.mli \
-	src/analysis/track_definition.ml  \
+	src/analysis/locate.mli           \
+	src/analysis/locate.ml            \
 	src/analysis/polarity_search.ml   \
 	src/analysis/expansion.ml         \
 	src/analysis/completion.mli       \

--- a/doc/dev/ARCHITECTURE.md
+++ b/doc/dev/ARCHITECTURE.md
@@ -94,7 +94,7 @@ annotations, printing ...)
 
 `ocamldoc.ml`: get documentation associated to a definition
 
-`typedtrie.ml`: quick lookup of OCaml paths
+`typedtrie.ml`: a trie representation of a compilation unit, allowing quick lookup of OCaml paths
 
 `type_utils.ml`: light wrapper over some functions of OCaml typer
 
@@ -106,7 +106,7 @@ annotations, printing ...)
 
 `outline.ml`: produce an overview of an OCaml module's structure and definitions 
 
-`track_definition.ml`: implement locate feature, i.e. "where is this entity defined?"
+`locate.ml`: implement a jump-to-definition/declaration feature
 
 `jump.ml`: implement convenient nagivation commands
 

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -358,12 +358,10 @@ let rec locate ~config ?pos path trie : locate_result =
       Fallback.setopt fallback ;
       from_path ~config new_path
     | _ ->
-      logf "locate" "new path (%s) is not a real path. fallbacking..."
+      logf "locate" "new path (%s) is not a real path"
         (Typedtrie.path_to_string new_path);
-      logfmt "locate" (fun fmt -> Typedtrie.dump fmt trie);
-      match fallback with
-      | None -> Other_error
-      | Some l -> Found (l, None)
+      logfmt "locate (typedtrie dump)" (fun fmt -> Typedtrie.dump fmt trie);
+      Other_error (* incorrect path *)
     end
   | Typedtrie.Alias_of (loc, new_path) ->
     logf "locate" "alias of %s" (Typedtrie.path_to_string new_path) ;

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -145,30 +145,31 @@ end
 module File_switching : sig
   val reset : unit -> unit
 
-  val move_to : ?digest:Digest.t -> string -> unit (* raises Can't_move *)
+  val move_to : ?digest:Digest.t -> string -> unit
 
   val where_am_i : unit -> string option
 
   val source_digest : unit -> Digest.t option
 end = struct
   type t = {
-    last_file_visited : string option ;
-    digest : Digest.t option ;
+    last_file_visited : string;
+    digest : Digest.t option ; (* [None] only for packs. *)
   }
 
-  let default = { last_file_visited = None ; digest = None }
+  let last_file_visited t = t.last_file_visited
+  let digest t = t.digest
 
-  let state = ref default
+  let state = ref None
 
-  let reset () = state := default
+  let reset () = state := None
 
   let move_to ?digest file =
     logf "File_switching.move_to" "%s" file;
-    state := { last_file_visited = Some file ; digest }
+    state := Some { last_file_visited = file ; digest }
 
-  let where_am_i () = !state.last_file_visited
+  let where_am_i () = Option.map !state ~f:last_file_visited
 
-  let source_digest () = !state.digest
+  let source_digest () = Option.bind !state ~f:digest
 end
 
 

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -385,13 +385,12 @@ type locate_result =
   | Other_error (* FIXME *)
 
 let rec locate ~config ?pos path trie : locate_result =
-  match Typedtrie.find ?before:pos trie path with
+  match Typedtrie.find ~remember_loc:Fallback.set ?before:pos trie path with
   | Typedtrie.Found (loc, doc_opt) -> Found (loc, doc_opt)
-  | Typedtrie.Resolves_to (new_path, fallback) ->
-    begin match Namespaced_path.head new_path with
-    | (_, `Mod) ->
+  | Typedtrie.Resolves_to new_path ->
+    begin match snd (Namespaced_path.head new_path) with
+    | `Mod ->
       logf "locate" "resolves to %s" (Namespaced_path.to_string new_path);
-      Fallback.setopt fallback ;
       from_path ~config new_path
     | _ ->
       logf "locate" "new path (%s) is not a real path"

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -116,11 +116,11 @@ end = struct
   let cmti s = CMTI (file_path_to_mod_name s)
 
   let of_filename fn =
-    match String.split_on_char fn ~sep:'.' with
+    match Misc.rev_string_split ~on:'.' fn with
     | []
     | [ _ ] -> None
-    | lst ->
-      let ext = String.lowercase_ascii (Option.get @@ List.last lst) in
+    | ext :: _ ->
+      let ext = String.lowercase ext in
       Some (
         match ext with
         | "cmti" -> cmti fn

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -408,14 +408,6 @@ and browse_cmts ~config ~root path_opt : locate_result =
       | Some path ->
         match Typedtrie.path_head path with
         | id, `Mod ->
-          assert (
-            List.exists files ~f:(fun s ->
-              match File.of_filename s with
-              | None ->
-                false (* no extension? perhaps we should even assert false. *)
-              | Some f -> File.name f = Typedtrie.idname id
-            )
-          );
           log "loadpath" "Saw packed module => erasing loadpath" ;
           let new_path = cached.Cmt_cache.cmt_infos.cmt_loadpath in
           erase_loadpath ~cwd:(Filename.dirname root) ~new_path (fun () ->

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -702,7 +702,8 @@ let locate ~config ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
     let lazy trie = lazy_trie in
     match locate ~config ~context:(Initial pos) path trie with
     | Found (loc, doc) -> `Found (loc, doc)
-    | Other_error when Fallback.is_set () -> recover str_ident
+    | Other_error
+    | File_not_found _ when Fallback.is_set () -> recover str_ident
     | Other_error -> `Not_found (str_ident, File_switching.where_am_i ())
     | File_not_found f -> File.explain_not_found str_ident f
   with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -75,18 +75,86 @@ module Fallback = struct
   let is_set () = !fallback <> None
 end
 
-module File = struct
-  type t =
+module File : sig
+  type t = private
     | ML   of string
+    | MLL  of string
     | MLI  of string
     | CMT  of string
     | CMTI of string
 
-  let name = function ML name | MLI name | CMT name | CMTI name -> name
+  val ml : string -> t
+  val mli : string -> t
+  val cmt : string -> t
+  val cmti : string -> t
 
-  let ext = function
-    | ML _  -> ".ml"  | MLI _  -> ".mli"
-    | CMT _ -> ".cmt" | CMTI _ -> ".cmti"
+  val of_filename : string -> t option
+
+  (* FIXME: don't export this *)
+  exception Not_found of t
+
+  val alternate : t -> t
+
+  val name : t -> string
+
+  val with_ext : ?src_suffix_pair:(string * string) -> t -> string
+
+  val explain_not_found :
+    ?doc_from:string -> string -> t -> [> `File_not_found of string ]
+end = struct
+  type t =
+    | ML   of string
+    | MLL  of string
+    | MLI  of string
+    | CMT  of string
+    | CMTI of string
+
+  let file_path_to_mod_name f =
+    Misc.unitname (Filename.basename f)
+
+  let ml   s = ML   (file_path_to_mod_name s)
+  let mll  s = MLL  (file_path_to_mod_name s)
+  let mli  s = MLI  (file_path_to_mod_name s)
+  let cmt  s = CMT  (file_path_to_mod_name s)
+  let cmti s = CMTI (file_path_to_mod_name s)
+
+  let of_filename fn =
+    match String.split_on_char fn ~sep:'.' with
+    | []
+    | [ _ ] -> None
+    | lst ->
+      let ext = String.lowercase_ascii (Option.get @@ List.last lst) in
+      Some (
+        match ext with
+        | "cmti" -> cmti fn
+        | "cmt"  -> cmt fn
+        | "mll"  -> mll fn
+        | _ -> if Filename.check_suffix ext "i" then mli fn else ml fn
+      )
+
+  let alternate = function
+    | ML  s
+    | MLL s -> MLI s
+    | MLI s -> ML s
+    | CMT s  -> CMTI s
+    | CMTI s -> CMT s
+
+  let name = function
+    | ML name
+    | MLL name
+    | MLI name
+    | CMT name
+    | CMTI name -> name
+
+  let ext src_suffix_pair = function
+    | ML _  -> fst src_suffix_pair
+    | MLI _  -> snd src_suffix_pair
+    | MLL _ -> ".mll"
+    | CMT _ -> ".cmt"
+    | CMTI _ -> ".cmti"
+
+  let with_ext ?(src_suffix_pair=(".ml",".mli")) t =
+    name t ^ ext src_suffix_pair t
 
   exception Not_found of t
 
@@ -95,6 +163,9 @@ module File = struct
       match path with
       | ML file ->
         sprintf "'%s' seems to originate from '%s' whose ML file could not be \
+                 found" str_ident file
+      | MLL file ->
+        sprintf "'%s' seems to originate from '%s' whose MLL file could not be \
                  found" str_ident file
       | MLI file ->
         sprintf "'%s' seems to originate from '%s' whose MLI file could not be \
@@ -115,8 +186,8 @@ end
 module Preferences : sig
   val set : [ `ML | `MLI ] -> unit
 
-  val cmt : string -> File.t
-  val ml  : string -> File.t
+  val src : string -> File.t
+  val build : string -> File.t
 
   val is_preferred : string -> bool
 end = struct
@@ -128,18 +199,14 @@ end = struct
       | `ML -> true
       | _ -> false
 
-  open File
+  let src   file = if !prioritize_impl then File.ml  file else File.mli  file
+  let build file = if !prioritize_impl then File.cmt file else File.cmti file
 
-  let cmt file = if !prioritize_impl then CMT file else CMTI file
-  let ml file = if !prioritize_impl then ML file else MLI file
-
-  let is_preferred filename =
-    if !prioritize_impl then
-      Filename.check_suffix filename "ml" ||
-      Filename.check_suffix filename "ML"
-    else
-      Filename.check_suffix filename "mli" ||
-      Filename.check_suffix filename "MLI"
+  let is_preferred fn =
+    match File.of_filename fn with
+    | Some ML _ -> !prioritize_impl
+    | Some MLI _ -> not !prioritize_impl
+    | _ -> false
 end
 
 module File_switching : sig
@@ -187,34 +254,6 @@ module Utils = struct
     | Longident.Lident _ -> false
     | _ -> true
 
-  let split_extension file =
-    (* First grab basename to guard against directories with dots *)
-    let basename = Filename.basename file in
-    try
-      let last_dot_pos = String.rindex basename '.' in
-      let ext_name = String.sub basename last_dot_pos (String.length basename - last_dot_pos) in
-      let base_without_ext = String.sub basename 0 last_dot_pos in
-      (base_without_ext, Some ext_name)
-    with Not_found -> (file, None)
-
-
-  let synonym_extension file (impl_alias, intf_alias) =
-    match split_extension file with
-      | (without_ext, None) -> without_ext
-      | (without_ext, Some ext) ->
-        if ext = ".ml" then
-          without_ext ^ impl_alias
-        else (
-          if ext = ".mli" then
-            without_ext ^ intf_alias
-          else
-            file
-        )
-
-  let file_path_to_mod_name f =
-    let pref = Misc.chop_extensions f in
-    String.capitalize (Filename.basename pref)
-
   (* Reuse the code of [Misc.find_in_path_uncap] but returns all the files
      matching, instead of the first one.
      This is only used when looking for ml files, not cmts. Indeed for cmts we
@@ -223,10 +262,14 @@ module Utils = struct
      not the case for the "source path" however.
      We therefore get all matching files and use an heuristic at the call site
      to choose the appropriate file. *)
-  let find_all_in_path_uncap ?(fallback="") path name =
-    let has_fallback = fallback <> "" in
+  let find_all_in_path_uncap ?src_suffix_pair ~with_fallback path file =
+    let name = File.with_ext ?src_suffix_pair file in
     let uname = String.uncapitalize name in
-    let ufbck = String.uncapitalize fallback in
+    let fallback, ufallback =
+      let alt = File.alternate file in
+      let fallback = File.with_ext ?src_suffix_pair alt in
+      fallback, String.uncapitalize fallback
+    in
     let try_file dirname basename acc =
       if Misc.exact_file_exists ~dirname ~basename
       then Misc.canonicalize_filename (Filename.concat dirname basename) :: acc
@@ -236,8 +279,8 @@ module Utils = struct
       let acc = try_file dirname uname acc in
       let acc = try_file dirname name acc in
       let acc =
-        if has_fallback then
-          let acc = try_file dirname ufbck acc in
+        if with_fallback then
+          let acc = try_file dirname ufallback acc in
           let acc = try_file dirname fallback acc in
           acc
         else
@@ -248,63 +291,33 @@ module Utils = struct
     List.fold_left ~f:try_dir ~init:[] path
 
   let find_all_matches ~config ?(with_fallback=false) file =
-    let fname = Misc.chop_extension_if_any (File.name file) ^ (File.ext file) in
-    let fallback =
-      if not with_fallback then "" else
-      match file with
-      | File.ML f   -> Misc.chop_extension_if_any f ^ ".mli"
-      | File.MLI f  -> Misc.chop_extension_if_any f ^ ".ml"
-      | _ -> assert false
-    in
     let files =
       List.concat_map (fun synonym_pair ->
-        let fallback = synonym_extension fallback synonym_pair in
-        let fname = synonym_extension fname synonym_pair in
-        find_all_in_path_uncap ~fallback (Mconfig.source_path config) fname
+        find_all_in_path_uncap ~src_suffix_pair:synonym_pair ~with_fallback
+          (Mconfig.source_path config) file
       ) Mconfig.(config.merlin.suffixes)
     in
     List.uniq files ~cmp:String.compare
 
   let find_file_with_path ~config ?(with_fallback=false) file path =
-    let fname = Misc.chop_extension_if_any (File.name file) ^ (File.ext file) in
-    if Misc.unitname fname = Misc.unitname Mconfig.(config.query.filename) then
+    if File.name file = Misc.unitname Mconfig.(config.query.filename) then
       Mconfig.(config.query.filename)
     else
-      let fallback =
-        if not with_fallback then "" else
-          match file with
-          | File.ML f   -> Misc.chop_extension_if_any f ^ ".mli"
-          | File.MLI f  -> Misc.chop_extension_if_any f ^ ".ml"
-          | File.CMT f  -> Misc.chop_extension_if_any f ^ ".cmti"
-          | File.CMTI f -> Misc.chop_extension_if_any f ^ ".cmt"
+      let rec attempt_search src_suffix_pair =
+        let fallback = File.with_ext ~src_suffix_pair (File.alternate file) in
+        let fname = File.with_ext ~src_suffix_pair file in
+        try Some (Misc.find_in_path_uncap ~fallback path fname)
+        with Not_found -> None
       in
-      let rec attempt_search synonyms =
-        match synonyms with
-        | [] -> raise Not_found
-        | [synonym_pair] ->
-          (* Upon trying the final [synonym_pair], search failure should raise *)
-          let fallback = synonym_extension fallback synonym_pair in
-          let fname = synonym_extension fname synonym_pair in
-          (
-            try Misc.find_in_path_uncap ~fallback path fname with
-              Not_found -> raise (File.Not_found file)
-          )
-        | synonym_pair :: ((rest1 :: rest2) as rest_synonyms) ->
-          (* If cannot find match, continue searching through [rest_synonyms] *)
-          let fallback = synonym_extension fallback synonym_pair in
-          let fname = synonym_extension fname synonym_pair in
-          (
-            try Misc.find_in_path_uncap ~fallback path fname with
-              Not_found -> attempt_search rest_synonyms
-          )
-      in
-      attempt_search Mconfig.(config.merlin.suffixes)
+      try List.find_map Mconfig.(config.merlin.suffixes) ~f:attempt_search
+      with Not_found ->
+        raise (File.Not_found file)
 
-  let find_file ~config ?with_fallback file =
+  let find_file ~config ?with_fallback (file : File.t) =
     find_file_with_path ~config ?with_fallback file @@
         match file with
-        | File.ML  _ | File.MLI _  -> Mconfig.source_path config
-        | File.CMT _ | File.CMTI _ -> !loadpath
+        | ML  _ | MLI _  | MLL _ -> Mconfig.source_path config
+        | CMT _ | CMTI _         -> !loadpath
 end
 
 module Context = struct
@@ -394,7 +407,10 @@ and browse_cmts ~config ~root path_opt =
         | id, `Mod ->
           assert (
             List.exists files ~f:(fun s ->
-              Utils.file_path_to_mod_name s = Typedtrie.idname id
+              match File.of_filename s with
+              | None ->
+                false (* no extension? perhaps we should even assert false. *)
+              | Some f -> File.name f = Typedtrie.idname id
             )
           );
           log "loadpath" "Saw packed module => erasing loadpath" ;
@@ -435,13 +451,13 @@ and from_path ~config path =
     in
     begin match
       Utils.find_file ~config ~with_fallback:true
-        (Preferences.cmt (Typedtrie.idname fname))
+        (Preferences.build (Typedtrie.idname fname))
     with
     | cmt_file -> save_digest_and_return cmt_file
     | exception File.Not_found (File.CMT fname | File.CMTI fname) ->
       restore_loadpath ~config (fun () ->
         match
-          Utils.find_file ~config ~with_fallback:true (Preferences.cmt fname)
+          Utils.find_file ~config ~with_fallback:true (Preferences.build fname)
         with
         | cmt_file -> save_digest_and_return cmt_file
         | exception File.Not_found (File.CMT fname | File.CMTI fname) ->
@@ -462,13 +478,13 @@ and from_path ~config path =
       let modules = try Some (Typedtrie.peal_head path) with _ -> None in
       begin match
         Utils.find_file ~config ~with_fallback:true
-          (Preferences.cmt (Typedtrie.idname fname))
+          (Preferences.build (Typedtrie.idname fname))
       with
       | cmt_file -> browse_cmts ~config ~root:cmt_file modules
       | exception (File.Not_found (File.CMT fname | File.CMTI fname) as exn) ->
         restore_loadpath ~config (fun () ->
           match
-            Utils.find_file ~config ~with_fallback:true (Preferences.cmt fname)
+            Utils.find_file ~config ~with_fallback:true (Preferences.build fname)
           with
           | cmt_file -> browse_cmts ~config ~root:cmt_file modules
           | exception File.Not_found (File.CMT fname | File.CMTI fname) ->
@@ -501,11 +517,11 @@ exception Multiple_matches of string list
 let find_source ~config loc =
   let fname = loc.Location.loc_start.Lexing.pos_fname in
   let with_fallback = loc.Location.loc_ghost in
-  let mod_name = Utils.file_path_to_mod_name fname in
   let file =
-    let extensionless = Misc.chop_extension_if_any fname = fname in
-    if extensionless then Preferences.ml mod_name else
-    if Filename.check_suffix fname "i" then File.MLI mod_name else File.ML mod_name
+    match File.of_filename fname with
+    | Some file -> file
+    | None -> (* no extension? we have to decide. *)
+      Preferences.src fname
   in
   let filename = File.name file in
   let initial_path =

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -805,6 +805,7 @@ let inspect_context browse lid pos : Context.t option =
     | Module_binding_name _
     | Module_declaration_name _ ->
       None
+    | Module_expr _
     | Open_description _ -> Some Module_path
     | Module_type _ -> Some Module_type
     | Core_type _ -> Some Type

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -32,9 +32,11 @@ let loadpath     = ref []
 
 let last_location = ref Location.none
 
-let log title msg = Logger.log "track_definition" title msg
-let logf title fmt = Logger.logf "track_definition" title fmt
-let logfmt title fmt = Logger.logfmt "track_definition" title fmt
+let log_section = "locate"
+
+let log title msg = Logger.log log_section title msg
+let logf title fmt = Logger.logf log_section title fmt
+let logfmt title fmt = Logger.logfmt log_section title fmt
 
 let erase_loadpath ~cwd ~new_path k =
   let str_path_list =
@@ -411,7 +413,7 @@ and browse_cmts ~config ~root modules =
       "erased" loadpath, it could mean that we are looking for a persistent
       unit, and that's why we restore the initial loadpath. *)
 and from_path ~config path =
-  log "from_path '%s'" (Typedtrie.path_to_string path) ;
+  log "from_path" (Typedtrie.path_to_string path) ;
   match path with
   | [ fname, `Mod ] ->
     let save_digest_and_return root =
@@ -517,8 +519,7 @@ let find_source ~config loc =
   | [ x ] -> Some x
   | files ->
     logf (sprintf "find_source(%s)" filename)
-      "multiple matches in the source path (%s) : %s"
-      (String.concat ~sep:", " @@ Mconfig.source_path config)
+      "multiple matches in the source path : %s"
       (String.concat ~sep:" , " files);
     try
       match File_switching.source_digest () with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -399,11 +399,6 @@ let rec locate ~config ?pos path trie : locate_result =
       logfmt "locate (typedtrie dump)" (fun fmt -> Typedtrie.dump fmt trie);
       Other_error (* incorrect path *)
     end
-  | Typedtrie.Alias_of (loc, new_path) ->
-    logf "locate" "alias of %s" (Namespaced_path.to_string new_path) ;
-    (* TODO: maybe give the option to NOT follow module aliases? *)
-    Fallback.set loc;
-    locate ~config ~pos:loc.Location.loc_start new_path trie
 
 and from_path ~config path : locate_result =
   log "from_path" (Namespaced_path.to_string path) ;

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -384,14 +384,14 @@ type locate_result =
   | File_not_found of File.t
   | Other_error (* FIXME *)
 
-let rec locate ~config ~state ?pos path trie : locate_result =
-  match Typedtrie.find ~remember_loc:Fallback.set ?before:pos ~state trie path with
+let rec locate ~config ~context path trie : locate_result =
+  match Typedtrie.find ~remember_loc:Fallback.set ~context trie path with
   | Typedtrie.Found (loc, doc_opt) -> Found (loc, doc_opt)
   | Typedtrie.Resolves_to (new_path, state) ->
     begin match Namespaced_path.head_exn new_path with
     | Ident (_, `Mod) ->
       logf "locate" "resolves to %s" (Namespaced_path.to_unique_string new_path);
-      from_path ~config ~state new_path
+      from_path ~config ~context:(Typedtrie.Resume state) new_path
     | _ ->
       logf "locate" "new path (%s) is not a real path"
         (Namespaced_path.to_unique_string new_path);
@@ -399,7 +399,7 @@ let rec locate ~config ~state ?pos path trie : locate_result =
       Other_error (* incorrect path *)
     end
 
-and from_path ~config ~state path : locate_result =
+and from_path ~config ~context path : locate_result =
   log "from_path" (Namespaced_path.to_unique_string path) ;
   match Namespaced_path.head_exn path with
   | Ident (fname, `Mod) ->
@@ -415,7 +415,7 @@ and from_path ~config ~state path : locate_result =
         log "from_path" "Saw packed module => erasing loadpath" ;
         erase_loadpath ~cwd:(Filename.dirname cmt_file)
           ~new_path:cmt_infos.cmt_loadpath
-          (fun () -> from_path ~state ~config path)
+          (fun () -> from_path ~context ~config path)
       | Some trie, None ->
         (* We found the module we were looking for, we can stop here. *)
         let pos_fname =
@@ -428,7 +428,7 @@ and from_path ~config ~state path : locate_result =
         (* TODO: retrieve "ocaml.text" floating attributes? *)
         Found (loc, None)
       | Some trie, Some _ ->
-        locate ~config ~state path trie
+        locate ~config ~context path trie
     in
     begin match Utils.find_file ~config ~with_fallback:true file with
     | Some cmt_file -> browse_cmt cmt_file
@@ -700,7 +700,7 @@ let locate ~config ~ml_or_mli ~path ~lazy_trie ~pos ~str_ident loc =
   try
     if not (Utils.is_ghost_loc loc) then Fallback.set loc;
     let lazy trie = lazy_trie in
-    match locate ~config ~pos ~state:Typedtrie.clean_state path trie with
+    match locate ~config ~context:(Initial pos) path trie with
     | Found (loc, doc) -> `Found (loc, doc)
     | Other_error when Fallback.is_set () -> recover str_ident
     | Other_error -> `Not_found (str_ident, File_switching.where_am_i ())

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -48,7 +48,8 @@ val get_doc
   -> local_defs:Mtyper.typedtree
   -> comments:(string * Location.t) list
   -> pos:Lexing.position
-  -> [ `User_input of string | `Completion_entry of (Cmt_cache.namespace * Path.t * Location.t) ]
+  -> [ `User_input of string
+     | `Completion_entry of (Namespaced_path.Namespace.t * Path.t * Location.t) ]
   -> [> `File_not_found of string
       | `Found of string
       | `Builtin of string

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -26,6 +26,8 @@
 
 )* }}} *)
 
+val log_section : string
+
 val from_string
   :  config:Mconfig.t
   -> env:Env.t

--- a/src/analysis/namespaced_path.ml
+++ b/src/analysis/namespaced_path.ml
@@ -1,0 +1,109 @@
+open Std
+
+module Namespace = struct
+  type t = [
+    | `Vals
+    | `Type
+    | `Constr
+    | `Mod
+    | `Modtype
+    | `Functor
+    | `Labels
+    | `Unknown
+    | `Apply
+  ]
+
+  let to_tag_string = function
+    | `Mod -> ""
+    | `Functor -> "[functor]"
+    | `Labels -> "[label]"
+    | `Constr -> "[cstr]"
+    | `Type -> "[type]"
+    | `Vals -> "[val]"
+    | `Modtype -> "[Mty]"
+    | `Unknown -> "[?]"
+    | `Apply -> "[functor application]"
+
+  let to_string = function
+    | `Mod -> "(module) "
+    | `Functor -> "(functor)"
+    | `Labels -> "(label) "
+    | `Constr -> "(constructor) "
+    | `Type -> "(type) "
+    | `Vals -> "(value) "
+    | `Modtype -> "(module type) "
+    | `Unknown -> "(unknown)"
+    | `Apply -> "(functor application)"
+end
+
+module Ident = struct
+  type t =
+    | Id of Ident.t
+    | String of string
+
+  let name = function
+    | Id id -> Ident.name id
+    | String s -> s
+
+  let equal mi1 mi2 =
+    match mi1, mi2 with
+    | Id i1, Id i2 -> Ident.equal i1 i2
+    | Id i, String s
+    | String s, Id i -> (Ident.name i) = s
+    | String s1, String s2 -> s1 = s2
+end
+
+type t =
+  | TPident of Ident.t * Namespace.t
+  | TPdot of t * string * Namespace.t
+  | TPapply of t * t
+(* type path = (string * namespace) list *)
+
+let rec to_string = function
+  | TPident (id, ns) -> Ident.name id ^ Namespace.to_tag_string ns
+  | TPdot (p, s, ns) -> to_string p ^ "." ^ s ^ Namespace.to_tag_string ns
+  | TPapply (p1, p2) -> to_string p1 ^ "(" ^ to_string p2 ^ ")"
+
+let rec head = function
+  | TPident (id, ns) -> id, ns
+  | TPdot(p, _, _) -> head p
+  | TPapply _ -> assert false
+
+let rec peal_head_exn = function
+  | TPident _ -> invalid_arg "peal_head_exn"
+  | TPdot(TPident _, s, ns) -> TPident (String s, ns)
+  | TPdot(p, s, ns) -> TPdot(peal_head_exn p, s, ns)
+  | TPapply (TPident _, _) -> invalid_arg "peal_head_exn"
+  | TPapply (p1, p2) -> TPapply (peal_head_exn p1, p2)
+
+let peal_head p =
+  try Some (peal_head_exn p)
+  with Invalid_argument _ -> None
+
+let rec equal p1 p2 =
+  match p1, p2 with
+  | TPident (i1, ns1), TPident (i2, ns2) ->
+    Ident.equal i1 i2 && ns1 = ns2
+  | TPdot(p1, s1, ns1), TPdot(p2, s2, ns2) ->
+    s1 = s2 && ns1 = ns2 && equal p1 p2
+  | TPapply(p11, p21), TPapply(p12, p22) ->
+    equal p11 p12 && equal p21 p22
+  | _, _ -> false
+
+let rec rewrite_path ~new_prefix = function
+  | TPident (id, ns) -> TPdot(new_prefix, Ident.name id, ns)
+  | TPdot(p, s, ns) -> TPdot (rewrite_path ~new_prefix p, s, ns)
+  | TPapply (p1, p2) -> TPapply (rewrite_path ~new_prefix p1, p2)
+
+let of_path ~namespace =
+  let rec aux ns =
+    let open Path in
+    function
+    | Pident id -> TPident (Id id, ns)
+    | Pdot (p, str, _) ->
+      (* FIXME: not always `Mod *)
+      TPdot (aux `Mod p, str, ns)
+    | Papply (p1, p2) ->
+      TPapply (aux `Mod p1, aux `Mod p2)
+  in
+  aux namespace

--- a/src/analysis/namespaced_path.ml
+++ b/src/analysis/namespaced_path.ml
@@ -124,3 +124,10 @@ let strip_stamps =
   )
 
 let empty = []
+
+let rec subst_prefix ~old_prefix ~new_prefix p =
+  match old_prefix, p with
+  | [], _ -> Some (new_prefix @ p)
+  | op1 :: ops, elt1 :: p when equal_elt op1 elt1 ->
+    subst_prefix ~old_prefix:ops ~new_prefix p
+  | _ -> None

--- a/src/analysis/namespaced_path.mli
+++ b/src/analysis/namespaced_path.mli
@@ -1,0 +1,42 @@
+module Namespace : sig
+  type t = [
+    | `Vals
+    | `Type
+    | `Constr
+    | `Mod
+    | `Modtype
+    | `Functor
+    | `Labels
+    | `Unknown
+    | `Apply
+  ]
+
+  val to_string : t -> string
+end
+
+module Ident : sig
+  type t = private
+    | Id of Ident.t
+    | String of string
+
+  val name : t -> string
+end
+
+type t = private
+  | TPident of Ident.t * Namespace.t
+  | TPdot of t * string * Namespace.t
+  | TPapply of t * t
+
+val to_string : t -> string
+
+val head : t -> Ident.t * Namespace.t
+
+val peal_head : t -> t option
+
+val peal_head_exn : t -> t
+
+val equal : t -> t -> bool
+
+val rewrite_path : new_prefix:t -> t -> t
+
+val of_path : namespace:Namespace.t -> Path.t -> t

--- a/src/analysis/namespaced_path.mli
+++ b/src/analysis/namespaced_path.mli
@@ -45,3 +45,5 @@ val strip_stamps : t -> t
 val of_path : namespace:Namespace.t -> Path.t -> t
 
 val empty : t
+
+val subst_prefix : old_prefix:t -> new_prefix:t -> t -> t option

--- a/src/analysis/namespaced_path.mli
+++ b/src/analysis/namespaced_path.mli
@@ -14,7 +14,7 @@ module Namespace : sig
   val to_string : t -> string
 end
 
-module Ident : sig
+module Id : sig
   type t = private
     | Id of Ident.t
     | String of string
@@ -22,21 +22,26 @@ module Ident : sig
   val name : t -> string
 end
 
-type t = private
-  | TPident of Ident.t * Namespace.t
-  | TPdot of t * string * Namespace.t
-  | TPapply of t * t
+type t (* = private elt list *)
+and elt = private
+  | Ident of Id.t * Namespace.t
+  | Applied_to of t
 
 val to_string : t -> string
+val to_unique_string : t -> string
 
-val head : t -> Ident.t * Namespace.t
+val head : t -> elt option
+val head_exn : t -> elt
 
 val peal_head : t -> t option
-
 val peal_head_exn : t -> t
 
 val equal : t -> t -> bool
 
-val rewrite_path : new_prefix:t -> t -> t
+val rewrite_head : new_prefix:t -> t -> t
+
+val strip_stamps : t -> t
 
 val of_path : namespace:Namespace.t -> Path.t -> t
+
+val empty : t

--- a/src/analysis/typedtrie.ml
+++ b/src/analysis/typedtrie.ml
@@ -30,7 +30,19 @@ open Std
 open Browse_tree
 open Browse_raw
 
-open Cmt_cache
+type t = elt list Ident.tbl
+and elt = {
+  loc : Location.t;
+  doc : string option;
+  namespace : Namespaced_path.Namespace.t;
+  node : node;
+}
+and node =
+   | Leaf
+   | Internal of t
+   | Included of Namespaced_path.t
+   | Alias    of Namespaced_path.t
+
 module Trie = struct
   let empty = Ident.empty
 
@@ -54,52 +66,30 @@ module Trie = struct
 
   let iter f t = Ident.iter f t
 
-  let get k t =
+  let get (k : Namespaced_path.Ident.t) t =
     match k with
     | Id k -> Ident.find_same k t
     | String s -> snd (Ident.find_name s t) (* FIXME: find_name returns a pair only since 4.06 *)
 
-  exception Found of Ident.t * Location.t * string option * namespace * node
+  exception Found of Ident.t * elt
 
-  let find f t =
+  let find f (t : t) =
     try
       iter (fun key data ->
-        List.iter data ~f:(fun (l, doc, ns, node) ->
-          if f key l doc ns node then
-            raise (Found (key, l, doc, ns, node))
+        List.iter data ~f:(fun data ->
+          if f key data then
+            raise (Found (key, data))
         )
       ) t;
       raise Not_found
     with
-    | Found (k, l, d, n, v) -> (k, l, d, n, v)
+    | Found (key, data) -> key, data
 
   let find_some f t =
     try Some (find f t)
     with Not_found -> None
 end
 
-let idname = function
-  | Id id -> Ident.name id
-  | String s -> s
-
-let path_to_string (p : tagged_path) =
-  let ns_to_string = function
-    | `Mod -> ""
-    | `Functor -> "[functor]"
-    | `Labels -> "[label]"
-    | `Constr -> "[cstr]"
-    | `Type -> "[type]"
-    | `Vals -> "[val]"
-    | `Modtype -> "[Mty]"
-    | `Unknown -> "[?]"
-    | `Apply -> "[functor application]"
-  in
-  let rec name = function
-    | TPident (id, ns) -> idname id ^ ns_to_string ns
-    | TPdot (p, s, ns) -> name p ^ "." ^ s ^ ns_to_string ns
-    | TPapply (p1, p2) -> name p1 ^ "(" ^ name p2 ^ ")"
-  in
-  name p
 
 let extract_doc (attrs : Parsetree.attributes) =
   String.concat ~sep:"\n" (
@@ -108,13 +98,11 @@ let extract_doc (attrs : Parsetree.attributes) =
     )
   )
 
-type t = trie
-
 (* See mli for documentation. *)
 type result =
   | Found of Location.t * string option
-  | Alias_of of Location.t * tagged_path
-  | Resolves_to of tagged_path * Location.t option
+  | Alias_of of Location.t * Namespaced_path.t
+  | Resolves_to of Namespaced_path.t * Location.t option
 
 let rec remove_top_indir =
   List.concat_map ~f:(fun bt ->
@@ -190,23 +178,10 @@ let rec pattern_idlocs pat =
   | Tpat_variant (_, Some pat, _) -> pattern_idlocs pat
   | _ -> []
 
-let tag_path ~namespace =
-  let rec aux ns =
-    let open Path in
-    function
-    | Pident id -> TPident (Id id, ns)
-    | Pdot (p, str, _) ->
-      (* FIXME: not always `Mod *)
-      TPdot (aux `Mod p, str, ns)
-    | Papply (p1, p2) ->
-      TPapply (aux `Mod p1, aux `Mod p2)
-  in
-  aux namespace
-
 let rec build ?(local_buffer=false) ~trie browses =
   let rec node_for_direct_mod namespace = function
-    | `Alias path -> Alias (tag_path ~namespace path)
-    | `Ident path -> Alias (tag_path ~namespace:`Modtype path)
+    | `Alias path -> Alias (Namespaced_path.of_path ~namespace path)
+    | `Ident path -> Alias (Namespaced_path.of_path ~namespace:`Modtype path)
     | `Str s ->
       Internal (build ~local_buffer ~trie:Trie.empty [of_structure s])
     | `Sg s ->
@@ -214,7 +189,7 @@ let rec build ?(local_buffer=false) ~trie browses =
     | `Mod_expr me -> node_for_direct_mod `Mod (remove_indir_me me)
     | `Mod_type mty -> node_for_direct_mod `Modtype (remove_indir_mty mty)
     | `Functor (id, floc, pack_loc, packed) when local_buffer ->
-      let arg_node = [ floc, None, namespace, Leaf ] in
+      let arg_node = [{ loc = floc; doc = None; namespace; node = Leaf }] in
       let trie =
         begin match node_for_direct_mod `Mod packed with
         | Internal t ->
@@ -228,8 +203,14 @@ let rec build ?(local_buffer=false) ~trie browses =
       let node2 = node_for_direct_mod `Mod (remove_indir_me me2) in
       let trie  =
         Trie.of_list [
-          Ident.create "1", [ me1.Typedtree.mod_loc, None, `Mod, node1 ];
-          Ident.create "2", [ me2.Typedtree.mod_loc, None, `Mod, node2 ];
+          Ident.create "1", [
+            { loc = me1.Typedtree.mod_loc; doc = None; namespace = `Mod
+            ; node = node1 }
+          ];
+          Ident.create "2", [
+            { loc = me2.Typedtree.mod_loc; doc = None; namespace = `Mod
+            ; node = node2 }
+          ];
         ]
       in
       Internal trie
@@ -258,7 +239,7 @@ let rec build ?(local_buffer=false) ~trie browses =
             (remove_indir_me mb.Typedtree.mb_expr)
         in
         Trie.add_multiple mb.Typedtree.mb_id
-          (t.t_loc, doc, `Mod, node) trie
+          {loc = t.t_loc; doc; namespace = `Mod; node} trie
       (* Ignore patterns. *)
       | _ -> trie
     in
@@ -287,10 +268,10 @@ let rec build ?(local_buffer=false) ~trie browses =
       | `Not_included -> build ~local_buffer ~trie (Lazy.force t.t_children)
       | `Included (included_idents, packed) ->
         let rec helper packed =
-          let f data =
+          let f node =
             List.fold_left included_idents ~init:trie ~f:(fun trie (id, ns) ->
-              let data = (t.t_loc, None, ns, data) in
-              Trie.add_multiple id data trie
+              let node = { loc = t.t_loc; doc = None; namespace = ns; node } in
+              Trie.add_multiple id node trie
             )
           in
           match
@@ -304,10 +285,10 @@ let rec build ?(local_buffer=false) ~trie browses =
               | `Mod_expr _ -> `Mod
               | `Mod_type _ -> `Modtype
             in
-            let p = tag_path ~namespace path in
+            let p = Namespaced_path.of_path ~namespace path in
             f (Included p)
           | `Ident p ->
-            let p = tag_path ~namespace:`Modtype p in
+            let p = Namespaced_path.of_path ~namespace:`Modtype p in
             f (Included p)
           | `Mod_type _
           | `Mod_expr _ as packed -> helper packed
@@ -330,39 +311,46 @@ let rec build ?(local_buffer=false) ~trie browses =
         List.fold_left idlocs ~init:trie ~f:(fun trie (id, loc) ->
           if local_buffer then
             let children = collect_local_modules Trie.empty t.t_children in
-            if Trie.is_empty children then
-              Trie.add_multiple id (t.t_loc, doc, `Vals, Leaf) trie
-            else
-              Trie.add_multiple id (t.t_loc, doc, `Vals, Internal children) trie
+            let node =
+              if Trie.is_empty children
+              then Leaf
+              else Internal children
+            in
+            let elt = { loc = t.t_loc; doc; namespace = `Vals; node } in
+            Trie.add_multiple id elt trie
           else
-            Trie.add_multiple id (loc, doc, `Vals, Leaf) trie
+            let elt = { loc = loc; doc; namespace = `Vals; node = Leaf } in
+            Trie.add_multiple id elt trie
         )
       end
     | Value_description vd ->
-      Trie.add_multiple vd.val_id (t.t_loc, doc, `Vals, Leaf) trie
+      Trie.add_multiple vd.val_id
+        { loc = t.t_loc; doc; namespace = `Vals; node = Leaf } trie
     | Module_binding mb ->
       let node =
         node_for_direct_mod `Mod
           (remove_indir_me mb.mb_expr)
       in
-      Trie.add_multiple mb.mb_id (t.t_loc, doc, `Mod, node) trie
+      Trie.add_multiple mb.mb_id { loc=t.t_loc; doc; namespace=`Mod; node } trie
     | Module_declaration md ->
       let node =
         node_for_direct_mod `Mod
           (remove_indir_mty md.md_type)
       in
-      Trie.add_multiple md.md_id (t.t_loc, doc, `Mod, node) trie
+      Trie.add_multiple md.md_id { loc=t.t_loc; doc; namespace=`Mod; node } trie
     | Module_type_declaration mtd ->
       let node =
         match mtd.mtd_type with
          None -> Leaf
         | Some m -> node_for_direct_mod `Modtype (remove_indir_mty m)
       in
-      Trie.add_multiple mtd.mtd_id (t.t_loc, doc, `Modtype, node) trie
+      Trie.add_multiple mtd.mtd_id
+        { loc=t.t_loc; doc; namespace=`Modtype; node } trie
     | Type_declaration td ->
       (* TODO: add constructors and labels as well.
          Because why the hell not. *)
-      Trie.add_multiple td.typ_id (t.t_loc, doc, `Type, Leaf) trie
+      Trie.add_multiple td.typ_id
+        { loc = t.t_loc; doc; namespace = `Type; node = Leaf } trie
     | Type_extension _ ->
       (* TODO: add constructors and labels as well.
          Because why the hell not. *)
@@ -376,98 +364,60 @@ let rec build ?(local_buffer=false) ~trie browses =
 
 let of_browses = build ~trie:Trie.empty
 
-let rec path_head = function
-  | TPident (id, ns) -> id, ns
-  | TPdot(p, _, _) -> path_head p
-  | TPapply _ -> assert false
-
-let rec peal_head = function
-  | TPident _ -> assert false
-  | TPdot(TPident _, s, ns) -> TPident (String s, ns)
-  | TPdot(p, s, ns) -> TPdot(peal_head p, s, ns)
-  | TPapply (TPident _, _) -> assert false
-  | TPapply (p1, p2) -> TPapply (peal_head p1, p2)
-
-let path_equal p1 p2 =
-  let maybe_ident_equal mi1 mi2 =
-    match mi1, mi2 with
-    | Id i1, Id i2 -> Ident.equal i1 i2
-    | Id i, String s
-    | String s, Id i -> (Ident.name i) = s
-    | String s1, String s2 -> s1 = s2
-  in
-  let rec aux p1 p2 =
-    match p1, p2 with
-    | TPident (i1, ns1), TPident (i2, ns2) ->
-      maybe_ident_equal i1 i2 && ns1 = ns2
-    | TPdot(p1, s1, ns1), TPdot(p2, s2, ns2) ->
-      s1 = s2 && ns1 = ns2 && aux p1 p2
-    | TPapply(p11, p21), TPapply(p12, p22) ->
-      aux p11 p12 && aux p21 p22
-    | _, _ -> false
-  in
-  aux p1 p2
-
-let rec rewrite_path ~new_prefix = function
-  | TPident (s, ns) -> TPdot(new_prefix, idname s, ns)
-  | TPdot(p, s, ns) -> TPdot (rewrite_path ~new_prefix p, s, ns)
-  | TPapply (p1, p2) -> TPapply (rewrite_path ~new_prefix p1, p2)
-
-
 let rec follow ?before trie path =
-  let (x, namespace) = path_head path in
+  let (x, namespace) = Namespaced_path.head path in
   try
     let lst = Trie.get x trie in
     let lst =
-      List.filter lst ~f:(fun (_, _, ns, _) -> ns = namespace || ns = `Unknown)
+      List.filter lst ~f:(fun { namespace = ns } -> ns = namespace || ns = `Unknown)
     in
     let lst =
       match before with
       | None -> lst
       | Some before ->
-        List.filter lst ~f:(fun (l1, _, _, _) ->
-          Lexing.compare_pos l1.Location.loc_start before < 0)
+        List.filter lst ~f:(fun { loc } ->
+          Lexing.compare_pos loc.Location.loc_start before < 0)
     in
     match
-      List.sort lst ~cmp:(fun (l1, _, _, _) (l2, _, _, _) ->
+      List.sort lst ~cmp:(fun { loc = l1 } { loc = l2 } ->
         (* We wants the ones closed last to be at the beginning of the list. *)
         Lexing.compare_pos l2.Location.loc_end l1.Location.loc_end)
     with
     | [] -> Resolves_to (path, None)
-    | (loc, doc, _, Leaf) :: _ ->
+    | {loc; doc; node = Leaf} :: _ ->
       (* we're not checking whether [xs = []] here, as we wouldn't be able to
          lookup anything else which would be correct I think.
          [xs] can be non-nil in this case when [x] is a first class module.
          ... and perhaps in other situations I am not aware of.  *)
       Found (loc, doc)
-    | (loc, _, _, Alias new_prefix) :: _ ->
-      begin match path with
-      | TPident _ ->
+    | {loc; node = Alias new_prefix} :: _ ->
+      begin match Namespaced_path.peal_head path with
+      | None ->
         (* FIXME: at this point, we might be deep in the trie, and [path]
            might only make sense for a few steps, but in the upper nodes it
            might need to be prefixed.
            We need to recurse like we do for [Resolves_to] *)
         Alias_of (loc, new_prefix)
-      | _ ->
-        let new_path = rewrite_path ~new_prefix (peal_head path) in
+      | Some path ->
+        let new_path = Namespaced_path.rewrite_path ~new_prefix path in
         begin match follow ~before:loc.Location.loc_start trie new_path with
         | Resolves_to (p, None) -> Resolves_to (p, Some loc)
         | otherwise -> otherwise
         end
       end
-    | (loc, _, _, Included new_prefix) :: _ ->
-      let new_path = rewrite_path ~new_prefix path in
+    | { loc; node = Included new_prefix} :: _ ->
+      let new_path = Namespaced_path.rewrite_path ~new_prefix path in
       begin match follow ~before:loc.Location.loc_start trie new_path with
       | Resolves_to (p, None) -> Resolves_to (p, Some loc)
       | otherwise -> otherwise
       end
-    | (l, doc, _, Internal t) :: _ ->
+    | { loc = l; doc; node = Internal t } :: _ ->
       begin match path with
       | TPident _ -> Found (l, doc)
       | _ ->
-        let xs = peal_head path in
+        let xs = Namespaced_path.peal_head_exn path in
         match follow ?before t xs with
-        | Resolves_to (p, None) when path_equal p xs -> Found (l, doc) (* questionable *)
+        | Resolves_to (p, None) when Namespaced_path.equal p xs -> Found (l, doc) (* questionable *)
         | Resolves_to (p, x) as checkpoint ->
           begin match follow ~before:l.Location.loc_start trie p with
           (* This feels wrong *)
@@ -480,27 +430,14 @@ let rec follow ?before trie path =
   | Not_found ->
     Resolves_to (path, None)
 
-let dump_namespace fmt (namespace : namespace) =
-  Format.pp_print_string fmt
-    (match namespace with
-     | `Mod -> "(Mod) "
-     | `Functor -> "(functor)"
-     | `Labels -> "(lbl) "
-     | `Constr -> "(cstr) "
-     | `Type -> "(typ) "
-     | `Vals -> "(val) "
-     | `Modtype -> "(Mty) "
-     | `Unknown -> "(?)"
-     | `Apply -> "(functor application)")
-
 let rec find ~before trie path =
   match
-    Trie.find_some (fun _name loc _docopt _namespace _node ->
+    Trie.find_some (fun _name { loc; _ } ->
       Lexing.compare_pos loc.Location.loc_start before < 0
       && Lexing.compare_pos loc.Location.loc_end before > 0
     ) trie
   with
-  | Some (_name, loc, _docopt, _namespace, Internal subtrie) ->
+  | Some (_name, { loc; node = Internal subtrie }) ->
     begin match find ~before subtrie path with
     | Resolves_to (p, x) as checkpoint ->
       begin match follow ~before:loc.Location.loc_start trie p with
@@ -509,7 +446,7 @@ let rec find ~before trie path =
       end
     | otherwise -> otherwise
     end
-  | Some (name, loc, _docopt, _namespace, _) ->
+  | Some (name, { loc }) ->
     Logger.log "locate" "Typedtrie.find"
       "cursor is in a leaf, so we look only before the leaf" ;
     follow ~before:loc.Location.loc_start trie path
@@ -521,16 +458,16 @@ let find ?before trie path =
   | Some before -> find ~before trie path
 
 let rec dump fmt trie =
-  let dump_node (loc, _doc_opt, namespace, node) =
-    dump_namespace fmt namespace;
+  let dump_node {loc; namespace; node} =
+    Format.pp_print_string fmt (Namespaced_path.Namespace.to_string namespace);
     match node with
     | Leaf -> Location.print_loc fmt loc
     | Included path ->
       Format.fprintf fmt "%a <%s>" Location.print_loc loc
-        (path_to_string path)
+        (Namespaced_path.to_string path)
     | Alias path ->
       Format.fprintf fmt "%a = %s" Location.print_loc loc
-        (path_to_string path)
+        (Namespaced_path.to_string path)
     | Internal t ->
       Format.fprintf fmt "%a = %a" Location.print_loc loc dump t
   in

--- a/src/analysis/typedtrie.ml
+++ b/src/analysis/typedtrie.ml
@@ -147,7 +147,6 @@ let extract_doc (attrs : Parsetree.attributes) =
 (* See mli for documentation. *)
 type result =
   | Found of Location.t * string option
-  | Alias_of of Location.t * Namespaced_path.t
   | Resolves_to of Namespaced_path.t * Location.t option
 
 let rec remove_top_indir =
@@ -416,12 +415,7 @@ let rec follow ?before trie path =
         Found (loc, doc)
       | Alias new_prefix ->
         begin match Namespaced_path.peal_head path with
-        | None ->
-          (* FIXME: at this point, we might be deep in the trie, and [path]
-             might only make sense for a few steps, but in the upper nodes it
-             might need to be prefixed.
-             We need to recurse like we do for [Resolves_to] *)
-          Alias_of (loc, new_prefix)
+        | None -> Found (loc, doc)
         | Some path ->
           let new_path = Namespaced_path.rewrite_path ~new_prefix path in
           begin match follow ~before:loc.Location.loc_start trie new_path with

--- a/src/analysis/typedtrie.ml
+++ b/src/analysis/typedtrie.ml
@@ -362,11 +362,14 @@ let rec build ~local_buffer ~trie browses : t =
          Because why the hell not. *)
       Trie.add td.typ_id
         { loc = t.t_loc; doc; namespace = `Type; node = Leaf } trie
-    | Type_extension _ ->
-      (* TODO: add constructors and labels as well.
-         Because why the hell not. *)
-(*       Trie.add_multiple (Path.last te.tyext_path) (t.t_loc, doc, `Type, Leaf) trie *)
-      trie
+    | Type_extension te ->
+      List.fold_left ~init:trie ~f:(fun trie ec ->
+        Trie.add ec.ext_id
+          { loc = t.t_loc; doc; namespace = `Type; node = Leaf } trie
+      ) te.tyext_constructors
+    | Extension_constructor ec ->
+      Trie.add ec.ext_id
+        { loc = t.t_loc; doc; namespace = `Type; node = Leaf } trie
     | Case _
     | Expression _ when local_buffer ->
       build ~local_buffer ~trie (Lazy.force t.t_children)

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -44,18 +44,23 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
 type result =
   | Found of Location.t * string option
     (** Found at location *)
-  | Resolves_to of Namespaced_path.t * Location.t option
-    (** Not found in trie, look for [path] in loadpath.
-        If the second parameter is [Some] it means we encountered an include or
-        module alias at some point, so we can always fallback there if we don't
-        find anything in the loadpath. *)
+  | Resolves_to of Namespaced_path.t
+    (** Not found in trie, look for [path] in loadpath. *)
 
-val find : ?before:Lexing.position -> t -> Namespaced_path.t -> result
+val find
+   : remember_loc:(Location.t -> unit)
+  -> ?before:Lexing.position
+  -> t
+  -> Namespaced_path.t
+  -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].
     If [follow] returns [Resolves_to (p, _)] it will go back up in the trie, and
     will try to [follow] again with [before] set to the the start of the node we
-    just got up from. *)
+    just got up from.
+
+    @param remember_loc is used to capture a trace of the indirections that we
+    traverse. *)
 
 (* For debugging purposes. *)
 val dump : Format.formatter -> t -> unit

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -43,7 +43,9 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
 
 type state
 
-val clean_state : state
+type context =
+  | Initial of Lexing.position
+  | Resume of state
 
 type result =
   | Found of Location.t * string option
@@ -53,10 +55,9 @@ type result =
 
 val find
    : remember_loc:(Location.t -> unit)
-  -> ?before:Lexing.position
+  -> context:context
   -> t
   -> Namespaced_path.t
-  -> state:state
   -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -41,10 +41,14 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
     [cursor] in this case, so we can't be inside an expression, or a functor, …
 *)
 
+type state
+
+val clean_state : state
+
 type result =
   | Found of Location.t * string option
     (** Found at location *)
-  | Resolves_to of Namespaced_path.t
+  | Resolves_to of Namespaced_path.t * state
     (** Not found in trie, look for [path] in loadpath. *)
 
 val find
@@ -52,6 +56,7 @@ val find
   -> ?before:Lexing.position
   -> t
   -> Namespaced_path.t
+  -> state:state
   -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -26,9 +26,7 @@
 
 )* }}} *)
 
-open Cmt_cache
-
-type t = trie
+type t
 
 val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
 (** Constructs a trie from a list of [BrowseT.t].
@@ -43,28 +41,18 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
     [cursor] in this case, so we can't be inside an expression, or a functor, …
 *)
 
-val tag_path : namespace:namespace -> Path.t -> tagged_path
-
-val path_to_string : tagged_path -> string
-
-val idname : maybe_ident -> string
-
-val peal_head : tagged_path -> tagged_path
-
-val path_head : tagged_path -> maybe_ident * namespace
-
 type result =
   | Found of Location.t * string option
     (** Found at location *)
-  | Alias_of of Location.t * tagged_path
+  | Alias_of of Location.t * Namespaced_path.t
     (** Alias of [path], introduced at [Location.t] *)
-  | Resolves_to of tagged_path * Location.t option
+  | Resolves_to of Namespaced_path.t * Location.t option
     (** Not found in trie, look for [path] in loadpath.
         If the second parameter is [Some] it means we encountered an include or
         module alias at some point, so we can always fallback there if we don't
         find anything in the loadpath. *)
 
-val find : ?before:Lexing.position -> t -> tagged_path -> result
+val find : ?before:Lexing.position -> t -> Namespaced_path.t -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].
     If [follow] returns [Resolves_to (p, _)] it will go back up in the trie, and

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -43,22 +43,28 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
     [cursor] in this case, so we can't be inside an expression, or a functor, …
 *)
 
-val tag_path : namespace:namespace -> Path.t -> path
+val tag_path : namespace:namespace -> Path.t -> tagged_path
 
-val path_to_string : path -> string
+val path_to_string : tagged_path -> string
+
+val idname : maybe_ident -> string
+
+val peal_head : tagged_path -> tagged_path
+
+val path_head : tagged_path -> maybe_ident * namespace
 
 type result =
   | Found of Location.t * string option
     (** Found at location *)
-  | Alias_of of Location.t * path
+  | Alias_of of Location.t * tagged_path
     (** Alias of [path], introduced at [Location.t] *)
-  | Resolves_to of path * Location.t option
+  | Resolves_to of tagged_path * Location.t option
     (** Not found in trie, look for [path] in loadpath.
         If the second parameter is [Some] it means we encountered an include or
         module alias at some point, so we can always fallback there if we don't
         find anything in the loadpath. *)
 
-val find : ?before:Lexing.position -> t -> path -> result
+val find : ?before:Lexing.position -> t -> tagged_path -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].
     If [follow] returns [Resolves_to (p, _)] it will go back up in the trie, and

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -58,10 +58,6 @@ type result =
         module alias at some point, so we can always fallback there if we don't
         find anything in the loadpath. *)
 
-val follow : ?before:Lexing.position -> t -> path -> result
-(** [follow ?before t path] will follow [path] in [t], using [before] to
-    select the right branch in presence of shadowing. *)
-
 val find : ?before:Lexing.position -> t -> path -> result
 (** [find ?before t path] starts by going down in [t] following branches
     enclosing [before]. Then it will behave as [follow ?before].

--- a/src/analysis/typedtrie.mli
+++ b/src/analysis/typedtrie.mli
@@ -44,8 +44,6 @@ val of_browses : ?local_buffer:bool -> Browse_tree.t list -> t
 type result =
   | Found of Location.t * string option
     (** Found at location *)
-  | Alias_of of Location.t * Namespaced_path.t
-    (** Alias of [path], introduced at [Location.t] *)
   | Resolves_to of Namespaced_path.t * Location.t option
     (** Not found in trie, look for [path] in loadpath.
         If the second parameter is [Some] it means we encountered an include or

--- a/src/kernel/mbrowse.mli
+++ b/src/kernel/mbrowse.mli
@@ -55,6 +55,8 @@ val of_typedtree :
   [ `Implementation of Typedtree.structure
   | `Interface of Typedtree.signature ] -> t
 
+val node_of_binary_part : Env.t -> Cmt_format.binary_part -> node
+
 (** Identify nodes introduced by recovery *)
 val is_recovered_expression : Typedtree.expression -> bool
 val is_recovered : Browse_raw.node -> bool

--- a/src/ocaml/support/cmt_cache.ml
+++ b/src/ocaml/support/cmt_cache.ml
@@ -39,14 +39,23 @@ type namespace = [
   | `Unknown
   | `Apply
 ]
-type path = (string * namespace) list
 
-type trie = (Location.t * string option * namespace * node) list String.Map.t
+type maybe_ident =
+  | Id of Ident.t
+  | String of string
+
+type tagged_path =
+  | TPident of maybe_ident * namespace
+  | TPdot of tagged_path * string * namespace
+  | TPapply of tagged_path * tagged_path
+(* type path = (string * namespace) list *)
+
+type trie = (Location.t * string option * namespace * node) list Ident.tbl
  and node =
    | Leaf
    | Internal of trie
-   | Included of path
-   | Alias    of path
+   | Included of tagged_path
+   | Alias    of tagged_path
 
 
 type cmt_item = {
@@ -59,7 +68,7 @@ include File_cache.Make (struct
 
   let read file = {
     cmt_infos = Cmt_format.read_cmt file ;
-    location_trie = String.Map.empty ;
+    location_trie = Ident.empty ;
   }
 
   let cache_name = "Cmt_cache"

--- a/src/ocaml/support/cmt_cache.ml
+++ b/src/ocaml/support/cmt_cache.ml
@@ -28,39 +28,10 @@
 
 open Std
 
-type namespace = [
-  | `Vals
-  | `Type
-  | `Constr
-  | `Mod
-  | `Modtype
-  | `Functor
-  | `Labels
-  | `Unknown
-  | `Apply
-]
-
-type maybe_ident =
-  | Id of Ident.t
-  | String of string
-
-type tagged_path =
-  | TPident of maybe_ident * namespace
-  | TPdot of tagged_path * string * namespace
-  | TPapply of tagged_path * tagged_path
-(* type path = (string * namespace) list *)
-
-type trie = (Location.t * string option * namespace * node) list Ident.tbl
- and node =
-   | Leaf
-   | Internal of trie
-   | Included of tagged_path
-   | Alias    of tagged_path
-
 
 type cmt_item = {
   cmt_infos : Cmt_format.cmt_infos ;
-  mutable location_trie : trie ;
+  mutable location_trie : Typedtrie.t option;
 }
 
 include File_cache.Make (struct
@@ -68,7 +39,7 @@ include File_cache.Make (struct
 
   let read file = {
     cmt_infos = Cmt_format.read_cmt file ;
-    location_trie = Ident.empty ;
+    location_trie = None;
   }
 
   let cache_name = "Cmt_cache"

--- a/src/ocaml/typer_402/typing/typedtree.ml
+++ b/src/ocaml/typer_402/typing/typedtree.ml
@@ -551,6 +551,8 @@ let rec bound_idents pat =
 let pat_bound_idents pat =
   idents := []; bound_idents pat; let res = !idents in idents := []; res
 
+let pat_bound_idents_with_loc = pat_bound_idents
+
 let rev_let_bound_idents_with_loc bindings =
   idents := [];
   List.iter (fun vb -> bound_idents vb.vb_pat) bindings;

--- a/src/ocaml/typer_402/typing/typedtree.mli
+++ b/src/ocaml/typer_402/typing/typedtree.mli
@@ -514,3 +514,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> (Ident.t * string Asttypes.loc) list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/src/ocaml/typer_403/typing/typedtree.ml
+++ b/src/ocaml/typer_403/typing/typedtree.ml
@@ -565,12 +565,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/src/ocaml/typer_403/typing/typedtree.mli
+++ b/src/ocaml/typer_403/typing/typedtree.mli
@@ -639,3 +639,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/src/ocaml/typer_404/typing/typedtree.ml
+++ b/src/ocaml/typer_404/typing/typedtree.ml
@@ -573,12 +573,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/src/ocaml/typer_404/typing/typedtree.mli
+++ b/src/ocaml/typer_404/typing/typedtree.mli
@@ -658,3 +658,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/src/ocaml/typer_405/typing/typedtree.ml
+++ b/src/ocaml/typer_405/typing/typedtree.ml
@@ -574,12 +574,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/src/ocaml/typer_405/typing/typedtree.mli
+++ b/src/ocaml/typer_405/typing/typedtree.mli
@@ -662,3 +662,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/src/ocaml/typer_406/typing/typedtree.ml
+++ b/src/ocaml/typer_406/typing/typedtree.ml
@@ -580,12 +580,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/src/ocaml/typer_406/typing/typedtree.mli
+++ b/src/ocaml/typer_406/typing/typedtree.mli
@@ -668,3 +668,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/src/ocaml/typer_407/typing/typedtree.ml
+++ b/src/ocaml/typer_407/typing/typedtree.ml
@@ -580,12 +580,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/src/ocaml/typer_407/typing/typedtree.mli
+++ b/src/ocaml/typer_407/typing/typedtree.mli
@@ -668,3 +668,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc : pattern -> (Ident.t * label loc) list

--- a/tests/locate/ambiguity/rebinding.t
+++ b/tests/locate/ambiguity/rebinding.t
@@ -7,7 +7,7 @@ Jumping to Z.foo before the rebinding of X:
       "file": "tests/locate/ambiguity/rebinding.ml",
       "pos": {
         "line": 4,
-        "col": 6
+        "col": 10
       }
     },
     "notifications": []
@@ -22,7 +22,7 @@ Jumping to Z.foo after the rebinding of X:
       "file": "tests/locate/ambiguity/rebinding.ml",
       "pos": {
         "line": 4,
-        "col": 6
+        "col": 10
       }
     },
     "notifications": []

--- a/tests/locate/ambiguity/rebinding.t
+++ b/tests/locate/ambiguity/rebinding.t
@@ -13,7 +13,7 @@ Jumping to Z.foo before the rebinding of X:
     "notifications": []
   }
 
-Jumping to Z.foo after the rebinding of X: (FIXME)
+Jumping to Z.foo after the rebinding of X:
 
   $ $MERLIN single locate -look-for ml -position 15:13 -filename ./rebinding.ml < ./rebinding.ml
   {
@@ -21,8 +21,8 @@ Jumping to Z.foo after the rebinding of X: (FIXME)
     "value": {
       "file": "tests/locate/ambiguity/rebinding.ml",
       "pos": {
-        "line": 2,
-        "col": 2
+        "line": 4,
+        "col": 6
       }
     },
     "notifications": []

--- a/tests/locate/context-detection/label.t
+++ b/tests/locate/context-detection/label.t
@@ -6,7 +6,7 @@
       "file": "tests/locate/context-detection/label.ml",
       "pos": {
         "line": 3,
-        "col": 0
+        "col": 4
       }
     },
     "notifications": []
@@ -19,7 +19,7 @@
       "file": "tests/locate/context-detection/label.ml",
       "pos": {
         "line": 8,
-        "col": 0
+        "col": 4
       }
     },
     "notifications": []

--- a/tests/locate/context-detection/test.t
+++ b/tests/locate/context-detection/test.t
@@ -159,16 +159,14 @@ FIXME this should jump to line 11:
     "notifications": []
   }
 
-FIXME this is ignoring the local record def and jumping to the toplevel def:
-
   $ $MERLIN single locate -look-for ml -position 24:3 -filename ./test.ml < ./test.ml
   {
     "class": "return",
     "value": {
       "file": "tests/locate/context-detection/test.ml",
       "pos": {
-        "line": 5,
-        "col": 0
+        "line": 23,
+        "col": 6
       }
     },
     "notifications": []

--- a/tests/locate/context-detection/test.t
+++ b/tests/locate/context-detection/test.t
@@ -50,7 +50,7 @@ FIXME this should say "Already at definition point" (we're defining the label):
       "file": "tests/locate/context-detection/test.ml",
       "pos": {
         "line": 5,
-        "col": 0
+        "col": 4
       }
     },
     "notifications": []
@@ -76,7 +76,7 @@ FIXME this should say "Already at definition point" (we're defining the label):
       "file": "tests/locate/context-detection/test.ml",
       "pos": {
         "line": 5,
-        "col": 0
+        "col": 4
       }
     },
     "notifications": []

--- a/tests/locate/context-detection/test.t
+++ b/tests/locate/context-detection/test.t
@@ -32,7 +32,7 @@ Trying them all:
     "value": {
       "file": "tests/locate/context-detection/test.ml",
       "pos": {
-        "line": 7,
+        "line": 3,
         "col": 0
       }
     },

--- a/tests/locate/context-detection/test.t
+++ b/tests/locate/context-detection/test.t
@@ -26,15 +26,13 @@ Trying them all:
     "notifications": []
   }
 
-In that one we apparently traverse the module type aliasing:
-
   $ $MERLIN single locate -look-for ml -position 9:12 -filename ./test.ml < ./test.ml
   {
     "class": "return",
     "value": {
       "file": "tests/locate/context-detection/test.ml",
       "pos": {
-        "line": 3,
+        "line": 7,
         "col": 0
       }
     },

--- a/tests/locate/functors/all_local.t
+++ b/tests/locate/functors/all_local.t
@@ -36,7 +36,7 @@ Check the argument is substituted for the parameter
     "value": {
       "file": "tests/locate/functors/all_local.ml",
       "pos": {
-        "line": 2,
+        "line": 6,
         "col": 2
       }
     },

--- a/tests/locate/functors/all_local.t
+++ b/tests/locate/functors/all_local.t
@@ -36,8 +36,8 @@ Check the argument is substituted for the parameter
     "value": {
       "file": "tests/locate/functors/all_local.ml",
       "pos": {
-        "line": 18,
-        "col": 0
+        "line": 2,
+        "col": 2
       }
     },
     "notifications": []

--- a/tests/locate/functors/from_application.t
+++ b/tests/locate/functors/from_application.t
@@ -7,7 +7,7 @@ FIXME: we confuse the module for the constructor and jump to the wrong place
     "value": {
       "file": "tests/locate/functors/from_application.ml",
       "pos": {
-        "line": 9,
+        "line": 5,
         "col": 0
       }
     },

--- a/tests/locate/functors/nested_applications.ml
+++ b/tests/locate/functors/nested_applications.ml
@@ -1,0 +1,33 @@
+module type S = sig
+  type t
+end
+
+module Identity(X : S) : S = X
+
+module Apply(Id : S -> S) = Id
+
+module Simple = struct
+  type t
+end
+
+module M1 = Identity(Identity(Simple))
+
+module M2 = Apply(Identity)(Simple)
+
+type t1 = M1.t
+
+type t2 = M2.t
+
+module Alternative_apply(Id : S -> S)(X : S) = struct include Id(X) end
+
+module M3 = Alternative_apply(Identity)(Simple)
+
+type t3 = M3.t
+
+module M4 = Alternative_apply(functor(X : S) -> X)(Simple)
+
+type t4 = M4.t
+
+module M5 = Identity((functor(X : S) -> X)(Simple))
+
+type t5 = M5.t

--- a/tests/locate/functors/nested_applications.t
+++ b/tests/locate/functors/nested_applications.t
@@ -1,0 +1,59 @@
+
+  $ $MERLIN single locate -look-for ml -position 17:14 \
+  > -filename ./nested_applications.ml < ./nested_applications.ml
+  {
+    "class": "return",
+    "value": "Needed cmt file of module 'X' to locate 'M1.t' but it is not present",
+    "notifications": []
+  }
+
+  $ $MERLIN single locate -look-for ml -position 19:14 \
+  > -filename ./nested_applications.ml < ./nested_applications.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/locate/functors/nested_applications.ml",
+      "pos": {
+        "line": 10,
+        "col": 2
+      }
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single locate -look-for ml -position 25:14 \
+  > -filename ./nested_applications.ml < ./nested_applications.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/locate/functors/nested_applications.ml",
+      "pos": {
+        "line": 21,
+        "col": 54
+      }
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single locate -look-for ml -position 29:14 \
+  > -filename ./nested_applications.ml < ./nested_applications.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/locate/functors/nested_applications.ml",
+      "pos": {
+        "line": 2,
+        "col": 2
+      }
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single locate -look-for ml -position 33:14 \
+  > -filename ./nested_applications.ml < ./nested_applications.ml
+  {
+    "class": "return",
+    "value": "Needed cmt file of module 'X' to locate 'M5.t' but it is not present",
+    "notifications": []
+  }
+

--- a/tests/locate/functors/nested_applications.t
+++ b/tests/locate/functors/nested_applications.t
@@ -3,7 +3,13 @@
   > -filename ./nested_applications.ml < ./nested_applications.ml
   {
     "class": "return",
-    "value": "Needed cmt file of module 'X' to locate 'M1.t' but it is not present",
+    "value": {
+      "file": "tests/locate/functors/nested_applications.ml",
+      "pos": {
+        "line": 5,
+        "col": 0
+      }
+    },
     "notifications": []
   }
 
@@ -53,7 +59,13 @@
   > -filename ./nested_applications.ml < ./nested_applications.ml
   {
     "class": "return",
-    "value": "Needed cmt file of module 'X' to locate 'M5.t' but it is not present",
+    "value": {
+      "file": "tests/locate/functors/nested_applications.ml",
+      "pos": {
+        "line": 5,
+        "col": 0
+      }
+    },
     "notifications": []
   }
 

--- a/tests/locate/issue802/a.ml
+++ b/tests/locate/issue802/a.ml
@@ -3,3 +3,5 @@ open Error
 let f () = raise MyError
 
 let g () = Constructor
+
+let c : ext = C1

--- a/tests/locate/issue802/error.ml
+++ b/tests/locate/issue802/error.ml
@@ -1,3 +1,7 @@
 type t = Constructor
 
 exception MyError
+
+type ext = ..
+
+type ext += C1

--- a/tests/locate/issue802/test.t
+++ b/tests/locate/issue802/test.t
@@ -19,18 +19,47 @@ Test jumping from a normal constructor:
     "notifications": []
   }
 
-And from an exception (FIXME):
+From an exception:
 
   $ $MERLIN single locate -look-for ml -position 3:21 -filename ./a.ml < ./a.ml
   {
     "class": "return",
     "value": {
-      "file": "tests/locate/issue802/mylib__.ml",
+      "file": "tests/locate/issue802/error.ml",
       "pos": {
-        "line": 2,
+        "line": 3,
         "col": 0
       }
     },
     "notifications": []
   }
 
+From an extension constructor:
+
+  $ $MERLIN single locate -look-for ml -position 7:16 -filename ./a.ml < ./a.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/locate/issue802/error.ml",
+      "pos": {
+        "line": 7,
+        "col": 12
+      }
+    },
+    "notifications": []
+  }
+
+And from the extensible type name itself:
+
+  $ $MERLIN single locate -look-for ml -position 7:10 -filename ./a.ml < ./a.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/locate/issue802/error.ml",
+      "pos": {
+        "line": 5,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }

--- a/tests/locate/local-definitions/issue806.t
+++ b/tests/locate/local-definitions/issue806.t
@@ -1,4 +1,3 @@
-FIXME
 
   $ $MERLIN single locate -look-for ml -position 5:3 -filename ./issue806.ml < ./issue806.ml
   {
@@ -6,8 +5,8 @@ FIXME
     "value": {
       "file": "tests/locate/local-definitions/issue806.ml",
       "pos": {
-        "line": 1,
-        "col": 0
+        "line": 4,
+        "col": 6
       }
     },
     "notifications": []

--- a/tests/locate/partial-cmt/test.t
+++ b/tests/locate/partial-cmt/test.t
@@ -45,10 +45,10 @@ That is: if the file is a.mli then the test is broken:
   {
     "class": "return",
     "value": {
-      "file": "tests/locate/partial-cmt/a.mli",
+      "file": "tests/locate/partial-cmt/a.ml",
       "pos": {
         "line": 1,
-        "col": 9
+        "col": 0
       }
     },
     "notifications": []


### PR DESCRIPTION
Notable changes:
- support for partial `.cmt[i]` files
- better context detection
- better tracking of namespaces (i.e. less confused about various kind of items having the same name)
- initial support for functor, e.g. in the following jumping from `Foo.t` on line 15 will bring the cursor to line 6.
  ```ocaml
  (*  1 *) module type S = sig
  (*  2 *)   type t
  (*  3 *) end
  (*  4 *) 
  (*  5 *) module M = struct
  (*  6 *)   type t = T
  (*  7 *) end
  (*  8 *) 
  (*  9 *) module Make(Arg : S) : S = struct
  (* 10 *)   include Arg
  (* 11 *) end
  (* 12 *) 
  (* 13 *) module Foo = Make(M)
  (* 14 *) 
  (* 15 *) type t = Foo.t
  ```
- fix handling of exceptions and extension constructors
- properly handle local bindings

This fixes a couple of open issues.

There are no regression on the tests in the `tests` directory. No guarantee about tests not present in that directory. :)