### PR TITLE
Add a dune-project file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name merlin)


### PR DESCRIPTION
Otherwise `opam pin add merlin --dev` fails with:

```
...
### output ###
# Error: There is no dune-project file in the current directory, please add one with a (name <name>) field in it.
# Hint: dune subst must be executed from the root of the project.
...
```