### PR TITLE
msvc: use correct preprocessor macro

### DIFF
--- a/src/frontend/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin.c
@@ -187,7 +187,7 @@ static void append_argument(unsigned char *buffer, size_t len, ssize_t *pos, con
   *pos = j;
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 extern __declspec(dllimport) char **environ;
 #else
 extern char **environ;

--- a/src/platform/os_ipc_stub.c
+++ b/src/platform/os_ipc_stub.c
@@ -29,7 +29,7 @@ typedef SSIZE_T ssize_t;
 #include <caml/alloc.h>
 #include <caml/threads.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 extern __declspec(dllimport) char **environ;
 #else
 extern char **environ;


### PR DESCRIPTION
This fixes compilation under `mingw64`. cc @dra27 