### PR TITLE
Ppx cwd

### DIFF
--- a/src/frontend/new/new_merlin.ml
+++ b/src/frontend/new/new_merlin.ml
@@ -75,9 +75,9 @@ let run = function
         let config, command_args =
           let fails = ref [] in
           let config, command_args =
-            Marg.parse_all ~warning:(fun fail -> fails := fail :: !fails)
-              Mconfig.arguments_table (List.map snd spec)
-              raw_args Mconfig.initial command_args
+            Mconfig.parse_arguments
+              ~wd:(Sys.getcwd ()) ~warning:(fun w -> fails := w :: !fails)
+              (List.map snd spec) raw_args Mconfig.initial command_args
           in
           let config =
             Mconfig.({config with merlin = {config.merlin with failures = !fails}})

--- a/src/frontend/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin_server.ml
@@ -12,13 +12,7 @@ module Server = struct
   let process_request {Os_ipc. wd; environ; argv; context = _}  =
     match Array.to_list argv with
     | "stop-server" :: _ -> raise Exit
-    | args ->
-      begin try Sys.chdir wd
-        with _ ->
-          Logger.logf "Ocamlmerlin_server" "Server.process_request"
-            "cannot change working directory to %S" wd
-      end;
-      New_merlin.run environ args
+    | args -> New_merlin.run environ (Some wd) args
 
   let process_client client =
     let context = client.Os_ipc.context in
@@ -79,7 +73,7 @@ let main () =
   (* Setup env for extensions *)
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
   match List.tl (Array.to_list Sys.argv) with
-  | "single" :: args -> exit (New_merlin.run "" args)
+  | "single" :: args -> exit (New_merlin.run "" None args)
   | "old-protocol" :: args -> Old_merlin.run args
   | ["server"; socket_path; socket_fd] -> Server.start socket_path socket_fd
   | ("-help" | "--help" | "-h" | "server") :: _ ->

--- a/src/frontend/old/old_command.ml
+++ b/src/frontend/old/old_command.ml
@@ -47,7 +47,7 @@ let customize config =
     let extensions = List.remove_all ext config.merlin.extensions in
     {config with merlin = {config.merlin with extensions}};
   | `Flags flags ->
-    let flags_to_apply = [{flag_cwd = None; flag_list = flags}] in
+    let flags_to_apply = [{workdir = config.query.directory; workval = flags}] in
     {config with merlin = {config.merlin with flags_to_apply}}
   | `Use pkgs ->
     let packages_to_load =
@@ -193,7 +193,7 @@ let dispatch_sync tr config state (type a) : a sync_command -> a = function
   | Flags_get ->
     let pipeline = make_pipeline tr config state in
     let config = Mpipeline.final_config pipeline in
-    List.concat_map ~f:(fun f -> f.Mconfig.flag_list)
+    List.concat_map ~f:(fun f -> f.workval)
       Mconfig.(config.merlin.flags_to_apply)
 
   | Project_get ->

--- a/src/frontend/old/old_merlin.ml
+++ b/src/frontend/old/old_merlin.ml
@@ -116,9 +116,9 @@ let setup_system () =
 
 let setup_merlin args =
   let config, protocol =
-    Marg.parse_all ~warning:prerr_endline
-      Mconfig.arguments_table ocamlmerlin_args
-      args Mconfig.initial `Json
+    Mconfig.parse_arguments
+      ~wd:(Sys.getcwd ()) ~warning:prerr_endline ocamlmerlin_args args
+      Mconfig.initial `Json
   in
   Old_command.default_config := config;
   let protocol = match protocol with

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -140,8 +140,7 @@ let dump pipeline = function
 
   | [`String "flags"] ->
     let prepare_flags flags =
-      `List (List.map ~f:Json.string (List.concat_map flags
-                                     ~f:(fun f -> f.Mconfig.flag_list))) in
+      Json.list Json.string (List.concat_map flags ~f:(fun f -> f.workval)) in
     let user = prepare_flags
         Mconfig.((Mpipeline.input_config pipeline).merlin.flags_to_apply) in
     let applied = prepare_flags

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -17,8 +17,8 @@ type ocaml = {
   nopervasives         : bool;
   strict_formats       : bool;
   open_modules         : string list;
-  ppx                  : string list;
-  pp                   : string;
+  ppx                  : string with_workdir list;
+  pp                   : string with_workdir option;
   warnings             : Warnings.state;
 }
 
@@ -41,9 +41,9 @@ let dump_ocaml x = `Assoc [
     "unsafe_string"        , `Bool x.unsafe_string;
     "nopervasives"         , `Bool x.nopervasives;
     "strict_formats"       , `Bool x.strict_formats;
-    "open_modules"         , `List (List.map ~f:Json.string x.open_modules);
-    "ppx"                  , `List (List.map ~f:Json.string x.ppx);
-    "pp"                   , `String x.pp;
+    "open_modules"         , Json.list Json.string x.open_modules;
+    "ppx"                  , Json.list (dump_with_workdir Json.string) x.ppx;
+    "pp"                   , Json.option (dump_with_workdir Json.string) x.pp;
     "warnings"             , dump_warnings x.warnings;
   ]
 
@@ -51,8 +51,9 @@ let dump_ocaml x = `Assoc [
 
 let cwd = ref None
 
-let resolve_relative_path ?cwd:path f =
-  let_ref cwd path f
+let unsafe_get_cwd () = match !cwd with
+  | None -> assert false
+  | Some cwd -> cwd
 
 let canonicalize_filename path =
   Misc.canonicalize_filename ?cwd:!cwd path
@@ -60,14 +61,9 @@ let canonicalize_filename path =
 let marg_path f =
   Marg.param "path" (fun path acc -> f (canonicalize_filename path) acc)
 
-let marg_exec_path f =
-  Marg.param "path" (fun path acc ->
-      (* Don't canonicalize if relative path can be resolved by looking up
-         PATH. *)
-      if Filename.basename path = path then
-        f path acc
-      else
-        f (canonicalize_filename path) acc)
+let marg_commandline f =
+  Marg.param "command"
+    (fun workval acc -> f {workdir = unsafe_get_cwd (); workval} acc)
 
 (** {1 Findlib configuration} *)
 
@@ -85,11 +81,6 @@ let dump_findlib x = `Assoc [
 
 (** {1 Merlin high-level settings} *)
 
-type flag_list = {
-  flag_cwd : string option;
-  flag_list : string list;
-}
-
 type merlin = {
   build_path  : string list;
   source_path : string list;
@@ -105,10 +96,10 @@ type merlin = {
 
   exclude_query_dir : bool;
 
-  flags_to_apply    : flag_list list;
+  flags_to_apply    : string list with_workdir list;
   packages_to_load  : string list;
 
-  flags_applied    : flag_list list;
+  flags_applied    : string list with_workdir list;
   dotmerlin_loaded : string list;
   packages_loaded  : string list;
 
@@ -122,11 +113,8 @@ type merlin = {
 }
 
 let dump_merlin x =
-  let dump_flag_list { flag_cwd; flag_list } =
-    `Assoc [
-      "cwd", Json.(option string) flag_cwd;
-      "flags", `List (List.map ~f:Json.string flag_list);
-    ]
+  let dump_flag_list flags =
+    dump_with_workdir (Json.list Json.string) flags
   in
   `Assoc [
     "build_path"   , `List (List.map ~f:Json.string x.build_path);
@@ -240,10 +228,10 @@ let normalize_step t =
     in
     let failures = ref [] in
     let warning failure = failures := failure :: !failures in
-    let t = List.fold_left ~f:(fun t {flag_cwd; flag_list} ->
-        fst (resolve_relative_path ?cwd:flag_cwd
-               (Marg.parse_all ~warning arguments_table [] flag_list t))
-      ) ~init:t flagss
+    let t = List.fold_left ~f:(fun t {workdir; workval} -> fst (
+        let_ref cwd (Some workdir)
+          (Marg.parse_all ~warning arguments_table [] workval t)
+      )) ~init:t flagss
     in
     {t with merlin = {t.merlin with failures = !failures @ t.merlin.failures}}
   else
@@ -278,10 +266,7 @@ let load_dotmerlins ~filenames t =
       if dot.reader = []
       then merlin.reader
       else dot.reader;
-    flags_to_apply =
-      List.map
-        ~f:(fun (cwd, flag_list) -> {flag_cwd = Some cwd; flag_list}) dot.flags
-      @ merlin.flags_to_apply;
+    flags_to_apply = dot.flags @ merlin.flags_to_apply;
     dotmerlin_loaded = dot.dot_merlins @ merlin.dotmerlin_loaded;
     packages_to_load = dot.packages @ merlin.packages_to_load;
   } in
@@ -381,7 +366,7 @@ let merlin_flags = [
     "-flags",
     Marg.param "string" (fun flags merlin ->
         let flags =
-          { flag_cwd = None;  flag_list = Shell.split_command flags }
+          { workdir = unsafe_get_cwd (); workval = Shell.split_command flags }
         in
         {merlin with flags_to_apply = flags :: merlin.flags_to_apply}),
     "<quoted flags> Unescape argument and interpret it as more flags"
@@ -576,13 +561,13 @@ let ocaml_flags = [
   );
   (
     "-ppx",
-    marg_exec_path (fun command ocaml ->
+    marg_commandline (fun command ocaml ->
         {ocaml with ppx = command :: ocaml.ppx}),
     "<command> Pipe abstract syntax trees through preprocessor <command>"
   );
   (
     "-pp",
-    marg_exec_path (fun pp ocaml -> {ocaml with pp}),
+    marg_commandline (fun pp ocaml -> {ocaml with pp = Some pp}),
     "<command> Pipe sources through preprocessor <command>"
   );
   ( "-w",
@@ -628,7 +613,7 @@ let initial = {
     strict_formats       = false;
     open_modules         = [];
     ppx                  = [];
-    pp                   = "";
+    pp                   = None;
     warnings             = Warnings.backup ();
   };
   findlib = {
@@ -670,6 +655,10 @@ let initial = {
     printer_width = 0;
   }
 }
+
+let parse_arguments ~wd ~warning local_spec args t local =
+  let_ref cwd (Some wd) @@ fun () ->
+  Marg.parse_all ~warning arguments_table local_spec args t local
 
 let global_flags = [
   (

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -17,8 +17,8 @@ type ocaml = {
   nopervasives         : bool;
   strict_formats       : bool;
   open_modules         : string list;
-  ppx                  : string list;
-  pp                   : string;
+  ppx                  : string with_workdir list;
+  pp                   : string with_workdir option;
   warnings             : Warnings.state;
 }
 
@@ -36,11 +36,6 @@ val dump_findlib : findlib -> json
 
 (** {1 Merlin high-level settings} *)
 
-type flag_list = {
-  flag_cwd : string option;
-  flag_list : string list;
-}
-
 type merlin = {
   build_path  : string list;
   source_path : string list;
@@ -56,10 +51,10 @@ type merlin = {
 
   exclude_query_dir : bool;
 
-  flags_to_apply    : flag_list list;
+  flags_to_apply    : string list with_workdir list;
   packages_to_load  : string list;
 
-  flags_applied    : flag_list list;
+  flags_applied    : string list with_workdir list;
   dotmerlin_loaded : string list;
   packages_loaded  : string list;
 
@@ -100,7 +95,10 @@ val normalize : Trace.t -> t -> t
 
 val is_normalized : t -> bool
 
-val arguments_table : t Marg.table
+val parse_arguments :
+  wd:string ->
+  warning:(string -> unit) -> 'a Marg.spec list -> string list ->
+  t -> 'a -> t * 'a
 
 val flags_for_completion : unit -> string list
 

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -155,7 +155,7 @@ type config = {
   cmi_path     : string list;
   cmt_path     : string list;
   packages     : string list;
-  flags        : (string * string list) list;
+  flags        : string list with_workdir list;
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;
@@ -225,7 +225,8 @@ let prepend_config ~stdlib {path; directives; _} config =
     | `SUFFIX suffix ->
       {config with suffixes = (parse_suffix suffix) @ config.suffixes}
     | `FLG flags ->
-      {config with flags = (cwd, Shell.split_command flags) :: config.flags}
+      let flags = {workdir = cwd; workval = Shell.split_command flags} in
+      {config with flags = flags :: config.flags}
     | `STDLIB path ->
       {config with stdlib = Some (canonicalize_filename ~cwd path)}
     | `FINDLIB path ->

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -48,6 +48,7 @@ type directive = [
 
 type file = {
   recurse    : bool;
+  includes   : string list;
   path       : string;
   directives : directive list;
 }
@@ -58,6 +59,7 @@ module Cache = File_cache.Make (struct
       let ic = open_in path in
       let acc = ref [] in
       let recurse = ref false in
+      let includes = ref [] in
       let tell l = acc := l :: !acc in
       try
         let rec aux () =
@@ -82,6 +84,8 @@ module Cache = File_cache.Make (struct
             tell (`FLG (String.drop 4 line))
           else if String.is_prefixed ~by:"REC" line then
             recurse := true
+          else if String.is_prefixed ~by:". " line then
+            includes := String.trim (String.drop 2 line) :: !includes
           else if String.is_prefixed ~by:"STDLIB " line then
             tell (`STDLIB (String.drop 7 line))
           else if String.is_prefixed ~by:"FINDLIB " line then
@@ -106,7 +110,8 @@ module Cache = File_cache.Make (struct
       with
       | End_of_file ->
         close_in_noerr ic;
-        {recurse = !recurse; path; directives = List.rev !acc}
+        let recurse = !recurse and includes = !includes in
+        {recurse; includes; path; directives = List.rev !acc}
       | exn ->
         close_in_noerr ic;
         raise exn
@@ -130,23 +135,35 @@ let find fname =
     in
     loop fname
 
-let rec directives_of_file fname =
-  match find fname with
-  | None -> []
-  | Some fname ->
-    let file = Cache.read fname in
-    file ::
-    if file.recurse then
-      let path = file.path in
-      let dir =
-        let dir = Filename.dirname path in
-        if Filename.basename path <> ".merlin"
-        then dir else Filename.dirname dir
+let directives_of_files filenames =
+  let marked = Hashtbl.create 7 in
+  let rec process acc = function
+    | x :: rest when Hashtbl.mem marked x ->
+      process acc rest
+    | x :: rest ->
+      Hashtbl.add marked x ();
+      let file = Cache.read x in
+      let dir = Filename.dirname file.path in
+      let rest =
+        List.map ~f:(canonicalize_filename ~cwd:dir) file.includes @ rest
       in
-      if dir <> path then
-        directives_of_file dir
-      else []
-    else []
+      let rest =
+        if file.recurse then (
+          let dir =
+            if Filename.basename file.path <> ".merlin"
+            then dir else Filename.dirname dir
+          in
+          if dir <> file.path then
+            match find dir with
+            | Some fname -> fname :: rest
+            | None -> rest
+          else rest
+        ) else rest
+      in
+      process (file :: acc) rest
+    | [] -> List.rev acc
+  in
+  process [] filenames
 
 type config = {
   dot_merlins  : string list;
@@ -265,12 +282,11 @@ let postprocess_config config =
 
 let load ~stdlib filenames =
   let filenames = List.map ~f:canonicalize_filename filenames in
-  let directives = List.map ~f:directives_of_file filenames in
+  let filenames = List.filter_map ~f:find filenames in
+  let directives = directives_of_files filenames in
   let config =
     List.fold_left directives ~init:empty_config
-      ~f:(fun config subfiles ->
-          List.fold_left subfiles ~init:config
-            ~f:(fun config file -> prepend_config ~stdlib file config))
+      ~f:(fun config file -> prepend_config ~stdlib file config)
   in
   postprocess_config config
 

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -155,7 +155,7 @@ type config = {
   cmi_path     : string list;
   cmt_path     : string list;
   packages     : string list;
-  flags        : string list list;
+  flags        : (string * string list) list;
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;
@@ -225,7 +225,7 @@ let prepend_config ~stdlib {path; directives; _} config =
     | `SUFFIX suffix ->
       {config with suffixes = (parse_suffix suffix) @ config.suffixes}
     | `FLG flags ->
-      {config with flags = Shell.split_command flags :: config.flags}
+      {config with flags = (cwd, Shell.split_command flags) :: config.flags}
     | `STDLIB path ->
       {config with stdlib = Some (canonicalize_filename ~cwd path)}
     | `FINDLIB path ->

--- a/src/kernel/mconfig_dot.mli
+++ b/src/kernel/mconfig_dot.mli
@@ -35,7 +35,7 @@ type config = {
   cmi_path     : string list;
   cmt_path     : string list;
   packages     : string list;
-  flags        : string list list;
+  flags        : (string * string list) list;
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;

--- a/src/kernel/mconfig_dot.mli
+++ b/src/kernel/mconfig_dot.mli
@@ -26,6 +26,8 @@
 
 )* }}} *)
 
+open Std
+
 (** Load and cache dot-merlin files **)
 
 type config = {
@@ -35,7 +37,7 @@ type config = {
   cmi_path     : string list;
   cmt_path     : string list;
   packages     : string list;
-  flags        : (string * string list) list;
+  flags        : string list with_workdir list;
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;

--- a/src/kernel/mppx.ml
+++ b/src/kernel/mppx.ml
@@ -30,13 +30,16 @@ let with_include_dir path f =
 
 
 let rewrite _trace cfg parsetree =
-  let ppx = cfg.ocaml.ppx @ Ppxsetup.command_line cfg.merlin.packages_ppx in
+  let ppx = cfg.ocaml.ppx @
+            List.map
+              (fun ppx -> {Std. workdir = cfg.query.directory; workval = ppx })
+              (Ppxsetup.command_line cfg.merlin.packages_ppx)
+  in
   let prev_dir = Sys.getcwd () in
   let restore () =
     if not (change_directory prev_dir) then
       ignore (change_directory "/")
   in
-  ignore (change_directory cfg.query.directory);
   (* add include path attribute to the parsetree *)
   with_include_dir (Mconfig.build_path cfg) @@ fun () ->
   match Pparse.apply_rewriters ~ppx ~tool_name:"merlin" parsetree with

--- a/src/kernel/mppx.ml
+++ b/src/kernel/mppx.ml
@@ -6,7 +6,7 @@ let change_directory dir =
   | () -> true
   | exception exn ->
     Logger.logf "Mppx" "changing directory"
-      "chang_directory %S failed with %t" dir
+      "change_directory %S failed with %t" dir
       (fun () -> Printexc.to_string exn);
     false
 

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -14,8 +14,6 @@ type error =
   | CannotRun of string
   | WrongMagic of string
 
-exception Error of error
-
 (* Note: some of the functions here should go to Ast_mapper instead,
    which would encapsulate the "binary AST" protocol. *)
 
@@ -28,44 +26,66 @@ let write_ast magic ast =
   close_out oc;
   fn
 
-let null = match Sys.os_type with "Win32" -> " NUL" | _ -> "/dev/null"
+let report_error = function
+  | CannotRun cmd ->
+    Logger.logf "Pparse" "report_error"
+      "Error while running external preprocessor. Command line: %s" cmd
+  | WrongMagic cmd ->
+    Logger.logf "Pparse" "report_error"
+      "External preprocessor does not produce a valid file. Command line: %s" cmd
 
 let ppx_commandline cmd fn_in fn_out =
-  Printf.sprintf "%s %s %s 1>%s 2>%s"
-    cmd (Filename.quote fn_in) (Filename.quote fn_out) null null
+  Printf.sprintf "%s %s %s 1>&2"
+    cmd (Filename.quote fn_in) (Filename.quote fn_out)
 
 let pp_commandline cmd fn_in fn_out =
   Printf.sprintf "%s %s 1>%s"
     cmd (Filename.quote fn_in) (Filename.quote fn_out)
 
-let apply_rewriter magic fn_in ppx =
+let apply_rewriter magic (fn_in, failures) ppx =
+  Logger.log "Pparse" "apply_rewriter" ppx;
+  Logger.log_flush ();
   let fn_out = Filename.temp_file "camlppx" "" in
   let comm = ppx_commandline ppx fn_in fn_out in
-  let ok = Sys.command comm = 0 in
-  if ok then
-    Misc.remove_file fn_in
-  else begin
-    try
-      Sys.rename fn_in
-        (Filename.concat (Filename.get_temp_dir_name ()) "camlppx.lastfail")
-    with _ -> ()
-  end;
-  if not ok then begin
+  let failure =
+    let ok = Sys.command comm = 0 in
+    if not ok then Some (CannotRun comm)
+    else if not (Sys.file_exists fn_out) then
+      Some (WrongMagic comm)
+    else
+      (* check magic before passing to the next ppx *)
+      let ic = open_in_bin fn_out in
+      let buffer =
+        try really_input_string ic (String.length magic)
+        with End_of_file -> ""
+      in
+      close_in ic;
+      if buffer <> magic then
+        Some (WrongMagic comm)
+      else
+        None
+  in
+  match failure with
+  | Some err ->
     Misc.remove_file fn_out;
-    raise (Error (CannotRun comm));
-  end;
-  if not (Sys.file_exists fn_out) then
-    raise (Error (WrongMagic comm));
-  (* check magic before passing to the next ppx *)
-  let ic = open_in_bin fn_out in
-  let buffer =
-    try really_input_string ic (String.length magic) with End_of_file -> "" in
-  close_in ic;
-  if buffer <> magic then begin
-    Misc.remove_file fn_out;
-    raise (Error (WrongMagic comm));
-  end;
-  fn_out
+    let fallback =
+      let fallback =
+        Filename.concat (Filename.get_temp_dir_name ())
+          ("camlppx.lastfail" ^ string_of_int failures)
+      in
+      match Sys.rename fn_in fallback with
+      | () -> fallback
+      | exception exn ->
+        Logger.logf "Pparse" "apply_rewriter"
+          "exception while renaming ast: %a"
+          (fun () -> Printexc.to_string) exn;
+        fn_in
+    in
+    report_error (CannotRun comm);
+    (fallback, failures + 1)
+  | None ->
+    Misc.remove_file fn_in;
+    (fn_out, failures)
 
 let read_ast magic fn =
   let ic = open_in_bin fn in
@@ -83,9 +103,12 @@ let read_ast magic fn =
     raise exn
 
 let rewrite magic ast ppxs =
-  read_ast magic
-    (List.fold_left (apply_rewriter magic) (write_ast magic ast)
-       (List.rev ppxs))
+  let fn_out, _ =
+    List.fold_left
+      (apply_rewriter magic) (write_ast magic ast, 0) (List.rev ppxs)
+  in
+  read_ast magic fn_out
+
 
 let apply_rewriters_str ~ppx ?(restore = true) ~tool_name ast =
   match ppx with
@@ -124,7 +147,7 @@ let read_ast magic fn =
     Misc.remove_file fn;
     raise exn
 
-let apply_pp ~filename ~source ~pp =
+(*let apply_pp ~filename ~source ~pp =
   let fn_in = Filename.temp_file "merlinpp" (Filename.basename filename) in
   begin
     let oc = open_out_bin fn_in in
@@ -152,19 +175,4 @@ let apply_pp ~filename ~source ~pp =
     `Interface (read_ast Config.ast_intf_magic_number fn_out
                 : Parsetree.signature)
   else
-    Misc.fatal_error "OCaml and preprocessor have incompatible versions"
-
-let report_error ppf = function
-  | CannotRun cmd ->
-    Format.fprintf ppf "Error while running external preprocessor@.\
-                 Command line: %s@." cmd
-  | WrongMagic cmd ->
-    Format.fprintf ppf "External preprocessor does not produce a valid file@.\
-                 Command line: %s@." cmd
-
-let () =
-  Location.register_error_of_exn
-    (function
-      | Error err -> Some (Location.error_of_printer_file report_error err)
-      | _ -> None
-    )
+    Misc.fatal_error "OCaml and preprocessor have incompatible versions"*)

--- a/src/ocaml/driver/pparse.mli
+++ b/src/ocaml/driver/pparse.mli
@@ -12,12 +12,6 @@
 
 open Format
 
-type error =
-  | CannotRun of string
-  | WrongMagic of string
-
-exception Error of error
-
 (** If [restore = true] (the default), cookies set by external rewriters will be
     kept for later calls. *)
 
@@ -26,7 +20,5 @@ val apply_rewriters_sig: ppx:string list -> ?restore:bool -> tool_name:string ->
 
 val apply_rewriters: ppx:string list -> ?restore:bool -> tool_name:string -> Mreader.parsetree -> Mreader.parsetree
 
-val report_error : formatter -> error -> unit
-
-val apply_pp : filename:string -> source:string -> pp:string ->
-  [> `Interface of Parsetree.signature | `Implementation of Parsetree.structure ]
+(*val apply_pp : filename:string -> source:string -> pp:string ->
+  [> `Interface of Parsetree.signature | `Implementation of Parsetree.structure ]*)

--- a/src/ocaml/driver/pparse.mli
+++ b/src/ocaml/driver/pparse.mli
@@ -10,15 +10,15 @@
 (*                                                                     *)
 (***********************************************************************)
 
-open Format
+open Std
 
 (** If [restore = true] (the default), cookies set by external rewriters will be
     kept for later calls. *)
 
-val apply_rewriters_str: ppx:string list -> ?restore:bool -> tool_name:string -> Parsetree.structure -> Parsetree.structure
-val apply_rewriters_sig: ppx:string list -> ?restore:bool -> tool_name:string -> Parsetree.signature -> Parsetree.signature
+val apply_rewriters_str: ppx:string with_workdir list -> ?restore:bool -> tool_name:string -> Parsetree.structure -> Parsetree.structure
+val apply_rewriters_sig: ppx:string with_workdir list -> ?restore:bool -> tool_name:string -> Parsetree.signature -> Parsetree.signature
 
-val apply_rewriters: ppx:string list -> ?restore:bool -> tool_name:string -> Mreader.parsetree -> Mreader.parsetree
+val apply_rewriters: ppx:string with_workdir list -> ?restore:bool -> tool_name:string -> Mreader.parsetree -> Mreader.parsetree
 
 (*val apply_pp : filename:string -> source:string -> pp:string ->
   [> `Interface of Parsetree.signature | `Implementation of Parsetree.structure ]*)

--- a/src/utils/logger.ml
+++ b/src/utils/logger.ml
@@ -41,13 +41,20 @@ let destination = ref None
 let output_section oc section title =
   Printf.fprintf oc "# %2.2f %s - %s\n" (delta_time ()) section title
 
+let log_flush () =
+  match !destination with
+  | None -> ()
+  | Some oc -> flush oc
+
 let log section title msg =
   match !destination with
   | None -> ()
   | Some oc ->
     output_section oc section title;
-    output_string oc msg;
-    output_char oc '\n'
+    if msg <> "" then (
+      output_string oc msg;
+      output_char oc '\n';
+    )
 
 let logf section title =
   Printf.ksprintf (log section title)
@@ -90,6 +97,7 @@ let with_log_file file f =
   match file with
   | None -> f ()
   | Some file ->
+    log_flush ();
     let destination', release = match file with
       | "" -> (None, ignore)
       | "-" -> (Some stderr, ignore)
@@ -105,6 +113,7 @@ let with_log_file file f =
     let destination0 = !destination in
     destination := destination';
     let release () =
+      log_flush ();
       destination := destination0;
       release ()
     in

--- a/src/utils/logger.mli
+++ b/src/utils/logger.mli
@@ -42,6 +42,7 @@ val log    : section -> title -> string -> unit
 val logf   : section -> title -> ('b, unit, string, unit) format4 -> 'b
 val logfmt : section -> title -> (Format.formatter -> unit) -> unit
 val logj   : section -> title -> (unit -> Std.json) -> unit
+val log_flush : unit -> unit
 
 val notify : section -> ('b, unit, string, unit) format4 -> 'b
 val with_notifications : (section * string) list ref -> (unit -> 'a) -> 'a

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -36,8 +36,12 @@ module Json = struct
     | None -> `Null
     | Some x -> f x
 
+  let list f x =
+    `List (List.map f x)
+
   let print f () x =
     pretty_to_string (f x)
+
 end
 
 type json =
@@ -758,3 +762,16 @@ let file_contents filename =
     raise exn
 
 external reraise : exn -> 'a = "%reraise"
+
+type 'a with_workdir = {
+  workdir : string;
+  workval : 'a;
+}
+(** Some value that must be interpreted with respect to a specific work
+    directory. (e.g. for resolving relative paths or executing sub-commands *)
+
+let dump_with_workdir f x : json =
+  `Assoc [
+    "workdir", `String x.workdir;
+    "workval", f x.workval;
+  ]

--- a/tests/config/path-expansion.t
+++ b/tests/config/path-expansion.t
@@ -2,22 +2,34 @@ A simple name is not expanded
 
   $ echo | $MERLIN single dump-configuration -filename relative_path.ml -ppx test1 | \
   > jq '.value.ocaml.ppx'
+  sh: test1: command not found
   [
-    "test1"
+    {
+      "workdir": "tests/config",
+      "workval": "test1"
+    }
   ]
 
 Neither is an absolute path
 
   $ echo | $MERLIN single dump-configuration -filename relative_path.ml -ppx /test2 | \
   > jq '.value.ocaml.ppx'
+  sh: /test2: No such file or directory
   [
-    "/test2"
+    {
+      "workdir": "tests/config",
+      "workval": "/test2"
+    }
   ]
 
 But relative names are
 
   $ echo | $MERLIN single dump-configuration -filename relative_path.ml -ppx ./test3 | \
   > jq '.value.ocaml.ppx'
+  sh: ./test3: No such file or directory
   [
-    "tests/config/test3"
+    {
+      "workdir": "tests/config",
+      "workval": "./test3"
+    }
   ]


### PR DESCRIPTION
This branch executes ppx binary in the same directory as the .merlin, such that relative paths that are passed to a ppx can be interpreted in the right directory.

Dubious: I left a patch that allows expansion of `~/` in the paths processed by Merlin.
I added it for experimentation purposes but I think it should be removed, unless @trefis thinks otherwise :).