### PR TITLE
[RFC] Changed Vscode link to vscode-reasonml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The wiki also contains pages for:
 - [Spacemacs](https://github.com/ocaml/merlin/wiki/spacemacs-from-scratch)
 
 External contributors have implemented modes for more editors:  
-* [Visual Studio Code](https://github.com/hackwaly/vscode-ocaml)  
+* [Visual Studio Code](https://github.com/reasonml-editor/vscode-reasonml)  
 * [Sublime Text 3](https://github.com/cynddl/sublime-text-merlin)  
 * [ocaml-merlin package for Atom](https://atom.io/packages/ocaml-merlin)  
 * [nuclide for Atom](https://nuclide.io/) includes Merlin support


### PR DESCRIPTION
Since the original vscode update is deprecated and recommends
using the other plugin instead.

I tested the reasonml plugin and it did work for basic OCaml files even if the reason stuff was not configured and only merlin was installed. Maybe @hackwaly can give a bit more context.