### PR TITLE
Fixed warnings found by clang static analyzer.

### DIFF
--- a/src/frontend/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin.c
@@ -437,7 +437,6 @@ static const char *search_in_path(const char *PATH, const char *argv0, char *mer
       }
 
       binary_path[i] = 0;
-      i += 1;
     }
 
     // Check path

--- a/src/platform/os_ipc_stub.c
+++ b/src/platform/os_ipc_stub.c
@@ -124,12 +124,12 @@ static ssize_t recv_buffer(int fd, int fds[3])
 
   struct cmsghdr *cm = CMSG_FIRSTHDR(&msg);
 
-  int *fds0 = (int*)CMSG_DATA(cm);
   if (cm == NULL)
   {
     perror("recvmsg");
     return -1;
   }
+  int *fds0 = (int*)CMSG_DATA(cm);
   int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
 
   /* Check malformed packet */

--- a/src/platform/os_ipc_stub.c
+++ b/src/platform/os_ipc_stub.c
@@ -125,6 +125,11 @@ static ssize_t recv_buffer(int fd, int fds[3])
   struct cmsghdr *cm = CMSG_FIRSTHDR(&msg);
 
   int *fds0 = (int*)CMSG_DATA(cm);
+  if (cm == NULL)
+  {
+    perror("recvmsg");
+    return -1;
+  }
   int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
 
   /* Check malformed packet */


### PR DESCRIPTION
Actually there were not that much warnings from the clang static analyzer, beside the suggestion to use `strlcopy` instead of `strcopy` which is not available on all platforms.

The first warning is that the value of the `i += 1;` is never used which a simple scan through the source code can confirm.

The second warning comes the fact that `cm` is not tested for `NULL` and the corresponding path is given by
```
os_ipc_stub.c:128:15: warning: Access to field 'cmsg_len' results in a dereference of a null pointer (loaded from variable 'cm') [clang-analyzer-core.NullDereference]
  int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
              ^
os_ipc_stub.c:258:12: note: Assuming the condition is false
  } while (selectres == -1 && errno == EINTR);
           ^
os_ipc_stub.c:258:28: note: Left side of '&&' is false
  } while (selectres == -1 && errno == EINTR);
                           ^
os_ipc_stub.c:254:3: note: Loop condition is false.  Exiting loop
  do {
  ^
os_ipc_stub.c:263:7: note: Assuming 'selectres' is > 0
  if (selectres > 0)
      ^
os_ipc_stub.c:263:3: note: Taking true branch
  if (selectres > 0)
  ^
os_ipc_stub.c:266:11: note: Calling 'recv_buffer'
    len = recv_buffer(clientfd, fds);
          ^
os_ipc_stub.c:90:3: note: Taking false branch
  if (recvd == -1)
  ^
os_ipc_stub.c:96:7: note: Assuming 'recvd' is >= 4
  if (recvd < 4)
      ^
os_ipc_stub.c:96:3: note: Taking false branch
  if (recvd < 4)
  ^
os_ipc_stub.c:108:7: note: Assuming 'recvd' is <= 4
  if (recvd > 4)
      ^
os_ipc_stub.c:108:3: note: Taking false branch
  if (recvd > 4)
  ^
os_ipc_stub.c:125:3: note: 'cm' initialized to a null pointer value
  struct cmsghdr *cm = CMSG_FIRSTHDR(&msg);
  ^
os_ipc_stub.c:128:15: note: Access to field 'cmsg_len' results in a dereference of a null pointer (loaded from variable 'cm')
  int nfds = (cm->cmsg_len - CMSG_LEN(0)) / sizeof(int);
````