### PR TITLE
Fix emacs label completion

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -882,10 +882,10 @@ prefix of `bar' is `'."
   ;; Remove non-matching entry, adjusting optional labels if needed
   (cl-loop for x in labels
            for name = (cdr (assoc 'name x))
-           unless (or (string-prefix-p prefix name)
-                      (when (equal (aref name 0) ??)
-                        (aset name 0 ?~)
-                        (string-prefix-p prefix name)))
+           when (or (string-prefix-p prefix name)
+                    (when (equal (aref name 0) ??)
+                      (aset name 0 ?~)
+                      (string-prefix-p prefix name)))
            collect (append x '((kind . "Label") (info . nil)))))
 
 (defun merlin/complete (ident)

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -878,14 +878,14 @@ prefix of `bar' is `'."
          (prefix (if (string-equal s "") s (concat s "."))))
     (cons prefix suffix)))
 
-(defun merlin--completion-prepare-labels (labels suffix)
+(defun merlin--completion-prepare-labels (labels prefix)
   ;; Remove non-matching entry, adjusting optional labels if needed
   (cl-loop for x in labels
            for name = (cdr (assoc 'name x))
-           unless (or (string-prefix-p suffix name)
+           unless (or (string-prefix-p prefix name)
                       (when (equal (aref name 0) ??)
                         (aset name 0 ?~)
-                        (string-prefix-p suffix name)))
+                        (string-prefix-p prefix name)))
            collect (append x '((kind . "Label") (info . nil)))))
 
 (defun merlin/complete (ident)


### PR DESCRIPTION
Fix merlin's emacs autocompletion filtering out the labels the user wants. For example, if I have a function

`val func : unit:unit -> int:int -> unit`

And I try to complete

`func ~un`

The auto-completed parameter would be `~int`. 

This pull request fixes it so the auto-completed parameter is `~unit` as expected.