### PR TITLE
Emacs: Don't present the user with non-label completions when they are trying to write a label.

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -924,7 +924,15 @@ prefix of `bar' is `'."
       (setq-local merlin--dwimed t)
       (setq prefix ""))
     ;; Concat results
-    (let ((result (append labels entries)))
+    (let ((result
+           (if (and (not (string-empty-p ident))
+                    (or (equal (aref ident 0) ?~)
+                        (equal (aref ident 0) ??))
+                    labels)
+               ;; If the user is trying to autocomplete a label, don't present
+               ;; non-label completions.
+               labels
+             (append labels entries))))
       (if expected-ty
           (cl-loop for x in result
                    collect (append x `((argument_type . ,expected-ty))))


### PR DESCRIPTION
If I am using Emacs and I have a function

`val func : unit:unit -> int:int -> unit`

And I try to complete

`func ~`

The functions `~+ : int -> int` and `~+. : float -> float` are suggested as completions. These are very likely not what the user wants, since they're not actually labels.

This pull request makes it so that if valid label completions exist and the user has typed something starting with "~" or "?", then only valid labels are suggested as completions.