### PR TITLE
Return type info in module outlines

### DIFF
--- a/src/frontend/query_json.ml
+++ b/src/frontend/query_json.ml
@@ -257,10 +257,13 @@ let json_of_completions {Compl. entries; context } =
   ]
 
 let rec json_of_outline outline =
-  let json_of_item { outline_name ; outline_kind ; location ; children } =
+  let json_of_item { outline_name ; outline_kind ; outline_type; location ; children } =
     with_location location [
       "name", `String outline_name;
       "kind", `String (string_of_completion_kind outline_kind);
+      "type", (match outline_type with
+        | None -> `Null
+        | Some typ -> `String typ);
       "children", `List (json_of_outline children);
     ]
   in

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -77,6 +77,7 @@ and item = {
     | `Class
     | `Method
   ];
+  outline_type : string option ;
   location : Location_aux.t ;
   children : outline ;
 }


### PR DESCRIPTION
This adds type information for value bindings in `outline` query.

This allows to implement CodeLens like functionality. Example with neovim below:

![codelens-neovim](https://user-images.githubusercontent.com/30594/51112098-5e77db00-180f-11e9-8914-367d8e47a64b.gif)
