### PR TITLE
Emacs: Show the number of errors in the modeline

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1733,19 +1733,21 @@ Empty string defaults to jumping to all these."
 
 (defun merlin-lighter ()
   "Return the lighter for merlin which indicates the status of merlin process."
-  (let (messages)
+  (let (messages
+        (num-errors (length merlin-erroneous-buffer)))
     (when merlin-report-errors-in-lighter
       (cond ((not merlin--project-cache) nil)
             ((cdr-safe merlin--project-cache)
-             (add-to-list 'messages "check config!"))
+             (push "check config!" messages))
             ((not (car-safe merlin--project-cache))
-             (add-to-list 'messages "no .merlin"))))
-    (when merlin-erroneous-buffer
-      (add-to-list 'messages "errors in buffer"))
+             (push "no .merlin" messages))))
+    (unless (zerop num-errors)
+      (push (format "%d error%s" num-errors (if (> num-errors 1) "s" ""))
+            messages))
     (when (and merlin-show-instance-in-lighter
                (merlin-lookup 'name merlin-buffer-configuration))
-      (add-to-list 'messages
-                   (merlin-lookup 'name merlin-buffer-configuration)))
+      (push (merlin-lookup 'name merlin-buffer-configuration)
+            messages))
     (if messages
         (concat " Merlin (" (mapconcat 'identity messages ",") ")")
       " Merlin")))


### PR DESCRIPTION
Also replace `add-to-list` with `push`, to conform to elisp best practices (see the docstring of `add-to-list`).

Before:

![screen shot 2019-01-16 at 17 16 45](https://user-images.githubusercontent.com/70800/51266238-9e2af800-19b2-11e9-92c1-49346a2a7ff8.png)

After:

![screen shot 2019-01-16 at 17 15 33](https://user-images.githubusercontent.com/70800/51266254-a6833300-19b2-11e9-8e78-a9b90a5d85b7.png)