### PR TITLE
Lsp without stringext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+next version
+============
+
+Add support for lsp, contributed by Andrey Popp (@andreypopp) and Bryan Phelps
+(@bryphe).
+
 merlin 3.2.2
 ============
 Tue Oct  9 11:25:12 BST 2018

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Main collaborators:
 
 Contributors:
 * [Andrew Noyes](https://github.com/atn34)
+* [Andrey Popp](https://github.com/andreypopp)
 * [Anil Madhavapeddy](https://github.com/avsm)
 * [Anton Bachin](https://github.com/aantron)
 * [Armaël Guéneau](https://github.com/Armael)
@@ -201,6 +202,7 @@ Contributors:
 * [Benjamin San Souci](https://github.com/bsansouci)
 * [Bernhard Schommer](https://github.com/bschommer)
 * [Bobby Priambodo](https://github.com/bobbypriambodo)
+* [Bryan Phelps](https://github.com/bryphe)
 * [Chris Konstad](https://github.com/chriskonstad)
 * [Christopher Reichert](https://github.com/creichert)
 * [Christophe Troestler](https://github.com/Chris00)

--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -59,7 +59,7 @@ end = struct
   }
 
   let normalize_line_endings text =
-    let text = Stringext.replace_all ~pattern:"\r\n" ~with_:"\n" text in
+    let text = Std.String.replace_all ~pattern:"\r\n" ~with_:"\n" text in
     text
 
   let uri doc = Lsp.Text_document.documentUri doc.tdoc

--- a/src/lsp/dune
+++ b/src/lsp/dune
@@ -1,6 +1,6 @@
 (library
   (name lsp)
-  (libraries merlin_utils yojson ppx_deriving_yojson.runtime stringext threads)
+  (libraries merlin_utils yojson ppx_deriving_yojson.runtime threads)
   (preprocess (pps ppx_deriving_yojson)))
 
 (ocamllex (modules text_document_text))

--- a/src/lsp/uri.ml
+++ b/src/lsp/uri.ml
@@ -7,13 +7,13 @@ let to_path (uri : t) =
     | false -> "file://"
   in
   let path =
-    match Stringext.chop_prefix ~prefix:proto uri with
+    match Std.String.chop_prefix ~prefix:proto uri with
     | Some path -> path
     | None -> uri in
   path
-  |> Stringext.replace_all ~pattern:"\\" ~with_:"/"
-  |> Stringext.replace_all ~pattern:"%3A" ~with_:":"
-  |> Stringext.replace_all ~pattern:"%5C" ~with_:"/"
+  |> Std.String.replace_all ~pattern:"\\" ~with_:"/"
+  |> Std.String.replace_all ~pattern:"%3A" ~with_:":"
+  |> Std.String.replace_all ~pattern:"%5C" ~with_:"/"
 
 let of_path (path : string) =
   let proto = match Sys.win32 with
@@ -22,8 +22,8 @@ let of_path (path : string) =
   in
   let path =
     path
-    |> Stringext.replace_all ~pattern:"\\" ~with_:"/"
-    |> Stringext.replace_all ~pattern:":" ~with_:"%3A"
+    |> Std.String.replace_all ~pattern:"\\" ~with_:"/"
+    |> Std.String.replace_all ~pattern:":" ~with_:"%3A"
   in
   proto ^ path
 


### PR DESCRIPTION
To be merged after #905.

- Remove dependency on stringext library.
- Update changelog and readme, add @andreypopp and @bryphe to the list of contributors.
