### PR TITLE
emacs: make sure PATH is updated when merlin-command is 'opam

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1674,7 +1674,8 @@ Empty string defaults to jumping to all these."
          (with-temp-buffer
            (if (eq (call-process-shell-command
                     "opam config var bin" nil (current-buffer) nil) 0)
-               (progn
+               (let ((bin-path
+                      (replace-regexp-in-string "\n$" "" (buffer-string))))
                  ;; the opam bin dir needs to be on the path, so if merlin
                  ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
                  ;; correct version is used rather than the version that
@@ -1682,11 +1683,8 @@ Empty string defaults to jumping to all these."
 
                  ;; this was originally done via `opam exec' but that doesnt
                  ;; work for opam 1, and added a performance hit
-                 (setq merlin-opam-bin-path
-                       (list (concat "PATH=" (string-trim (buffer-string)))))
-                 (concat
-                  (replace-regexp-in-string "\n$" "" (buffer-string))
-                  "/ocamlmerlin"))
+                 (setq merlin-opam-bin-path (list (concat "PATH=" bin-path)))
+                 (concat bin-path "/ocamlmerlin"))
 
              ;; best effort if opam is not available, lookup for the binary in
              ;; the existing env

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1685,7 +1685,9 @@ Empty string defaults to jumping to all these."
                             "/ocamlmerlin"))
 
                        ;; best effort if opam is not available, lookup for the binary in the existing env
-                       "ocamlmerlin")))))
+                       (progn
+                         (message "merlin-command: opam config failed (%S)" (buffer-string))
+                         "ocamlmerlin"))))))
 
       ;; cache command in merlin-buffer configuration to avoid having to shell
       ;; out to `opam` each time.

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1665,29 +1665,35 @@ Empty string defaults to jumping to all these."
 
   (let ((command (merlin-lookup 'command merlin-buffer-configuration)))
     (unless command
-      (setq command
-            (cond ((functionp merlin-command) (funcall merlin-command))
-                  ((stringp merlin-command) merlin-command)
-                  ((equal merlin-command 'opam)
-                   (with-temp-buffer
-                     (if (eq (call-process-shell-command "opam config var bin" nil (current-buffer) nil) 0)
-                         (progn
-                           ;; the opam bin dir needs to be on the path, so if merlin
-                           ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
-                           ;; correct version is used rather than the version that
-                           ;; happens to be on the path
+      (setq
+       command
+       (cond
+        ((functionp merlin-command) (funcall merlin-command))
+        ((stringp merlin-command) merlin-command)
+        ((equal merlin-command 'opam)
+         (with-temp-buffer
+           (if (eq (call-process-shell-command
+                    "opam config var bin" nil (current-buffer) nil) 0)
+               (progn
+                 ;; the opam bin dir needs to be on the path, so if merlin
+                 ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
+                 ;; correct version is used rather than the version that
+                 ;; happens to be on the path
 
-                           ;; this was originally done via `opam exec' but that doesnt
-                           ;; work for opam 1, and added a performance hit
-                           (setq merlin-opam-bin-path (list (concat "PATH=" (string-trim (buffer-string)))))
-                           (concat
-                            (replace-regexp-in-string "\n$" "" (buffer-string))
-                            "/ocamlmerlin"))
+                 ;; this was originally done via `opam exec' but that doesnt
+                 ;; work for opam 1, and added a performance hit
+                 (setq merlin-opam-bin-path
+                       (list (concat "PATH=" (string-trim (buffer-string)))))
+                 (concat
+                  (replace-regexp-in-string "\n$" "" (buffer-string))
+                  "/ocamlmerlin"))
 
-                       ;; best effort if opam is not available, lookup for the binary in the existing env
-                       (progn
-                         (message "merlin-command: opam config failed (%S)" (buffer-string))
-                         "ocamlmerlin"))))))
+             ;; best effort if opam is not available, lookup for the binary in
+             ;; the existing env
+             (progn
+               (message "merlin-command: opam config failed (%S)"
+                        (buffer-string))
+               "ocamlmerlin"))))))
 
       ;; cache command in merlin-buffer configuration to avoid having to shell
       ;; out to `opam` each time.

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1665,30 +1665,27 @@ Empty string defaults to jumping to all these."
 
   (let ((command (merlin-lookup 'command merlin-buffer-configuration)))
     (unless command
-      (if (equal merlin-command 'opam)
+      (setq command
+            (cond ((functionp merlin-command) (funcall merlin-command))
+                  ((stringp merlin-command) merlin-command)
+                  ((equal merlin-command 'opam)
+                   (with-temp-buffer
+                     (if (eq (call-process-shell-command "opam config var bin" nil (current-buffer) nil) 0)
+                         (progn
+                           ;; the opam bin dir needs to be on the path, so if merlin
+                           ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
+                           ;; correct version is used rather than the version that
+                           ;; happens to be on the path
 
-          (with-temp-buffer
-            (if (eq (call-process-shell-command "opam config var bin" nil (current-buffer) nil) 0)
-                (progn
+                           ;; this was originally done via `opam exec' but that doesnt
+                           ;; work for opam 1, and added a performance hit
+                           (setq merlin-opam-bin-path (list (concat "PATH=" (string-trim (buffer-string)))))
+                           (concat
+                            (replace-regexp-in-string "\n$" "" (buffer-string))
+                            "/ocamlmerlin"))
 
-                  (setq command (concat
-                                 (replace-regexp-in-string "\n$" "" (buffer-string))
-                                 "/ocamlmerlin"))
-
-                  ;; the opam bin dir needs to be on the path, so if merlin
-                  ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
-                  ;; correct version is used rather than the version that
-                  ;; happens to be on the path
-
-                  ;; this was originally done via `opam exec' but that doesnt
-                  ;; work for opam 1, and added a performance hit
-                  (setq merlin-opam-bin-path (list (concat "PATH=" (string-trim (buffer-string))))))
-
-              (setq command "ocamlmerlin")))
-
-        (setq command
-              (cond ((functionp merlin-command) (funcall merlin-command))
-                    ((stringp merlin-command) merlin-command))))
+                       ;; best effort if opam is not available, lookup for the binary in the existing env
+                       "ocamlmerlin")))))
 
       ;; cache command in merlin-buffer configuration to avoid having to shell
       ;; out to `opam` each time.

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1662,21 +1662,40 @@ Empty string defaults to jumping to all these."
   "Return or update path of ocamlmerlin binary selected by configuration"
   (unless merlin-buffer-configuration
     (setq merlin-buffer-configuration (merlin--configuration)))
+
   (let ((command (merlin-lookup 'command merlin-buffer-configuration)))
     (unless command
-      (setq command (if (functionp merlin-command) (funcall merlin-command)
-                      merlin-command)))
-    (when (equal command 'opam)
-      (with-temp-buffer
-        (if (eq (call-process-shell-command
-                 "opam config var bin" nil (current-buffer) nil) 0)
-            (progn
-              (setq command (concat
-                             (replace-regexp-in-string "\n$" "" (buffer-string))
-                             "/ocamlmerlin"))
-              (push (cons 'command command) merlin-buffer-configuration))
-          (message "merlin-command: opam config failed (%S)" (buffer-string))
-          (setq command "ocamlmerlin"))))
+      (if (equal merlin-command 'opam)
+
+          (with-temp-buffer
+            (if (eq (call-process-shell-command "opam config var bin" nil (current-buffer) nil) 0)
+                (progn
+
+                  (setq command (concat
+                                 (replace-regexp-in-string "\n$" "" (buffer-string))
+                                 "/ocamlmerlin"))
+
+                  ;; the opam bin dir needs to be on the path, so if merlin
+                  ;; calls out to sub binaries (e.g. ocamlmerlin-reason), the
+                  ;; correct version is used rather than the version that
+                  ;; happens to be on the path
+
+                  ;; this was originally done via `opam exec' but that doesnt
+                  ;; work for opam 1, and added a performance hit
+                  (setq merlin-opam-bin-path (list (concat "PATH=" (string-trim (buffer-string))))))
+
+              (setq command "ocamlmerlin")))
+
+        (setq command
+              (cond ((functionp merlin-command) (funcall merlin-command))
+                    ((stringp merlin-command) merlin-command))))
+
+      ;; cache command in merlin-buffer configuration to avoid having to shell
+      ;; out to `opam` each time.
+      (push (cons 'command command) merlin-buffer-configuration)
+      (when (boundp 'merlin-opam-bin-path)
+        (push (cons 'env merlin-opam-bin-path) merlin-buffer-configuration)))
+
     command))
 
 ;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Previously the path to `ocamlmerlin` was built through prepending the result of `opam config var bin`. This works for the merlin binary itself, but if additional readers are used (such as ocamlmerlin-reason), merlin reverted to using the environmental path to look up the location of these binaries.

This means that if you have an reader on your global path that's incompatible with the current opam switch's merlin/ocaml version, merlin gets very unhappy.

This calls `ocamlmerlin` via `opam config exec` instead, which sets up the environment correctly and means it finds other merlin binaries in the switch as you'd expect.