### PR TITLE
Don't select deprecated paths in `-short-paths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ next version
     + tweaked caching policy
     + fix environment when a file disappears
     + fix -short-paths handling of classes and class types (by Leo White)
+    + don't select deprecated paths in -short-paths (by Leo White)
 
   - editors modes
     + Add support for lsp, contributed by Andrey Popp (@andreypopp) and Bryan

--- a/src/ocaml/typing/403/short_paths.mli
+++ b/src/ocaml/typing/403/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/403/short_paths_graph.ml
+++ b/src/ocaml/typing/403/short_paths_graph.ml
@@ -80,6 +80,10 @@ module Path_set = Set.Make(Path)
 
 module Desc = struct
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type = struct
 
     type t =
@@ -110,10 +114,10 @@ module Desc = struct
   module Module = struct
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -127,11 +131,15 @@ module Desc = struct
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -234,15 +242,39 @@ module Origin = struct
 
 end
 
-(* CR lwhite: Should probably short-circuit indirections if they are to
-    canonical entries older than the indirection. *)
+let hidden_name name =
+  if name <> "" && name.[0] = '_' then true
+  else
+    try
+      for i = 1 to String.length name - 2 do
+        if name.[i] = '_' && name.[i + 1] = '_' then
+          raise Exit
+      done;
+      false
+    with Exit -> true
+
+let hidden_ident id =
+  if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
+  else hidden_name (Ident.name id)
+
+let hidden_definition deprecated name =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_name name
+
+let hidden_base_definition deprecated id =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_ident id
+
 module rec Type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Type.t option -> t
+  val base : Origin.t -> Ident.t -> Desc.Type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Type.t option -> t
+  val child :
+    Module.normalized -> string -> Desc.Type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -251,6 +283,8 @@ module rec Type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -265,7 +299,7 @@ end = struct
   open Desc.Type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Nth of int
     | Subst of Path.t * int list
@@ -274,10 +308,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -287,28 +323,36 @@ end = struct
     | Some Fresh -> Defined
     | Some (Nth n) -> Nth n
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -329,7 +373,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Nth _ | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -371,7 +415,7 @@ end = struct
         | exception Not_found -> Path(None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -379,9 +423,12 @@ and Class_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Class_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Class_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Class_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Class_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -390,6 +437,8 @@ and Class_type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -402,7 +451,7 @@ end = struct
   open Desc.Class_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Subst of Path.t * int list
     | Unknown
@@ -410,10 +459,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -422,28 +473,36 @@ end = struct
     | None -> Unknown
     | Some Fresh -> Defined
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -464,7 +523,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_class_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -502,7 +561,7 @@ end = struct
         | exception Not_found -> (None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -510,9 +569,12 @@ and Module_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Module_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Module_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Module_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -522,6 +584,8 @@ and Module_type : sig
 
   val path : Graph.t -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : Graph.t -> t -> Sort.t
 
 end = struct
@@ -529,50 +593,60 @@ end = struct
   open Desc.Module_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Unknown
 
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot (Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -593,7 +667,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -624,9 +698,11 @@ and Module : sig
 
   type normalized
 
-  val base : Origin.t -> Ident.t -> Desc.Module.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module.t option -> Desc.deprecated -> t
 
-  val child : normalized -> string -> Desc.Module.t option -> t
+  val child :
+    normalized -> string -> Desc.Module.t option -> Desc.deprecated -> t
 
   val application : normalized -> t -> Desc.Module.t option -> t
 
@@ -637,6 +713,8 @@ and Module : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -681,7 +759,7 @@ end = struct
           modules : t String_map.t; }
 
   and definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Signature of
         { mutable components : components }
     | Functor of
@@ -692,15 +770,18 @@ end = struct
   and t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
@@ -712,14 +793,15 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
@@ -730,9 +812,9 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let application func arg desc =
     let func_origin = Module.raw_origin func in
@@ -744,6 +826,7 @@ end = struct
     let func_path = Module.raw_path func in
     let arg_path = Module.raw_path arg in
     let path = Path.Papply(func_path, arg_path) in
+    let hidden = false in
     let definition =
       match desc with
       | None -> Unknown
@@ -754,17 +837,23 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -787,7 +876,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Signature _ | Functor _ | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -820,27 +909,27 @@ end = struct
   let force root t =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Unknown
     | Functor _
     | Signature { components = Forced _ } -> t
     | Signature ({ components = Unforced components; _} as r) -> begin
         let rec loop types class_types module_types modules = function
           | [] -> Forced { types; class_types; module_types; modules }
-          | Type(name, desc) :: rest ->
-              let typ = Type.child t name (Some desc) in
+          | Type(name, desc, dpr) :: rest ->
+              let typ = Type.child t name (Some desc) dpr in
               let types = String_map.add name typ types in
               loop types class_types module_types modules rest
-          | Class_type(name, desc) :: rest ->
-              let clty = Class_type.child t name (Some desc) in
+          | Class_type(name, desc, dpr) :: rest ->
+              let clty = Class_type.child t name (Some desc) dpr in
               let class_types = String_map.add name clty class_types in
               loop types class_types module_types modules rest
-          | Module_type(name, desc) :: rest ->
-              let mty = Module_type.child t name (Some desc) in
+          | Module_type(name, desc, dpr) :: rest ->
+              let mty = Module_type.child t name (Some desc) dpr in
               let module_types = String_map.add name mty module_types in
               loop types class_types module_types modules rest
-          | Module(name, desc) :: rest ->
-              let md = Module.child t name (Some desc) in
+          | Module(name, desc, dpr) :: rest ->
+              let md = Module.child t name (Some desc) dpr in
               let modules = String_map.add name md modules in
               loop types class_types module_types modules rest
         in
@@ -853,7 +942,7 @@ end = struct
   let types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -863,7 +952,7 @@ end = struct
   let class_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -873,7 +962,7 @@ end = struct
   let module_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -883,7 +972,7 @@ end = struct
   let modules root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -893,11 +982,11 @@ end = struct
   let find_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Type.child t name None
+        Type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { types; _ }; _ } ->
@@ -906,11 +995,11 @@ end = struct
   let find_class_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Class_type.child t name None
+        Class_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { class_types; _ }; _ } ->
@@ -919,11 +1008,11 @@ end = struct
   let find_module_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module_type.child t name None
+        Module_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { module_types; _ }; _ } ->
@@ -932,11 +1021,11 @@ end = struct
   let find_module root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module.child t name None
+        Module.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { modules; _ }; _ } ->
@@ -945,7 +1034,7 @@ end = struct
   let find_application root t path =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Signature _ -> raise Not_found
     | Unknown ->
         let arg = Graph.find_module root path in
@@ -1024,10 +1113,14 @@ and Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -1060,6 +1153,14 @@ and Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end = struct
 
@@ -1148,36 +1249,36 @@ end = struct
   let add t descs =
     let rec loop acc diff declarations = function
       | [] -> loop_declarations acc diff declarations
-      | Component.Type(origin, id, desc, source) :: rest ->
+      | Component.Type(origin, id, desc, source, dpr) :: rest ->
           let prev = previous_type acc id in
-          let typ = Type.base origin id (Some desc) in
+          let typ = Type.base origin id (Some desc) dpr in
           let types = Ident_map.add id typ acc.types in
           let type_names = add_name source id acc.type_names in
           let item = Diff.Item.Type(id, typ, prev) in
           let diff = item :: diff in
           let acc = { acc with types; type_names } in
           loop acc diff declarations rest
-      | Component.Class_type(origin,id, desc, source) :: rest ->
+      | Component.Class_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_class_type acc id in
-          let clty = Class_type.base origin id (Some desc) in
+          let clty = Class_type.base origin id (Some desc) dpr in
           let class_types = Ident_map.add id clty acc.class_types in
           let class_type_names = add_name source id acc.class_type_names in
           let item = Diff.Item.Class_type(id, clty, prev) in
           let diff = item :: diff in
           let acc = { acc with class_types; class_type_names } in
           loop acc diff declarations rest
-      | Component.Module_type(origin,id, desc, source) :: rest ->
+      | Component.Module_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module_type acc id in
-          let mty = Module_type.base origin id (Some desc) in
+          let mty = Module_type.base origin id (Some desc) dpr in
           let module_types = Ident_map.add id mty acc.module_types in
           let module_type_names = add_name source id acc.module_type_names in
           let item = Diff.Item.Module_type(id, mty, prev) in
           let diff = item :: diff in
           let acc = { acc with module_types; module_type_names } in
           loop acc diff declarations rest
-      | Component.Module(origin,id, desc, source) :: rest ->
+      | Component.Module(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module acc id in
-          let md = Module.base origin id (Some desc) in
+          let md = Module.base origin id (Some desc) dpr in
           let modules = Ident_map.add id md acc.modules in
           let module_names = add_name source id acc.module_names in
           let item = Diff.Item.Module(id, md, prev) in
@@ -1348,88 +1449,92 @@ end = struct
     | exception Not_found -> Path.Pident id
     | md -> Module.path t md
 
-  let rec is_module_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_path t) ids in
-            let path = canonical_module_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_path t) ids in
+        let path = canonical_module_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let rec is_module_path_visible t = function
+    | Path.Pident id -> is_module_ident_visible t id
     | Path.Pdot(path, _, _) ->
         is_module_path_visible t path
     | Path.Papply(path1, path2) ->
         is_module_path_visible t path1
         && is_module_path_visible t path2
 
-  let is_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_type_path t) ids in
-            let path = canonical_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_type_path t) ids in
+        let path = canonical_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_type_path_visible t = function
+    | Path.Pident id -> is_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_type_path_visible: \
            invalid type path"
 
-  let is_class_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.class_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_class_type_path t) ids in
-            let path = canonical_class_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_class_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.class_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_class_type_path t) ids in
+        let path = canonical_class_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_class_type_path_visible t = function
+    | Path.Pident id -> is_class_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_class_type_path_visible: \
            invalid class type path"
 
-  let is_module_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_type_path t) ids in
-            let path = canonical_module_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_type_path t) ids in
+        let path = canonical_module_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_module_type_path_visible t = function
+    | Path.Pident id -> is_module_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith

--- a/src/ocaml/typing/403/short_paths_graph.mli
+++ b/src/ocaml/typing/403/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -255,10 +255,10 @@ and short_paths_addition =
   | Class_type of Ident.t * class_type_declaration
   | Module_type of Ident.t * modtype_declaration
   | Module of Ident.t * module_declaration * module_components
-  | Type_open of Ident.t * Path.t
-  | Class_type_open of Ident.t * Path.t
-  | Module_type_open of Ident.t * Path.t
-  | Module_open of Ident.t * Path.t
+  | Type_open of Ident.t * Path.t * type_declaration
+  | Class_type_open of Ident.t * Path.t * class_type_declaration
+  | Module_type_open of Ident.t * Path.t * modtype_declaration
+  | Module_open of Ident.t * Path.t * module_components
 
 let copy_local ~from env =
   { env with
@@ -447,11 +447,25 @@ let register_pers_for_short_paths ps =
       ([], []) ps.ps_crcs
   in
   let path = Pident (Ident.create_persistent ps.ps_name) in
-  let desc =
-    Short_paths.Desc.Module.(Fresh
-      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  let components =
+    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
   in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Deprecated _ -> true
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name
+    deps alias_deps desc deprecated
 
 (* Reading persistent structures from .cmi files *)
 
@@ -1459,7 +1473,7 @@ let short_paths_type predef id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Type(id, decl)
-      | _ -> Type_open(id, path)
+      | _ -> Type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1473,7 +1487,7 @@ let short_paths_class_type id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Class_type(id, decl)
-      | _ -> Class_type_open(id, path)
+      | _ -> Class_type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1484,7 +1498,7 @@ let short_paths_module_type id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Module_type(id, decl)
-      | _ -> Module_type_open(id, path)
+      | _ -> Module_type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1495,7 +1509,7 @@ let short_paths_module id path decl comps old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Module(id, decl, comps)
-      | _ -> Module_open(id, path)
+      | _ -> Module_open(id, path, comps)
     in
     addition :: old
   end
@@ -2275,6 +2289,15 @@ let short_paths_module_type_desc mty =
   | Some (Mty_signature _ | Mty_functor _) -> Fresh
   | Some (Mty_alias _) -> assert false
 
+let deprecated_of_string_opt stro =
+  match stro with
+  | None -> Short_paths.Desc.Not_deprecated
+  | Some _ -> Short_paths.Desc.Deprecated
+
+let deprecated_of_attributes attrs =
+  deprecated_of_string_opt
+    (Builtin_attributes.deprecated_of_attrs attrs)
+
 let rec short_paths_module_desc env mpath mty comp =
   let open Short_paths.Desc.Module in
   match mty with
@@ -2303,7 +2326,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name ((decl, _), _) acc ->
              let desc = short_paths_type_desc decl in
-             let item = Short_paths.Desc.Module.Type(name, desc) in
+             let depr = deprecated_of_attributes decl.type_attributes in
+             let item = Short_paths.Desc.Module.Type(name, desc, depr) in
              item :: acc)
           c.comp_types []
       in
@@ -2311,7 +2335,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (clty, _) acc ->
              let desc = short_paths_class_type_desc clty in
-             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             let depr = deprecated_of_attributes clty.clty_attributes in
+             let item = Short_paths.Desc.Module.Class_type(name, desc, depr) in
              item :: acc)
           c.comp_cltypes comps
       in
@@ -2319,7 +2344,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (mtd, _) acc ->
              let desc = short_paths_module_type_desc mtd.mtd_type in
-             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             let depr = deprecated_of_attributes mtd.mtd_attributes in
+             let item = Short_paths.Desc.Module.Module_type(name, desc, depr) in
              item :: acc)
           c.comp_modtypes comps
       in
@@ -2334,7 +2360,8 @@ and short_paths_module_components_desc env mpath comp =
              let mty = EnvLazy.force subst_modtype_maker data in
              let mpath = Pdot(mpath, name, 0) in
              let desc = short_paths_module_desc env mpath mty.md_type comps in
-             let item = Short_paths.Desc.Module.Module(name, desc) in
+             let depr = deprecated_of_string_opt comps.deprecated in
+             let item = Short_paths.Desc.Module.Module(name, desc, depr) in
              item :: acc)
           c.comp_modules comps
       in
@@ -2365,32 +2392,50 @@ let short_paths_additions_desc env additions =
     (function
       | Type(id, decl) ->
           let desc = short_paths_type_desc decl in
-          Short_paths.Desc.Type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes decl.type_attributes in
+          Short_paths.Desc.Type(id, desc, source, depr)
       | Class_type(id, clty) ->
           let desc = short_paths_class_type_desc clty in
-          Short_paths.Desc.Class_type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes clty.clty_attributes in
+          Short_paths.Desc.Class_type(id, desc, source, depr)
       | Module_type(id, mtd) ->
           let desc = short_paths_module_type_desc mtd.mtd_type in
-          Short_paths.Desc.Module_type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes mtd.mtd_attributes in
+          Short_paths.Desc.Module_type(id, desc, source, depr)
       | Module(id, md, comps) ->
-          let desc = short_paths_module_desc env (Pident id) md.md_type comps in
-          Short_paths.Desc.Module(id, desc, true)
-      | Type_open(id, path) ->
+          let desc =
+            short_paths_module_desc env (Pident id) md.md_type comps
+          in
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_string_opt comps.deprecated in
+          Short_paths.Desc.Module(id, desc, source, depr)
+      | Type_open(id, path, decl) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Type.Alias path in
-          Short_paths.Desc.Type(id, desc, false)
-      | Class_type_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes decl.type_attributes in
+          Short_paths.Desc.Type(id, desc, source, depr)
+      | Class_type_open(id, path, clty) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Class_type.Alias path in
-          Short_paths.Desc.Class_type(id, desc, false)
-      | Module_type_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes clty.clty_attributes in
+          Short_paths.Desc.Class_type(id, desc, source, depr)
+      | Module_type_open(id, path, mtd) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Module_type.Alias path in
-          Short_paths.Desc.Module_type(id, desc, false)
-      | Module_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes mtd.mtd_attributes in
+          Short_paths.Desc.Module_type(id, desc, source, depr)
+      | Module_open(id, path, comps) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Module.Alias path in
-          Short_paths.Desc.Module(id, desc, false))
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_string_opt comps.deprecated in
+          Short_paths.Desc.Module(id, desc, source, depr))
     additions
 
 let () =

--- a/src/ocaml/typing/404/short_paths.ml
+++ b/src/ocaml/typing/404/short_paths.ml
@@ -300,43 +300,7 @@ module Origin_range_tbl = struct
 
 end
 
-module Height = struct
-
-  include Natural.Make_no_zero()
-
-  let hidden_name name =
-    if name <> "" && name.[0] = '_' then true
-    else
-      try
-        for i = 1 to String.length name - 2 do
-          if name.[i] = '_' && name.[i + 1] = '_' then
-            raise Exit
-        done;
-        false
-      with Exit -> true
-
-  let hidden_ident id =
-    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
-    else hidden_name (Ident.name id)
-
-  let measure_name name =
-    if hidden_name name then maximum
-    else one
-
-  let measure_ident id =
-    if hidden_ident id then maximum
-    else one
-
-  let rec measure_path = function
-    | Path.Pident id ->
-        measure_ident id
-    | Path.Pdot(p, name, _) ->
-        if hidden_name name then maximum
-        else succ (measure_path p)
-    | Path.Papply(p1, p2) ->
-        plus (measure_path p1) (measure_path p2)
-
-end
+module Height = Natural.Make_no_zero()
 
 module Todo = struct
 
@@ -1121,8 +1085,9 @@ module Shortest = struct
     { kind; graph; sections; todos }
 
   let local_or_open conc =
-    if conc then Component.Local
-    else Component.Open
+    match conc with
+    | Desc.Local -> Component.Local
+    | Desc.Open -> Component.Open
 
   let env parent desc =
     update parent;
@@ -1132,14 +1097,14 @@ module Shortest = struct
       List.map
         (fun desc ->
            match desc with
-           | Desc.Type(id, desc, conc) ->
-               Component.Type(origin, id, desc, local_or_open conc)
-           | Desc.Class_type(id, desc, conc) ->
-               Component.Class_type(origin, id, desc, local_or_open conc)
-           | Desc.Module_type(id, desc, conc) ->
-               Component.Module_type(origin, id, desc, local_or_open conc)
-           | Desc.Module(id, desc, conc) ->
-               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Type(id, desc, conc, dpr) ->
+               Component.Type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Class_type(id, desc, conc, dpr) ->
+               Component.Class_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module_type(id, desc, conc, dpr) ->
+               Component.Module_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module(id, desc, conc, dpr) ->
+               Component.Module(origin, id, desc, local_or_open conc, dpr)
            | Desc.Declare_type id ->
                Component.Declare_type(origin, id)
            | Desc.Declare_class_type id ->
@@ -1244,28 +1209,28 @@ module Shortest = struct
     in
     String_map.iter
       (fun name typ ->
-         if not (Height.hidden_name name) then begin
+         if not (Type.hidden typ) then begin
            let path = Path.Pdot(path, name, 0) in
            process_type t height path typ
          end)
       types;
     String_map.iter
-      (fun name mty ->
-         if not (Height.hidden_name name) then begin
+      (fun name clty ->
+         if not (Class_type.hidden clty) then begin
            let path = Path.Pdot(path, name, 0) in
-           process_class_type t height path mty
+           process_class_type t height path clty
          end)
       class_types;
     String_map.iter
       (fun name mty ->
-         if not (Height.hidden_name name) then begin
+         if not (Module_type.hidden mty) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module_type t height path mty
          end)
       module_types;
     String_map.iter
       (fun name md ->
-         if not (Height.hidden_name name) then begin
+         if not (Module.hidden md) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module t height path seen md
          end)
@@ -1280,22 +1245,22 @@ module Shortest = struct
           List.iter
             (function
               | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Type.hidden typ) then begin
                     let path = Path.Pident id in
                     process_type t height path typ
                   end
-              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+              | Todo.Item.Base (Diff.Item.Class_type(id, clty, _)) ->
+                  if not (Class_type.hidden clty) then begin
                     let path = Path.Pident id in
-                    process_class_type t height path mty
+                    process_class_type t height path clty
                   end
               | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module_type.hidden mty) then begin
                     let path = Path.Pident id in
                     process_module_type t height path mty
                   end
               | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module.hidden md) then begin
                     let path = Path.Pident id in
                     process_module t height path Path_set.empty md
                   end
@@ -1413,10 +1378,6 @@ module Shortest = struct
       | Module_type : Module_type.t kind
       | Module : Module.t kind
 
-    type suffix =
-      { names : string list;
-        height : Height.t; }
-
     type name =
       { name : string;
         height : Height.t; }
@@ -1450,7 +1411,6 @@ module Shortest = struct
             max: Height.t;
             func : Module.t t;
             arg : Module.t t;
-            suffix : suffix option;
             func_first : bool;
             searched : bool;
             finished : bool; }
@@ -1459,6 +1419,16 @@ module Shortest = struct
       | Ident { min; _ } -> min
       | Dot { min; _ } -> min
       | Application { min; _ } -> min
+
+    let max_height = function
+      | Ident { max; _ } -> max
+      | Dot { max; _ } -> max
+      | Application { max; _ } -> max
+
+    let search_origin = function
+      | Ident { origin; _ } -> origin
+      | Dot { origin; _ } -> origin
+      | Application { origin; _ } -> origin
 
     let finished = function
       | Ident { finished; _ } -> finished
@@ -1470,163 +1440,99 @@ module Shortest = struct
       | Dot { best; _ } -> best
       | Application { best; _ } -> best
 
-    let min_application fst snd suffix =
-      let base = Height.plus (min_height fst) (min_height snd) in
-      match suffix with
-      | None -> base
-      | Some { names = _; height } -> Height.plus base height
+    let min_application fst snd =
+      Height.plus (min_height fst) (min_height snd)
+
+    let max_application fst snd =
+      Height.plus (max_height fst) (max_height snd)
 
     let min_dot parent name =
       let base = min_height parent in
       Height.plus base name.height
 
-    let path_application fst snd suffix =
-      let base = Path.Papply(best fst, best snd) in
-      match suffix with
-      | None -> base
-      | Some { names; _ } ->
-          List.fold_left
-            (fun acc name -> Path.Pdot(acc, name, 0))
-            base names
+    let path_application fst snd =
+      Path.Papply(best fst, best snd)
 
     let path_dot parent name =
-      let base = best parent in
-      Path.Pdot(base, name.name, 0)
+      Path.Pdot(best parent, name.name, 0)
 
-    let create (type k) shortest (kind : k kind) (node : k) =
-      let rec loop :
-        type k. k kind -> k -> Origin.t -> Path.t ->
-          Height.t -> string list -> Path.t -> k t =
-        fun kind node origin best max suffix path ->
+    let is_visible_ident (type k) graph (kind : k kind) id =
+      match kind with
+      | Type -> Graph.is_type_ident_visible graph id
+      | Class_type -> Graph.is_class_type_ident_visible graph id
+      | Module_type -> Graph.is_module_type_ident_visible graph id
+      | Module -> Graph.is_module_ident_visible graph id
+
+    let create (type k) shortest (kind : k kind) canonical_path =
+      let rec loop : type k. k kind -> Path.t -> k t =
+        fun kind path ->
+          let graph = shortest.graph in
+          let (node : k), origin, hidden =
+            match kind with
+            | Type ->
+                let node = Graph.find_type graph path in
+                let origin = Type.origin graph node in
+                let hidden = Type.hidden node in
+                node, origin, hidden
+            | Class_type ->
+                let node = Graph.find_class_type graph path in
+                let origin = Class_type.origin graph node in
+                let hidden = Class_type.hidden node in
+                node, origin, hidden
+            | Module_type ->
+                let node = Graph.find_module_type graph path in
+                let origin = Module_type.origin graph node in
+                let hidden = Module_type.hidden node in
+                node, origin, hidden
+            | Module ->
+                let node = Graph.find_module graph path in
+                let origin = Module.origin graph node in
+                let hidden = Module.hidden node in
+                node, origin, hidden
+          in
+          let best = path in
           match path with
-          | Path.Pident _ ->
+          | Path.Pident id ->
+              let max =
+                if is_visible_ident graph kind id && not hidden then
+                  Height.one
+                else
+                  Height.maximum
+              in
               let min = Height.one in
               let finished = false in
-              Ident
-                { kind; node; origin; best; min; max; finished; }
+              Ident { kind; node; origin; best; min; max; finished }
           | Path.Pdot(parent, name, _) ->
-              let graph = shortest.graph in
-              let parent_md = Graph.find_module graph parent in
-              let parent_max = Height.measure_path parent in
-              let parent_origin = Module.origin graph parent_md in
-              let parent =
-                loop Module parent_md parent_origin
-                  parent parent_max [] parent
-              in
+              let parent = loop Module parent in
               let finished = false in
-              let name =
-                let height = Height.measure_name name in
-                { name; height }
+              let name_height =
+                if not hidden then Height.one
+                else Height.maximum
               in
+              let name = { name; height = name_height } in
               let searched = false in
+              let max = Height.plus (max_height parent) name_height in
               let min = Height.one in
               Dot
                 { kind; node; origin; best; min; max;
                   parent; name; searched; finished }
           | Path.Papply(func, arg) ->
-              let graph = shortest.graph in
-              let func_md = Graph.find_module graph func in
-              let func_max = Height.measure_path func in
-              let func_origin = Module.origin graph func_md in
-              let func =
-                loop Module func_md func_origin func func_max [] func
-              in
-              let arg_md = Graph.find_module graph arg in
-              let arg_max = Height.measure_path arg in
-              let arg_origin = Module.origin graph arg_md in
-              let arg =
-                loop Module arg_md arg_origin arg arg_max [] arg
-              in
+              let func = loop Module func in
+              let arg = loop Module arg in
               let func_first =
-                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+                Rev_deps.before (rev_deps shortest)
+                  (search_origin arg) (search_origin func)
               in
               let finished = false in
-              let suffix =
-                match suffix with
-                | [] -> None
-                | fst :: rest ->
-                  let names = suffix in
-                  let height =
-                    List.fold_left
-                      (fun acc name ->
-                         Height.plus acc (Height.measure_name name))
-                      (Height.measure_name fst) rest
-                  in
-                  Some { names; height }
-              in
-              let searched, min =
-                match kind with
-                | Type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Class_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module ->
-                    (* There are no module aliases containing extended paths *)
-                    let searched = true in
-                    let min = min_application func arg suffix in
-                    searched, min
-              in
+              (* There are no module aliases containing extended paths *)
+              let searched = true in
+              let max = max_application func arg in
+              let min = min_application func arg in
               Application
                 { kind; node; origin; best; min; max;
-                  func; arg; suffix; func_first; searched; finished }
+                  func; arg; func_first; searched; finished }
       in
-      let graph = shortest.graph in
-      let canonical_path, origin, max =
-        match kind with
-        | Type ->
-            let canonical_path = Type.path graph node in
-            let origin = Type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Class_type ->
-            let canonical_path = Class_type.path graph node in
-            let origin = Class_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_class_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module_type ->
-            let canonical_path = Module_type.path graph node in
-            let origin = Module_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module ->
-            let canonical_path = Module.path graph node in
-            let origin = Module.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-      in
-      loop kind node origin canonical_path max [] canonical_path
+      loop kind canonical_path
 
     let find (type k) shortest origin height (kind : k kind) (node : k) =
       let sections = force shortest origin height in
@@ -1710,15 +1616,13 @@ module Shortest = struct
                 in
                 let fst, snd =
                   let should_try_app =
-                    Height.equal
-                      (min_application fst snd r.suffix) r.min
+                    Height.equal (min_application fst snd) r.min
                   in
                   if not should_try_app then fst, snd
                   else begin
                     let fst = step shortest fst in
                     let should_try_app =
-                      Height.equal
-                        (min_application fst snd r.suffix) r.min
+                      Height.equal (min_application fst snd) r.min
                     in
                     if not should_try_app then fst, snd
                     else fst, step shortest snd
@@ -1730,11 +1634,10 @@ module Shortest = struct
                 in
                 let found =
                   finished func && finished arg
-                  && Height.equal
-                       (min_application fst snd r.suffix) r.min
+                  && Height.equal (min_application fst snd) r.min
                 in
                 if found then begin
-                  let best = path_application func arg r.suffix in
+                  let best = path_application func arg in
                   let max = r.min in
                   let finished = true in
                   Application
@@ -1743,7 +1646,7 @@ module Shortest = struct
                   let finished =
                     searched
                     && Height.less_than_or_equal
-                         r.max (min_application fst snd r.suffix)
+                         r.max (min_application fst snd)
                   in
                   let min = if finished then r.max else Height.succ r.min in
                   Application
@@ -1778,7 +1681,8 @@ module Shortest = struct
     match Type.resolve t.graph typ with
     | Type.Nth n -> Nth n
     | Type.Path(subst, typ) ->
-      let search = Search.create t Search.Type typ in
+      let canonical_path = Type.path t.graph typ in
+      let search = Search.create t Search.Type canonical_path in
       let path = Search.perform t search in
       Path(subst, path)
 
@@ -1793,33 +1697,38 @@ module Shortest = struct
   let find_type_simple t path =
     update t;
     let typ = Graph.find_type t.graph path in
-    let search = Search.create t Search.Type typ in
+    let canonical_path = Type.path t.graph typ in
+    let search = Search.create t Search.Type canonical_path in
     Search.perform t search
 
   let find_class_type t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
     let subst, clty = Class_type.resolve t.graph clty in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     let path = Search.perform t search in
     (subst, path)
 
   let find_class_type_simple t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     Search.perform t search
 
   let find_module_type t path =
     update t;
     let mty = Graph.find_module_type t.graph path in
-    let search = Search.create t Search.Module_type mty in
+    let canonical_path = Module_type.path t.graph mty in
+    let search = Search.create t Search.Module_type canonical_path in
     Search.perform t search
 
   let find_module t path =
     update t;
     let md = Graph.find_module t.graph path in
-    let search = Search.create t Search.Module md in
+    let canonical_path = Module.path t.graph md in
+    let search = Search.create t Search.Module canonical_path in
     Search.perform t search
 
 end
@@ -1832,7 +1741,8 @@ module Basis = struct
     { name : string;
       depends : string list;
       alias_depends : string list;
-      desc : Desc.Module.t; }
+      desc : Desc.Module.t;
+      deprecated : Desc.deprecated; }
 
   type t =
     { mutable next_dep : Dependency.t;
@@ -1879,11 +1789,11 @@ module Basis = struct
   let update_shortest t additions loads =
     let components =
       List.map
-        (fun { name; desc; _ } ->
+        (fun { name; desc; deprecated; _ } ->
            let index = String_map.find name t.assignment in
            let origin = Origin.Dependency index in
            let id = Ident.global name in
-           Component.Module(origin, id, desc, Component.Global))
+           Component.Module(origin, id, desc, Component.Global, deprecated))
         loads
     in
     let components =
@@ -1927,8 +1837,9 @@ module Basis = struct
   let add t name =
     t.pending_additions <- String_set.add name t.pending_additions
 
-  let load t name depends alias_depends desc =
-    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+  let load t name depends alias_depends desc deprecated =
+    let load = { name; depends; alias_depends; desc; deprecated } in
+    t.pending_loads <- load :: t.pending_loads
 
 end
 

--- a/src/ocaml/typing/404/short_paths.mli
+++ b/src/ocaml/typing/404/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/404/short_paths_graph.ml
+++ b/src/ocaml/typing/404/short_paths_graph.ml
@@ -80,6 +80,10 @@ module Path_set = Set.Make(Path)
 
 module Desc = struct
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type = struct
 
     type t =
@@ -110,10 +114,10 @@ module Desc = struct
   module Module = struct
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -127,11 +131,15 @@ module Desc = struct
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -234,15 +242,39 @@ module Origin = struct
 
 end
 
-(* CR lwhite: Should probably short-circuit indirections if they are to
-    canonical entries older than the indirection. *)
+let hidden_name name =
+  if name <> "" && name.[0] = '_' then true
+  else
+    try
+      for i = 1 to String.length name - 2 do
+        if name.[i] = '_' && name.[i + 1] = '_' then
+          raise Exit
+      done;
+      false
+    with Exit -> true
+
+let hidden_ident id =
+  if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
+  else hidden_name (Ident.name id)
+
+let hidden_definition deprecated name =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_name name
+
+let hidden_base_definition deprecated id =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_ident id
+
 module rec Type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Type.t option -> t
+  val base : Origin.t -> Ident.t -> Desc.Type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Type.t option -> t
+  val child :
+    Module.normalized -> string -> Desc.Type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -251,6 +283,8 @@ module rec Type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -265,7 +299,7 @@ end = struct
   open Desc.Type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Nth of int
     | Subst of Path.t * int list
@@ -274,10 +308,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -287,28 +323,36 @@ end = struct
     | Some Fresh -> Defined
     | Some (Nth n) -> Nth n
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -329,7 +373,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Nth _ | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -371,7 +415,7 @@ end = struct
         | exception Not_found -> Path(None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -379,9 +423,12 @@ and Class_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Class_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Class_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Class_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Class_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -390,6 +437,8 @@ and Class_type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -402,7 +451,7 @@ end = struct
   open Desc.Class_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Subst of Path.t * int list
     | Unknown
@@ -410,10 +459,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -422,28 +473,36 @@ end = struct
     | None -> Unknown
     | Some Fresh -> Defined
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -464,7 +523,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_class_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -502,7 +561,7 @@ end = struct
         | exception Not_found -> (None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -510,9 +569,12 @@ and Module_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Module_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Module_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Module_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -522,6 +584,8 @@ and Module_type : sig
 
   val path : Graph.t -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : Graph.t -> t -> Sort.t
 
 end = struct
@@ -529,50 +593,60 @@ end = struct
   open Desc.Module_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Unknown
 
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot (Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -593,7 +667,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -624,9 +698,11 @@ and Module : sig
 
   type normalized
 
-  val base : Origin.t -> Ident.t -> Desc.Module.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module.t option -> Desc.deprecated -> t
 
-  val child : normalized -> string -> Desc.Module.t option -> t
+  val child :
+    normalized -> string -> Desc.Module.t option -> Desc.deprecated -> t
 
   val application : normalized -> t -> Desc.Module.t option -> t
 
@@ -637,6 +713,8 @@ and Module : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -681,7 +759,7 @@ end = struct
           modules : t String_map.t; }
 
   and definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Signature of
         { mutable components : components }
     | Functor of
@@ -692,15 +770,18 @@ end = struct
   and t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
@@ -712,14 +793,15 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
@@ -730,9 +812,9 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let application func arg desc =
     let func_origin = Module.raw_origin func in
@@ -744,6 +826,7 @@ end = struct
     let func_path = Module.raw_path func in
     let arg_path = Module.raw_path arg in
     let path = Path.Papply(func_path, arg_path) in
+    let hidden = false in
     let definition =
       match desc with
       | None -> Unknown
@@ -754,17 +837,23 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -787,7 +876,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Signature _ | Functor _ | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -820,27 +909,27 @@ end = struct
   let force root t =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Unknown
     | Functor _
     | Signature { components = Forced _ } -> t
     | Signature ({ components = Unforced components; _} as r) -> begin
         let rec loop types class_types module_types modules = function
           | [] -> Forced { types; class_types; module_types; modules }
-          | Type(name, desc) :: rest ->
-              let typ = Type.child t name (Some desc) in
+          | Type(name, desc, dpr) :: rest ->
+              let typ = Type.child t name (Some desc) dpr in
               let types = String_map.add name typ types in
               loop types class_types module_types modules rest
-          | Class_type(name, desc) :: rest ->
-              let clty = Class_type.child t name (Some desc) in
+          | Class_type(name, desc, dpr) :: rest ->
+              let clty = Class_type.child t name (Some desc) dpr in
               let class_types = String_map.add name clty class_types in
               loop types class_types module_types modules rest
-          | Module_type(name, desc) :: rest ->
-              let mty = Module_type.child t name (Some desc) in
+          | Module_type(name, desc, dpr) :: rest ->
+              let mty = Module_type.child t name (Some desc) dpr in
               let module_types = String_map.add name mty module_types in
               loop types class_types module_types modules rest
-          | Module(name, desc) :: rest ->
-              let md = Module.child t name (Some desc) in
+          | Module(name, desc, dpr) :: rest ->
+              let md = Module.child t name (Some desc) dpr in
               let modules = String_map.add name md modules in
               loop types class_types module_types modules rest
         in
@@ -853,7 +942,7 @@ end = struct
   let types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -863,7 +952,7 @@ end = struct
   let class_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -873,7 +962,7 @@ end = struct
   let module_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -883,7 +972,7 @@ end = struct
   let modules root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -893,11 +982,11 @@ end = struct
   let find_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Type.child t name None
+        Type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { types; _ }; _ } ->
@@ -906,11 +995,11 @@ end = struct
   let find_class_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Class_type.child t name None
+        Class_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { class_types; _ }; _ } ->
@@ -919,11 +1008,11 @@ end = struct
   let find_module_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module_type.child t name None
+        Module_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { module_types; _ }; _ } ->
@@ -932,11 +1021,11 @@ end = struct
   let find_module root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module.child t name None
+        Module.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { modules; _ }; _ } ->
@@ -945,7 +1034,7 @@ end = struct
   let find_application root t path =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Signature _ -> raise Not_found
     | Unknown ->
         let arg = Graph.find_module root path in
@@ -1024,10 +1113,14 @@ and Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -1060,6 +1153,14 @@ and Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end = struct
 
@@ -1148,36 +1249,36 @@ end = struct
   let add t descs =
     let rec loop acc diff declarations = function
       | [] -> loop_declarations acc diff declarations
-      | Component.Type(origin, id, desc, source) :: rest ->
+      | Component.Type(origin, id, desc, source, dpr) :: rest ->
           let prev = previous_type acc id in
-          let typ = Type.base origin id (Some desc) in
+          let typ = Type.base origin id (Some desc) dpr in
           let types = Ident_map.add id typ acc.types in
           let type_names = add_name source id acc.type_names in
           let item = Diff.Item.Type(id, typ, prev) in
           let diff = item :: diff in
           let acc = { acc with types; type_names } in
           loop acc diff declarations rest
-      | Component.Class_type(origin,id, desc, source) :: rest ->
+      | Component.Class_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_class_type acc id in
-          let clty = Class_type.base origin id (Some desc) in
+          let clty = Class_type.base origin id (Some desc) dpr in
           let class_types = Ident_map.add id clty acc.class_types in
           let class_type_names = add_name source id acc.class_type_names in
           let item = Diff.Item.Class_type(id, clty, prev) in
           let diff = item :: diff in
           let acc = { acc with class_types; class_type_names } in
           loop acc diff declarations rest
-      | Component.Module_type(origin,id, desc, source) :: rest ->
+      | Component.Module_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module_type acc id in
-          let mty = Module_type.base origin id (Some desc) in
+          let mty = Module_type.base origin id (Some desc) dpr in
           let module_types = Ident_map.add id mty acc.module_types in
           let module_type_names = add_name source id acc.module_type_names in
           let item = Diff.Item.Module_type(id, mty, prev) in
           let diff = item :: diff in
           let acc = { acc with module_types; module_type_names } in
           loop acc diff declarations rest
-      | Component.Module(origin,id, desc, source) :: rest ->
+      | Component.Module(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module acc id in
-          let md = Module.base origin id (Some desc) in
+          let md = Module.base origin id (Some desc) dpr in
           let modules = Ident_map.add id md acc.modules in
           let module_names = add_name source id acc.module_names in
           let item = Diff.Item.Module(id, md, prev) in
@@ -1348,88 +1449,92 @@ end = struct
     | exception Not_found -> Path.Pident id
     | md -> Module.path t md
 
-  let rec is_module_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_path t) ids in
-            let path = canonical_module_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_path t) ids in
+        let path = canonical_module_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let rec is_module_path_visible t = function
+    | Path.Pident id -> is_module_ident_visible t id
     | Path.Pdot(path, _, _) ->
         is_module_path_visible t path
     | Path.Papply(path1, path2) ->
         is_module_path_visible t path1
         && is_module_path_visible t path2
 
-  let is_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_type_path t) ids in
-            let path = canonical_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_type_path t) ids in
+        let path = canonical_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_type_path_visible t = function
+    | Path.Pident id -> is_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_type_path_visible: \
            invalid type path"
 
-  let is_class_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.class_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_class_type_path t) ids in
-            let path = canonical_class_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_class_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.class_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_class_type_path t) ids in
+        let path = canonical_class_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_class_type_path_visible t = function
+    | Path.Pident id -> is_class_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_class_type_path_visible: \
            invalid class type path"
 
-  let is_module_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_type_path t) ids in
-            let path = canonical_module_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_type_path t) ids in
+        let path = canonical_module_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_module_type_path_visible t = function
+    | Path.Pident id -> is_module_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith

--- a/src/ocaml/typing/404/short_paths_graph.mli
+++ b/src/ocaml/typing/404/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -255,10 +255,10 @@ and short_paths_addition =
   | Class_type of Ident.t * class_type_declaration
   | Module_type of Ident.t * modtype_declaration
   | Module of Ident.t * module_declaration * module_components
-  | Type_open of Ident.t * Path.t
-  | Class_type_open of Ident.t * Path.t
-  | Module_type_open of Ident.t * Path.t
-  | Module_open of Ident.t * Path.t
+  | Type_open of Ident.t * Path.t * type_declaration
+  | Class_type_open of Ident.t * Path.t * class_type_declaration
+  | Module_type_open of Ident.t * Path.t * modtype_declaration
+  | Module_open of Ident.t * Path.t * module_components
 
 let copy_local ~from env =
   { env with
@@ -447,11 +447,25 @@ let register_pers_for_short_paths ps =
       ([], []) ps.ps_crcs
   in
   let path = Pident (Ident.create_persistent ps.ps_name) in
-  let desc =
-    Short_paths.Desc.Module.(Fresh
-      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  let components =
+    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
   in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Deprecated _ -> true
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name
+    deps alias_deps desc deprecated
 
 (* Reading persistent structures from .cmi files *)
 
@@ -1455,7 +1469,7 @@ let short_paths_type predef id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Type(id, decl)
-      | _ -> Type_open(id, path)
+      | _ -> Type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1469,7 +1483,7 @@ let short_paths_class_type id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Class_type(id, decl)
-      | _ -> Class_type_open(id, path)
+      | _ -> Class_type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1480,7 +1494,7 @@ let short_paths_module_type id path decl old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Module_type(id, decl)
-      | _ -> Module_type_open(id, path)
+      | _ -> Module_type_open(id, path, decl)
     in
     addition :: old
   end
@@ -1491,7 +1505,7 @@ let short_paths_module id path decl comps old =
     let addition =
       match path with
       | Pident id' when Ident.same id id' -> Module(id, decl, comps)
-      | _ -> Module_open(id, path)
+      | _ -> Module_open(id, path, comps)
     in
     addition :: old
   end
@@ -2271,6 +2285,15 @@ let short_paths_module_type_desc mty =
   | Some (Mty_signature _ | Mty_functor _) -> Fresh
   | Some (Mty_alias _) -> assert false
 
+let deprecated_of_string_opt stro =
+  match stro with
+  | None -> Short_paths.Desc.Not_deprecated
+  | Some _ -> Short_paths.Desc.Deprecated
+
+let deprecated_of_attributes attrs =
+  deprecated_of_string_opt
+    (Builtin_attributes.deprecated_of_attrs attrs)
+
 let rec short_paths_module_desc env mpath mty comp =
   let open Short_paths.Desc.Module in
   match mty with
@@ -2299,7 +2322,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name ((decl, _), _) acc ->
              let desc = short_paths_type_desc decl in
-             let item = Short_paths.Desc.Module.Type(name, desc) in
+             let depr = deprecated_of_attributes decl.type_attributes in
+             let item = Short_paths.Desc.Module.Type(name, desc, depr) in
              item :: acc)
           c.comp_types []
       in
@@ -2307,7 +2331,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (clty, _) acc ->
              let desc = short_paths_class_type_desc clty in
-             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             let depr = deprecated_of_attributes clty.clty_attributes in
+             let item = Short_paths.Desc.Module.Class_type(name, desc, depr) in
              item :: acc)
           c.comp_cltypes comps
       in
@@ -2315,7 +2340,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (mtd, _) acc ->
              let desc = short_paths_module_type_desc mtd.mtd_type in
-             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             let depr = deprecated_of_attributes mtd.mtd_attributes in
+             let item = Short_paths.Desc.Module.Module_type(name, desc, depr) in
              item :: acc)
           c.comp_modtypes comps
       in
@@ -2330,7 +2356,8 @@ and short_paths_module_components_desc env mpath comp =
              let mty = EnvLazy.force subst_modtype_maker data in
              let mpath = Pdot(mpath, name, 0) in
              let desc = short_paths_module_desc env mpath mty.md_type comps in
-             let item = Short_paths.Desc.Module.Module(name, desc) in
+             let depr = deprecated_of_string_opt comps.deprecated in
+             let item = Short_paths.Desc.Module.Module(name, desc, depr) in
              item :: acc)
           c.comp_modules comps
       in
@@ -2361,32 +2388,50 @@ let short_paths_additions_desc env additions =
     (function
       | Type(id, decl) ->
           let desc = short_paths_type_desc decl in
-          Short_paths.Desc.Type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes decl.type_attributes in
+          Short_paths.Desc.Type(id, desc, source, depr)
       | Class_type(id, clty) ->
           let desc = short_paths_class_type_desc clty in
-          Short_paths.Desc.Class_type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes clty.clty_attributes in
+          Short_paths.Desc.Class_type(id, desc, source, depr)
       | Module_type(id, mtd) ->
           let desc = short_paths_module_type_desc mtd.mtd_type in
-          Short_paths.Desc.Module_type(id, desc, true)
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_attributes mtd.mtd_attributes in
+          Short_paths.Desc.Module_type(id, desc, source, depr)
       | Module(id, md, comps) ->
-          let desc = short_paths_module_desc env (Pident id) md.md_type comps in
-          Short_paths.Desc.Module(id, desc, true)
-      | Type_open(id, path) ->
+          let desc =
+            short_paths_module_desc env (Pident id) md.md_type comps
+          in
+          let source = Short_paths.Desc.Local in
+          let depr = deprecated_of_string_opt comps.deprecated in
+          Short_paths.Desc.Module(id, desc, source, depr)
+      | Type_open(id, path, decl) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Type.Alias path in
-          Short_paths.Desc.Type(id, desc, false)
-      | Class_type_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes decl.type_attributes in
+          Short_paths.Desc.Type(id, desc, source, depr)
+      | Class_type_open(id, path, clty) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Class_type.Alias path in
-          Short_paths.Desc.Class_type(id, desc, false)
-      | Module_type_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes clty.clty_attributes in
+          Short_paths.Desc.Class_type(id, desc, source, depr)
+      | Module_type_open(id, path, mtd) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Module_type.Alias path in
-          Short_paths.Desc.Module_type(id, desc, false)
-      | Module_open(id, path) ->
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_attributes mtd.mtd_attributes in
+          Short_paths.Desc.Module_type(id, desc, source, depr)
+      | Module_open(id, path, comps) ->
           let id = Ident.rename id in
           let desc = Short_paths.Desc.Module.Alias path in
-          Short_paths.Desc.Module(id, desc, false))
+          let source = Short_paths.Desc.Open in
+          let depr = deprecated_of_string_opt comps.deprecated in
+          Short_paths.Desc.Module(id, desc, source, depr))
     additions
 
 let () =

--- a/src/ocaml/typing/405/short_paths.ml
+++ b/src/ocaml/typing/405/short_paths.ml
@@ -300,43 +300,7 @@ module Origin_range_tbl = struct
 
 end
 
-module Height = struct
-
-  include Natural.Make_no_zero()
-
-  let hidden_name name =
-    if name <> "" && name.[0] = '_' then true
-    else
-      try
-        for i = 1 to String.length name - 2 do
-          if name.[i] = '_' && name.[i + 1] = '_' then
-            raise Exit
-        done;
-        false
-      with Exit -> true
-
-  let hidden_ident id =
-    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
-    else hidden_name (Ident.name id)
-
-  let measure_name name =
-    if hidden_name name then maximum
-    else one
-
-  let measure_ident id =
-    if hidden_ident id then maximum
-    else one
-
-  let rec measure_path = function
-    | Path.Pident id ->
-        measure_ident id
-    | Path.Pdot(p, name, _) ->
-        if hidden_name name then maximum
-        else succ (measure_path p)
-    | Path.Papply(p1, p2) ->
-        plus (measure_path p1) (measure_path p2)
-
-end
+module Height = Natural.Make_no_zero()
 
 module Todo = struct
 
@@ -1121,8 +1085,9 @@ module Shortest = struct
     { kind; graph; sections; todos }
 
   let local_or_open conc =
-    if conc then Component.Local
-    else Component.Open
+    match conc with
+    | Desc.Local -> Component.Local
+    | Desc.Open -> Component.Open
 
   let env parent desc =
     update parent;
@@ -1132,14 +1097,14 @@ module Shortest = struct
       List.map
         (fun desc ->
            match desc with
-           | Desc.Type(id, desc, conc) ->
-               Component.Type(origin, id, desc, local_or_open conc)
-           | Desc.Class_type(id, desc, conc) ->
-               Component.Class_type(origin, id, desc, local_or_open conc)
-           | Desc.Module_type(id, desc, conc) ->
-               Component.Module_type(origin, id, desc, local_or_open conc)
-           | Desc.Module(id, desc, conc) ->
-               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Type(id, desc, conc, dpr) ->
+               Component.Type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Class_type(id, desc, conc, dpr) ->
+               Component.Class_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module_type(id, desc, conc, dpr) ->
+               Component.Module_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module(id, desc, conc, dpr) ->
+               Component.Module(origin, id, desc, local_or_open conc, dpr)
            | Desc.Declare_type id ->
                Component.Declare_type(origin, id)
            | Desc.Declare_class_type id ->
@@ -1244,28 +1209,28 @@ module Shortest = struct
     in
     String_map.iter
       (fun name typ ->
-         if not (Height.hidden_name name) then begin
+         if not (Type.hidden typ) then begin
            let path = Path.Pdot(path, name, 0) in
            process_type t height path typ
          end)
       types;
     String_map.iter
-      (fun name mty ->
-         if not (Height.hidden_name name) then begin
+      (fun name clty ->
+         if not (Class_type.hidden clty) then begin
            let path = Path.Pdot(path, name, 0) in
-           process_class_type t height path mty
+           process_class_type t height path clty
          end)
       class_types;
     String_map.iter
       (fun name mty ->
-         if not (Height.hidden_name name) then begin
+         if not (Module_type.hidden mty) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module_type t height path mty
          end)
       module_types;
     String_map.iter
       (fun name md ->
-         if not (Height.hidden_name name) then begin
+         if not (Module.hidden md) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module t height path seen md
          end)
@@ -1280,22 +1245,22 @@ module Shortest = struct
           List.iter
             (function
               | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Type.hidden typ) then begin
                     let path = Path.Pident id in
                     process_type t height path typ
                   end
-              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+              | Todo.Item.Base (Diff.Item.Class_type(id, clty, _)) ->
+                  if not (Class_type.hidden clty) then begin
                     let path = Path.Pident id in
-                    process_class_type t height path mty
+                    process_class_type t height path clty
                   end
               | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module_type.hidden mty) then begin
                     let path = Path.Pident id in
                     process_module_type t height path mty
                   end
               | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module.hidden md) then begin
                     let path = Path.Pident id in
                     process_module t height path Path_set.empty md
                   end
@@ -1413,10 +1378,6 @@ module Shortest = struct
       | Module_type : Module_type.t kind
       | Module : Module.t kind
 
-    type suffix =
-      { names : string list;
-        height : Height.t; }
-
     type name =
       { name : string;
         height : Height.t; }
@@ -1450,7 +1411,6 @@ module Shortest = struct
             max: Height.t;
             func : Module.t t;
             arg : Module.t t;
-            suffix : suffix option;
             func_first : bool;
             searched : bool;
             finished : bool; }
@@ -1459,6 +1419,16 @@ module Shortest = struct
       | Ident { min; _ } -> min
       | Dot { min; _ } -> min
       | Application { min; _ } -> min
+
+    let max_height = function
+      | Ident { max; _ } -> max
+      | Dot { max; _ } -> max
+      | Application { max; _ } -> max
+
+    let search_origin = function
+      | Ident { origin; _ } -> origin
+      | Dot { origin; _ } -> origin
+      | Application { origin; _ } -> origin
 
     let finished = function
       | Ident { finished; _ } -> finished
@@ -1470,163 +1440,99 @@ module Shortest = struct
       | Dot { best; _ } -> best
       | Application { best; _ } -> best
 
-    let min_application fst snd suffix =
-      let base = Height.plus (min_height fst) (min_height snd) in
-      match suffix with
-      | None -> base
-      | Some { names = _; height } -> Height.plus base height
+    let min_application fst snd =
+      Height.plus (min_height fst) (min_height snd)
+
+    let max_application fst snd =
+      Height.plus (max_height fst) (max_height snd)
 
     let min_dot parent name =
       let base = min_height parent in
       Height.plus base name.height
 
-    let path_application fst snd suffix =
-      let base = Path.Papply(best fst, best snd) in
-      match suffix with
-      | None -> base
-      | Some { names; _ } ->
-          List.fold_left
-            (fun acc name -> Path.Pdot(acc, name, 0))
-            base names
+    let path_application fst snd =
+      Path.Papply(best fst, best snd)
 
     let path_dot parent name =
-      let base = best parent in
-      Path.Pdot(base, name.name, 0)
+      Path.Pdot(best parent, name.name, 0)
 
-    let create (type k) shortest (kind : k kind) (node : k) =
-      let rec loop :
-        type k. k kind -> k -> Origin.t -> Path.t ->
-          Height.t -> string list -> Path.t -> k t =
-        fun kind node origin best max suffix path ->
+    let is_visible_ident (type k) graph (kind : k kind) id =
+      match kind with
+      | Type -> Graph.is_type_ident_visible graph id
+      | Class_type -> Graph.is_class_type_ident_visible graph id
+      | Module_type -> Graph.is_module_type_ident_visible graph id
+      | Module -> Graph.is_module_ident_visible graph id
+
+    let create (type k) shortest (kind : k kind) canonical_path =
+      let rec loop : type k. k kind -> Path.t -> k t =
+        fun kind path ->
+          let graph = shortest.graph in
+          let (node : k), origin, hidden =
+            match kind with
+            | Type ->
+                let node = Graph.find_type graph path in
+                let origin = Type.origin graph node in
+                let hidden = Type.hidden node in
+                node, origin, hidden
+            | Class_type ->
+                let node = Graph.find_class_type graph path in
+                let origin = Class_type.origin graph node in
+                let hidden = Class_type.hidden node in
+                node, origin, hidden
+            | Module_type ->
+                let node = Graph.find_module_type graph path in
+                let origin = Module_type.origin graph node in
+                let hidden = Module_type.hidden node in
+                node, origin, hidden
+            | Module ->
+                let node = Graph.find_module graph path in
+                let origin = Module.origin graph node in
+                let hidden = Module.hidden node in
+                node, origin, hidden
+          in
+          let best = path in
           match path with
-          | Path.Pident _ ->
+          | Path.Pident id ->
+              let max =
+                if is_visible_ident graph kind id && not hidden then
+                  Height.one
+                else
+                  Height.maximum
+              in
               let min = Height.one in
               let finished = false in
-              Ident
-                { kind; node; origin; best; min; max; finished; }
+              Ident { kind; node; origin; best; min; max; finished }
           | Path.Pdot(parent, name, _) ->
-              let graph = shortest.graph in
-              let parent_md = Graph.find_module graph parent in
-              let parent_max = Height.measure_path parent in
-              let parent_origin = Module.origin graph parent_md in
-              let parent =
-                loop Module parent_md parent_origin
-                  parent parent_max [] parent
-              in
+              let parent = loop Module parent in
               let finished = false in
-              let name =
-                let height = Height.measure_name name in
-                { name; height }
+              let name_height =
+                if not hidden then Height.one
+                else Height.maximum
               in
+              let name = { name; height = name_height } in
               let searched = false in
+              let max = Height.plus (max_height parent) name_height in
               let min = Height.one in
               Dot
                 { kind; node; origin; best; min; max;
                   parent; name; searched; finished }
           | Path.Papply(func, arg) ->
-              let graph = shortest.graph in
-              let func_md = Graph.find_module graph func in
-              let func_max = Height.measure_path func in
-              let func_origin = Module.origin graph func_md in
-              let func =
-                loop Module func_md func_origin func func_max [] func
-              in
-              let arg_md = Graph.find_module graph arg in
-              let arg_max = Height.measure_path arg in
-              let arg_origin = Module.origin graph arg_md in
-              let arg =
-                loop Module arg_md arg_origin arg arg_max [] arg
-              in
+              let func = loop Module func in
+              let arg = loop Module arg in
               let func_first =
-                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+                Rev_deps.before (rev_deps shortest)
+                  (search_origin arg) (search_origin func)
               in
               let finished = false in
-              let suffix =
-                match suffix with
-                | [] -> None
-                | fst :: rest ->
-                  let names = suffix in
-                  let height =
-                    List.fold_left
-                      (fun acc name ->
-                         Height.plus acc (Height.measure_name name))
-                      (Height.measure_name fst) rest
-                  in
-                  Some { names; height }
-              in
-              let searched, min =
-                match kind with
-                | Type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Class_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module ->
-                    (* There are no module aliases containing extended paths *)
-                    let searched = true in
-                    let min = min_application func arg suffix in
-                    searched, min
-              in
+              (* There are no module aliases containing extended paths *)
+              let searched = true in
+              let max = max_application func arg in
+              let min = min_application func arg in
               Application
                 { kind; node; origin; best; min; max;
-                  func; arg; suffix; func_first; searched; finished }
+                  func; arg; func_first; searched; finished }
       in
-      let graph = shortest.graph in
-      let canonical_path, origin, max =
-        match kind with
-        | Type ->
-            let canonical_path = Type.path graph node in
-            let origin = Type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Class_type ->
-            let canonical_path = Class_type.path graph node in
-            let origin = Class_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_class_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module_type ->
-            let canonical_path = Module_type.path graph node in
-            let origin = Module_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module ->
-            let canonical_path = Module.path graph node in
-            let origin = Module.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-      in
-      loop kind node origin canonical_path max [] canonical_path
+      loop kind canonical_path
 
     let find (type k) shortest origin height (kind : k kind) (node : k) =
       let sections = force shortest origin height in
@@ -1710,15 +1616,13 @@ module Shortest = struct
                 in
                 let fst, snd =
                   let should_try_app =
-                    Height.equal
-                      (min_application fst snd r.suffix) r.min
+                    Height.equal (min_application fst snd) r.min
                   in
                   if not should_try_app then fst, snd
                   else begin
                     let fst = step shortest fst in
                     let should_try_app =
-                      Height.equal
-                        (min_application fst snd r.suffix) r.min
+                      Height.equal (min_application fst snd) r.min
                     in
                     if not should_try_app then fst, snd
                     else fst, step shortest snd
@@ -1730,11 +1634,10 @@ module Shortest = struct
                 in
                 let found =
                   finished func && finished arg
-                  && Height.equal
-                       (min_application fst snd r.suffix) r.min
+                  && Height.equal (min_application fst snd) r.min
                 in
                 if found then begin
-                  let best = path_application func arg r.suffix in
+                  let best = path_application func arg in
                   let max = r.min in
                   let finished = true in
                   Application
@@ -1743,7 +1646,7 @@ module Shortest = struct
                   let finished =
                     searched
                     && Height.less_than_or_equal
-                         r.max (min_application fst snd r.suffix)
+                         r.max (min_application fst snd)
                   in
                   let min = if finished then r.max else Height.succ r.min in
                   Application
@@ -1778,7 +1681,8 @@ module Shortest = struct
     match Type.resolve t.graph typ with
     | Type.Nth n -> Nth n
     | Type.Path(subst, typ) ->
-      let search = Search.create t Search.Type typ in
+      let canonical_path = Type.path t.graph typ in
+      let search = Search.create t Search.Type canonical_path in
       let path = Search.perform t search in
       Path(subst, path)
 
@@ -1793,33 +1697,38 @@ module Shortest = struct
   let find_type_simple t path =
     update t;
     let typ = Graph.find_type t.graph path in
-    let search = Search.create t Search.Type typ in
+    let canonical_path = Type.path t.graph typ in
+    let search = Search.create t Search.Type canonical_path in
     Search.perform t search
 
   let find_class_type t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
     let subst, clty = Class_type.resolve t.graph clty in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     let path = Search.perform t search in
     (subst, path)
 
   let find_class_type_simple t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     Search.perform t search
 
   let find_module_type t path =
     update t;
     let mty = Graph.find_module_type t.graph path in
-    let search = Search.create t Search.Module_type mty in
+    let canonical_path = Module_type.path t.graph mty in
+    let search = Search.create t Search.Module_type canonical_path in
     Search.perform t search
 
   let find_module t path =
     update t;
     let md = Graph.find_module t.graph path in
-    let search = Search.create t Search.Module md in
+    let canonical_path = Module.path t.graph md in
+    let search = Search.create t Search.Module canonical_path in
     Search.perform t search
 
 end
@@ -1832,7 +1741,8 @@ module Basis = struct
     { name : string;
       depends : string list;
       alias_depends : string list;
-      desc : Desc.Module.t; }
+      desc : Desc.Module.t;
+      deprecated : Desc.deprecated; }
 
   type t =
     { mutable next_dep : Dependency.t;
@@ -1879,11 +1789,11 @@ module Basis = struct
   let update_shortest t additions loads =
     let components =
       List.map
-        (fun { name; desc; _ } ->
+        (fun { name; desc; deprecated; _ } ->
            let index = String_map.find name t.assignment in
            let origin = Origin.Dependency index in
            let id = Ident.global name in
-           Component.Module(origin, id, desc, Component.Global))
+           Component.Module(origin, id, desc, Component.Global, deprecated))
         loads
     in
     let components =
@@ -1927,8 +1837,9 @@ module Basis = struct
   let add t name =
     t.pending_additions <- String_set.add name t.pending_additions
 
-  let load t name depends alias_depends desc =
-    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+  let load t name depends alias_depends desc deprecated =
+    let load = { name; depends; alias_depends; desc; deprecated } in
+    t.pending_loads <- load :: t.pending_loads
 
 end
 

--- a/src/ocaml/typing/405/short_paths.mli
+++ b/src/ocaml/typing/405/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/405/short_paths_graph.ml
+++ b/src/ocaml/typing/405/short_paths_graph.ml
@@ -80,6 +80,10 @@ module Path_set = Set.Make(Path)
 
 module Desc = struct
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type = struct
 
     type t =
@@ -110,10 +114,10 @@ module Desc = struct
   module Module = struct
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -127,11 +131,15 @@ module Desc = struct
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -234,15 +242,39 @@ module Origin = struct
 
 end
 
-(* CR lwhite: Should probably short-circuit indirections if they are to
-    canonical entries older than the indirection. *)
+let hidden_name name =
+  if name <> "" && name.[0] = '_' then true
+  else
+    try
+      for i = 1 to String.length name - 2 do
+        if name.[i] = '_' && name.[i + 1] = '_' then
+          raise Exit
+      done;
+      false
+    with Exit -> true
+
+let hidden_ident id =
+  if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
+  else hidden_name (Ident.name id)
+
+let hidden_definition deprecated name =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_name name
+
+let hidden_base_definition deprecated id =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_ident id
+
 module rec Type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Type.t option -> t
+  val base : Origin.t -> Ident.t -> Desc.Type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Type.t option -> t
+  val child :
+    Module.normalized -> string -> Desc.Type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -251,6 +283,8 @@ module rec Type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -265,7 +299,7 @@ end = struct
   open Desc.Type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Nth of int
     | Subst of Path.t * int list
@@ -274,10 +308,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -287,28 +323,36 @@ end = struct
     | Some Fresh -> Defined
     | Some (Nth n) -> Nth n
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -329,7 +373,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Nth _ | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -371,7 +415,7 @@ end = struct
         | exception Not_found -> Path(None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -379,9 +423,12 @@ and Class_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Class_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Class_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Class_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Class_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -390,6 +437,8 @@ and Class_type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -402,7 +451,7 @@ end = struct
   open Desc.Class_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Subst of Path.t * int list
     | Unknown
@@ -410,10 +459,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -422,28 +473,36 @@ end = struct
     | None -> Unknown
     | Some Fresh -> Defined
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -464,7 +523,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_class_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -502,7 +561,7 @@ end = struct
         | exception Not_found -> (None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -510,9 +569,12 @@ and Module_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Module_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Module_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Module_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -522,6 +584,8 @@ and Module_type : sig
 
   val path : Graph.t -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : Graph.t -> t -> Sort.t
 
 end = struct
@@ -529,50 +593,60 @@ end = struct
   open Desc.Module_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Unknown
 
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot (Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -593,7 +667,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -624,9 +698,11 @@ and Module : sig
 
   type normalized
 
-  val base : Origin.t -> Ident.t -> Desc.Module.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module.t option -> Desc.deprecated -> t
 
-  val child : normalized -> string -> Desc.Module.t option -> t
+  val child :
+    normalized -> string -> Desc.Module.t option -> Desc.deprecated -> t
 
   val application : normalized -> t -> Desc.Module.t option -> t
 
@@ -637,6 +713,8 @@ and Module : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -681,7 +759,7 @@ end = struct
           modules : t String_map.t; }
 
   and definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Signature of
         { mutable components : components }
     | Functor of
@@ -692,15 +770,18 @@ end = struct
   and t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
@@ -712,14 +793,15 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
@@ -730,9 +812,9 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let application func arg desc =
     let func_origin = Module.raw_origin func in
@@ -744,6 +826,7 @@ end = struct
     let func_path = Module.raw_path func in
     let arg_path = Module.raw_path arg in
     let path = Path.Papply(func_path, arg_path) in
+    let hidden = false in
     let definition =
       match desc with
       | None -> Unknown
@@ -754,17 +837,23 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -787,7 +876,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Signature _ | Functor _ | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -820,27 +909,27 @@ end = struct
   let force root t =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Unknown
     | Functor _
     | Signature { components = Forced _ } -> t
     | Signature ({ components = Unforced components; _} as r) -> begin
         let rec loop types class_types module_types modules = function
           | [] -> Forced { types; class_types; module_types; modules }
-          | Type(name, desc) :: rest ->
-              let typ = Type.child t name (Some desc) in
+          | Type(name, desc, dpr) :: rest ->
+              let typ = Type.child t name (Some desc) dpr in
               let types = String_map.add name typ types in
               loop types class_types module_types modules rest
-          | Class_type(name, desc) :: rest ->
-              let clty = Class_type.child t name (Some desc) in
+          | Class_type(name, desc, dpr) :: rest ->
+              let clty = Class_type.child t name (Some desc) dpr in
               let class_types = String_map.add name clty class_types in
               loop types class_types module_types modules rest
-          | Module_type(name, desc) :: rest ->
-              let mty = Module_type.child t name (Some desc) in
+          | Module_type(name, desc, dpr) :: rest ->
+              let mty = Module_type.child t name (Some desc) dpr in
               let module_types = String_map.add name mty module_types in
               loop types class_types module_types modules rest
-          | Module(name, desc) :: rest ->
-              let md = Module.child t name (Some desc) in
+          | Module(name, desc, dpr) :: rest ->
+              let md = Module.child t name (Some desc) dpr in
               let modules = String_map.add name md modules in
               loop types class_types module_types modules rest
         in
@@ -853,7 +942,7 @@ end = struct
   let types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -863,7 +952,7 @@ end = struct
   let class_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -873,7 +962,7 @@ end = struct
   let module_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -883,7 +972,7 @@ end = struct
   let modules root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -893,11 +982,11 @@ end = struct
   let find_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Type.child t name None
+        Type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { types; _ }; _ } ->
@@ -906,11 +995,11 @@ end = struct
   let find_class_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Class_type.child t name None
+        Class_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { class_types; _ }; _ } ->
@@ -919,11 +1008,11 @@ end = struct
   let find_module_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module_type.child t name None
+        Module_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { module_types; _ }; _ } ->
@@ -932,11 +1021,11 @@ end = struct
   let find_module root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module.child t name None
+        Module.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { modules; _ }; _ } ->
@@ -945,7 +1034,7 @@ end = struct
   let find_application root t path =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Signature _ -> raise Not_found
     | Unknown ->
         let arg = Graph.find_module root path in
@@ -1024,10 +1113,14 @@ and Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -1060,6 +1153,14 @@ and Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end = struct
 
@@ -1148,36 +1249,36 @@ end = struct
   let add t descs =
     let rec loop acc diff declarations = function
       | [] -> loop_declarations acc diff declarations
-      | Component.Type(origin, id, desc, source) :: rest ->
+      | Component.Type(origin, id, desc, source, dpr) :: rest ->
           let prev = previous_type acc id in
-          let typ = Type.base origin id (Some desc) in
+          let typ = Type.base origin id (Some desc) dpr in
           let types = Ident_map.add id typ acc.types in
           let type_names = add_name source id acc.type_names in
           let item = Diff.Item.Type(id, typ, prev) in
           let diff = item :: diff in
           let acc = { acc with types; type_names } in
           loop acc diff declarations rest
-      | Component.Class_type(origin,id, desc, source) :: rest ->
+      | Component.Class_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_class_type acc id in
-          let clty = Class_type.base origin id (Some desc) in
+          let clty = Class_type.base origin id (Some desc) dpr in
           let class_types = Ident_map.add id clty acc.class_types in
           let class_type_names = add_name source id acc.class_type_names in
           let item = Diff.Item.Class_type(id, clty, prev) in
           let diff = item :: diff in
           let acc = { acc with class_types; class_type_names } in
           loop acc diff declarations rest
-      | Component.Module_type(origin,id, desc, source) :: rest ->
+      | Component.Module_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module_type acc id in
-          let mty = Module_type.base origin id (Some desc) in
+          let mty = Module_type.base origin id (Some desc) dpr in
           let module_types = Ident_map.add id mty acc.module_types in
           let module_type_names = add_name source id acc.module_type_names in
           let item = Diff.Item.Module_type(id, mty, prev) in
           let diff = item :: diff in
           let acc = { acc with module_types; module_type_names } in
           loop acc diff declarations rest
-      | Component.Module(origin,id, desc, source) :: rest ->
+      | Component.Module(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module acc id in
-          let md = Module.base origin id (Some desc) in
+          let md = Module.base origin id (Some desc) dpr in
           let modules = Ident_map.add id md acc.modules in
           let module_names = add_name source id acc.module_names in
           let item = Diff.Item.Module(id, md, prev) in
@@ -1348,88 +1449,92 @@ end = struct
     | exception Not_found -> Path.Pident id
     | md -> Module.path t md
 
-  let rec is_module_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_path t) ids in
-            let path = canonical_module_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_path t) ids in
+        let path = canonical_module_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let rec is_module_path_visible t = function
+    | Path.Pident id -> is_module_ident_visible t id
     | Path.Pdot(path, _, _) ->
         is_module_path_visible t path
     | Path.Papply(path1, path2) ->
         is_module_path_visible t path1
         && is_module_path_visible t path2
 
-  let is_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_type_path t) ids in
-            let path = canonical_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_type_path t) ids in
+        let path = canonical_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_type_path_visible t = function
+    | Path.Pident id -> is_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_type_path_visible: \
            invalid type path"
 
-  let is_class_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.class_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_class_type_path t) ids in
-            let path = canonical_class_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_class_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.class_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_class_type_path t) ids in
+        let path = canonical_class_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_class_type_path_visible t = function
+    | Path.Pident id -> is_class_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_class_type_path_visible: \
            invalid class type path"
 
-  let is_module_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_type_path t) ids in
-            let path = canonical_module_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_type_path t) ids in
+        let path = canonical_module_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_module_type_path_visible t = function
+    | Path.Pident id -> is_module_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith

--- a/src/ocaml/typing/405/short_paths_graph.mli
+++ b/src/ocaml/typing/405/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -483,8 +483,7 @@ and short_paths_addition =
   | Type_open of Path.t * (type_declaration * type_descriptions) comp_tbl
   | Class_type_open of Path.t * class_type_declaration comp_tbl
   | Module_type_open of Path.t * modtype_declaration comp_tbl
-  | Module_open of
-      Path.t * (Subst.t * module_declaration, module_declaration) EnvLazy.t comp_tbl
+  | Module_open of Path.t * module_components comp_tbl
 
 let copy_local ~from env =
   { env with
@@ -696,11 +695,25 @@ let register_pers_for_short_paths ps =
       ([], []) ps.ps_crcs
   in
   let path = Pident (Ident.create_persistent ps.ps_name) in
-  let desc =
-    Short_paths.Desc.Module.(Fresh
-      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  let components =
+    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
   in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Deprecated _ -> true
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name
+    deps alias_deps desc deprecated
 
 (* Reading persistent structures from .cmi files *)
 
@@ -1722,9 +1735,9 @@ let short_paths_module id decl comps old =
   if !Clflags.real_paths then old
   else Module(id, decl, comps) :: old
 
-let short_paths_module_open path decls old =
+let short_paths_module_open path comps old =
   if !Clflags.real_paths then old
-  else Module_open(path, decls) :: old
+  else Module_open(path, comps) :: old
 
 (* Compute structure descriptions *)
 
@@ -2148,12 +2161,13 @@ let add_components slot root env0 comps =
     add_cltypes (fun x -> `Class_type x)
       comps.comp_cltypes env0.cltypes additions
   in
-  let components =
-    add (fun x -> `Component x) comps.comp_components env0.components
+  let components, additions =
+    add_modules (fun x -> `Component x)
+      comps.comp_components env0.components additions
   in
-  let modules, additions =
-    add_modules (fun x -> `Module x)
-      comps.comp_modules env0.modules additions
+  let modules =
+    add (fun x -> `Module x)
+      comps.comp_modules env0.modules
   in
 
   { env0 with
@@ -2460,6 +2474,15 @@ let short_paths_module_type_desc mty =
   | Some (Mty_signature _ | Mty_functor _) -> Fresh
   | Some (Mty_alias _) -> assert false
 
+let deprecated_of_string_opt stro =
+  match stro with
+  | None -> Short_paths.Desc.Not_deprecated
+  | Some _ -> Short_paths.Desc.Deprecated
+
+let deprecated_of_attributes attrs =
+  deprecated_of_string_opt
+    (Builtin_attributes.deprecated_of_attrs attrs)
+
 let rec short_paths_module_desc env mpath mty comp =
   let open Short_paths.Desc.Module in
   match mty with
@@ -2488,7 +2511,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name ((decl, _), _) acc ->
              let desc = short_paths_type_desc decl in
-             let item = Short_paths.Desc.Module.Type(name, desc) in
+             let depr = deprecated_of_attributes decl.type_attributes in
+             let item = Short_paths.Desc.Module.Type(name, desc, depr) in
              item :: acc)
           c.comp_types []
       in
@@ -2496,7 +2520,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (clty, _) acc ->
              let desc = short_paths_class_type_desc clty in
-             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             let depr = deprecated_of_attributes clty.clty_attributes in
+             let item = Short_paths.Desc.Module.Class_type(name, desc, depr) in
              item :: acc)
           c.comp_cltypes comps
       in
@@ -2504,7 +2529,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (mtd, _) acc ->
              let desc = short_paths_module_type_desc mtd.mtd_type in
-             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             let depr = deprecated_of_attributes mtd.mtd_attributes in
+             let item = Short_paths.Desc.Module.Module_type(name, desc, depr) in
              item :: acc)
           c.comp_modtypes comps
       in
@@ -2519,7 +2545,8 @@ and short_paths_module_components_desc env mpath comp =
              let mty = EnvLazy.force subst_modtype_maker data in
              let mpath = Pdot(mpath, name, 0) in
              let desc = short_paths_module_desc env mpath mty.md_type comps in
-             let item = Short_paths.Desc.Module.Module(name, desc) in
+             let depr = deprecated_of_string_opt comps.deprecated in
+             let item = Short_paths.Desc.Module.Module(name, desc, depr) in
              item :: acc)
           c.comp_modules comps
       in
@@ -2551,47 +2578,65 @@ let short_paths_additions_desc env additions =
        match add with
        | Type(id, decl) ->
            let desc = short_paths_type_desc decl in
-           Short_paths.Desc.Type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes decl.type_attributes in
+           Short_paths.Desc.Type(id, desc, source, depr) :: acc
        | Class_type(id, clty) ->
            let desc = short_paths_class_type_desc clty in
-           Short_paths.Desc.Class_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes clty.clty_attributes in
+           Short_paths.Desc.Class_type(id, desc, source, depr) :: acc
        | Module_type(id, mtd) ->
            let desc = short_paths_module_type_desc mtd.mtd_type in
-           Short_paths.Desc.Module_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes mtd.mtd_attributes in
+           Short_paths.Desc.Module_type(id, desc, source, depr) :: acc
        | Module(id, md, comps) ->
-           let desc = short_paths_module_desc env (Pident id) md.md_type comps in
-           Short_paths.Desc.Module(id, desc, true) :: acc
+           let desc =
+             short_paths_module_desc env (Pident id) md.md_type comps
+           in
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_string_opt comps.deprecated in
+           Short_paths.Desc.Module(id, desc, source, depr) :: acc
        | Type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name ((decl, _), pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Type.Alias path in
-                Short_paths.Desc.Type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes decl.type_attributes in
+                Short_paths.Desc.Type(id, desc, source, depr) :: acc)
              decls acc
        | Class_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (clty, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Class_type.Alias path in
-                Short_paths.Desc.Class_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes clty.clty_attributes in
+                Short_paths.Desc.Class_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (mtd, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module_type.Alias path in
-                Short_paths.Desc.Module_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes mtd.mtd_attributes in
+                Short_paths.Desc.Module_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (comps, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module.Alias path in
-                Short_paths.Desc.Module(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_string_opt comps.deprecated in
+                Short_paths.Desc.Module(id, desc, source, depr) :: acc)
              decls acc)
     [] additions
 

--- a/src/ocaml/typing/406/short_paths.ml
+++ b/src/ocaml/typing/406/short_paths.ml
@@ -300,43 +300,7 @@ module Origin_range_tbl = struct
 
 end
 
-module Height = struct
-
-  include Natural.Make_no_zero()
-
-  let hidden_name name =
-    if name <> "" && name.[0] = '_' then true
-    else
-      try
-        for i = 1 to String.length name - 2 do
-          if name.[i] = '_' && name.[i + 1] = '_' then
-            raise Exit
-        done;
-        false
-      with Exit -> true
-
-  let hidden_ident id =
-    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
-    else hidden_name (Ident.name id)
-
-  let measure_name name =
-    if hidden_name name then maximum
-    else one
-
-  let measure_ident id =
-    if hidden_ident id then maximum
-    else one
-
-  let rec measure_path = function
-    | Path.Pident id ->
-        measure_ident id
-    | Path.Pdot(p, name, _) ->
-        if hidden_name name then maximum
-        else succ (measure_path p)
-    | Path.Papply(p1, p2) ->
-        plus (measure_path p1) (measure_path p2)
-
-end
+module Height = Natural.Make_no_zero()
 
 module Todo = struct
 
@@ -1121,8 +1085,9 @@ module Shortest = struct
     { kind; graph; sections; todos }
 
   let local_or_open conc =
-    if conc then Component.Local
-    else Component.Open
+    match conc with
+    | Desc.Local -> Component.Local
+    | Desc.Open -> Component.Open
 
   let env parent desc =
     update parent;
@@ -1132,14 +1097,14 @@ module Shortest = struct
       List.map
         (fun desc ->
            match desc with
-           | Desc.Type(id, desc, conc) ->
-               Component.Type(origin, id, desc, local_or_open conc)
-           | Desc.Class_type(id, desc, conc) ->
-               Component.Class_type(origin, id, desc, local_or_open conc)
-           | Desc.Module_type(id, desc, conc) ->
-               Component.Module_type(origin, id, desc, local_or_open conc)
-           | Desc.Module(id, desc, conc) ->
-               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Type(id, desc, conc, dpr) ->
+               Component.Type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Class_type(id, desc, conc, dpr) ->
+               Component.Class_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module_type(id, desc, conc, dpr) ->
+               Component.Module_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module(id, desc, conc, dpr) ->
+               Component.Module(origin, id, desc, local_or_open conc, dpr)
            | Desc.Declare_type id ->
                Component.Declare_type(origin, id)
            | Desc.Declare_class_type id ->
@@ -1244,28 +1209,28 @@ module Shortest = struct
     in
     String_map.iter
       (fun name typ ->
-         if not (Height.hidden_name name) then begin
+         if not (Type.hidden typ) then begin
            let path = Path.Pdot(path, name, 0) in
            process_type t height path typ
          end)
       types;
     String_map.iter
-      (fun name mty ->
-         if not (Height.hidden_name name) then begin
+      (fun name clty ->
+         if not (Class_type.hidden clty) then begin
            let path = Path.Pdot(path, name, 0) in
-           process_class_type t height path mty
+           process_class_type t height path clty
          end)
       class_types;
     String_map.iter
       (fun name mty ->
-         if not (Height.hidden_name name) then begin
+         if not (Module_type.hidden mty) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module_type t height path mty
          end)
       module_types;
     String_map.iter
       (fun name md ->
-         if not (Height.hidden_name name) then begin
+         if not (Module.hidden md) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module t height path seen md
          end)
@@ -1280,22 +1245,22 @@ module Shortest = struct
           List.iter
             (function
               | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Type.hidden typ) then begin
                     let path = Path.Pident id in
                     process_type t height path typ
                   end
-              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+              | Todo.Item.Base (Diff.Item.Class_type(id, clty, _)) ->
+                  if not (Class_type.hidden clty) then begin
                     let path = Path.Pident id in
-                    process_class_type t height path mty
+                    process_class_type t height path clty
                   end
               | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module_type.hidden mty) then begin
                     let path = Path.Pident id in
                     process_module_type t height path mty
                   end
               | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module.hidden md) then begin
                     let path = Path.Pident id in
                     process_module t height path Path_set.empty md
                   end
@@ -1413,10 +1378,6 @@ module Shortest = struct
       | Module_type : Module_type.t kind
       | Module : Module.t kind
 
-    type suffix =
-      { names : string list;
-        height : Height.t; }
-
     type name =
       { name : string;
         height : Height.t; }
@@ -1450,7 +1411,6 @@ module Shortest = struct
             max: Height.t;
             func : Module.t t;
             arg : Module.t t;
-            suffix : suffix option;
             func_first : bool;
             searched : bool;
             finished : bool; }
@@ -1459,6 +1419,16 @@ module Shortest = struct
       | Ident { min; _ } -> min
       | Dot { min; _ } -> min
       | Application { min; _ } -> min
+
+    let max_height = function
+      | Ident { max; _ } -> max
+      | Dot { max; _ } -> max
+      | Application { max; _ } -> max
+
+    let search_origin = function
+      | Ident { origin; _ } -> origin
+      | Dot { origin; _ } -> origin
+      | Application { origin; _ } -> origin
 
     let finished = function
       | Ident { finished; _ } -> finished
@@ -1470,163 +1440,99 @@ module Shortest = struct
       | Dot { best; _ } -> best
       | Application { best; _ } -> best
 
-    let min_application fst snd suffix =
-      let base = Height.plus (min_height fst) (min_height snd) in
-      match suffix with
-      | None -> base
-      | Some { names = _; height } -> Height.plus base height
+    let min_application fst snd =
+      Height.plus (min_height fst) (min_height snd)
+
+    let max_application fst snd =
+      Height.plus (max_height fst) (max_height snd)
 
     let min_dot parent name =
       let base = min_height parent in
       Height.plus base name.height
 
-    let path_application fst snd suffix =
-      let base = Path.Papply(best fst, best snd) in
-      match suffix with
-      | None -> base
-      | Some { names; _ } ->
-          List.fold_left
-            (fun acc name -> Path.Pdot(acc, name, 0))
-            base names
+    let path_application fst snd =
+      Path.Papply(best fst, best snd)
 
     let path_dot parent name =
-      let base = best parent in
-      Path.Pdot(base, name.name, 0)
+      Path.Pdot(best parent, name.name, 0)
 
-    let create (type k) shortest (kind : k kind) (node : k) =
-      let rec loop :
-        type k. k kind -> k -> Origin.t -> Path.t ->
-          Height.t -> string list -> Path.t -> k t =
-        fun kind node origin best max suffix path ->
+    let is_visible_ident (type k) graph (kind : k kind) id =
+      match kind with
+      | Type -> Graph.is_type_ident_visible graph id
+      | Class_type -> Graph.is_class_type_ident_visible graph id
+      | Module_type -> Graph.is_module_type_ident_visible graph id
+      | Module -> Graph.is_module_ident_visible graph id
+
+    let create (type k) shortest (kind : k kind) canonical_path =
+      let rec loop : type k. k kind -> Path.t -> k t =
+        fun kind path ->
+          let graph = shortest.graph in
+          let (node : k), origin, hidden =
+            match kind with
+            | Type ->
+                let node = Graph.find_type graph path in
+                let origin = Type.origin graph node in
+                let hidden = Type.hidden node in
+                node, origin, hidden
+            | Class_type ->
+                let node = Graph.find_class_type graph path in
+                let origin = Class_type.origin graph node in
+                let hidden = Class_type.hidden node in
+                node, origin, hidden
+            | Module_type ->
+                let node = Graph.find_module_type graph path in
+                let origin = Module_type.origin graph node in
+                let hidden = Module_type.hidden node in
+                node, origin, hidden
+            | Module ->
+                let node = Graph.find_module graph path in
+                let origin = Module.origin graph node in
+                let hidden = Module.hidden node in
+                node, origin, hidden
+          in
+          let best = path in
           match path with
-          | Path.Pident _ ->
+          | Path.Pident id ->
+              let max =
+                if is_visible_ident graph kind id && not hidden then
+                  Height.one
+                else
+                  Height.maximum
+              in
               let min = Height.one in
               let finished = false in
-              Ident
-                { kind; node; origin; best; min; max; finished; }
+              Ident { kind; node; origin; best; min; max; finished }
           | Path.Pdot(parent, name, _) ->
-              let graph = shortest.graph in
-              let parent_md = Graph.find_module graph parent in
-              let parent_max = Height.measure_path parent in
-              let parent_origin = Module.origin graph parent_md in
-              let parent =
-                loop Module parent_md parent_origin
-                  parent parent_max [] parent
-              in
+              let parent = loop Module parent in
               let finished = false in
-              let name =
-                let height = Height.measure_name name in
-                { name; height }
+              let name_height =
+                if not hidden then Height.one
+                else Height.maximum
               in
+              let name = { name; height = name_height } in
               let searched = false in
+              let max = Height.plus (max_height parent) name_height in
               let min = Height.one in
               Dot
                 { kind; node; origin; best; min; max;
                   parent; name; searched; finished }
           | Path.Papply(func, arg) ->
-              let graph = shortest.graph in
-              let func_md = Graph.find_module graph func in
-              let func_max = Height.measure_path func in
-              let func_origin = Module.origin graph func_md in
-              let func =
-                loop Module func_md func_origin func func_max [] func
-              in
-              let arg_md = Graph.find_module graph arg in
-              let arg_max = Height.measure_path arg in
-              let arg_origin = Module.origin graph arg_md in
-              let arg =
-                loop Module arg_md arg_origin arg arg_max [] arg
-              in
+              let func = loop Module func in
+              let arg = loop Module arg in
               let func_first =
-                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+                Rev_deps.before (rev_deps shortest)
+                  (search_origin arg) (search_origin func)
               in
               let finished = false in
-              let suffix =
-                match suffix with
-                | [] -> None
-                | fst :: rest ->
-                  let names = suffix in
-                  let height =
-                    List.fold_left
-                      (fun acc name ->
-                         Height.plus acc (Height.measure_name name))
-                      (Height.measure_name fst) rest
-                  in
-                  Some { names; height }
-              in
-              let searched, min =
-                match kind with
-                | Type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Class_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module ->
-                    (* There are no module aliases containing extended paths *)
-                    let searched = true in
-                    let min = min_application func arg suffix in
-                    searched, min
-              in
+              (* There are no module aliases containing extended paths *)
+              let searched = true in
+              let max = max_application func arg in
+              let min = min_application func arg in
               Application
                 { kind; node; origin; best; min; max;
-                  func; arg; suffix; func_first; searched; finished }
+                  func; arg; func_first; searched; finished }
       in
-      let graph = shortest.graph in
-      let canonical_path, origin, max =
-        match kind with
-        | Type ->
-            let canonical_path = Type.path graph node in
-            let origin = Type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Class_type ->
-            let canonical_path = Class_type.path graph node in
-            let origin = Class_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_class_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module_type ->
-            let canonical_path = Module_type.path graph node in
-            let origin = Module_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module ->
-            let canonical_path = Module.path graph node in
-            let origin = Module.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-      in
-      loop kind node origin canonical_path max [] canonical_path
+      loop kind canonical_path
 
     let find (type k) shortest origin height (kind : k kind) (node : k) =
       let sections = force shortest origin height in
@@ -1710,15 +1616,13 @@ module Shortest = struct
                 in
                 let fst, snd =
                   let should_try_app =
-                    Height.equal
-                      (min_application fst snd r.suffix) r.min
+                    Height.equal (min_application fst snd) r.min
                   in
                   if not should_try_app then fst, snd
                   else begin
                     let fst = step shortest fst in
                     let should_try_app =
-                      Height.equal
-                        (min_application fst snd r.suffix) r.min
+                      Height.equal (min_application fst snd) r.min
                     in
                     if not should_try_app then fst, snd
                     else fst, step shortest snd
@@ -1730,11 +1634,10 @@ module Shortest = struct
                 in
                 let found =
                   finished func && finished arg
-                  && Height.equal
-                       (min_application fst snd r.suffix) r.min
+                  && Height.equal (min_application fst snd) r.min
                 in
                 if found then begin
-                  let best = path_application func arg r.suffix in
+                  let best = path_application func arg in
                   let max = r.min in
                   let finished = true in
                   Application
@@ -1743,7 +1646,7 @@ module Shortest = struct
                   let finished =
                     searched
                     && Height.less_than_or_equal
-                         r.max (min_application fst snd r.suffix)
+                         r.max (min_application fst snd)
                   in
                   let min = if finished then r.max else Height.succ r.min in
                   Application
@@ -1778,7 +1681,8 @@ module Shortest = struct
     match Type.resolve t.graph typ with
     | Type.Nth n -> Nth n
     | Type.Path(subst, typ) ->
-      let search = Search.create t Search.Type typ in
+      let canonical_path = Type.path t.graph typ in
+      let search = Search.create t Search.Type canonical_path in
       let path = Search.perform t search in
       Path(subst, path)
 
@@ -1793,33 +1697,38 @@ module Shortest = struct
   let find_type_simple t path =
     update t;
     let typ = Graph.find_type t.graph path in
-    let search = Search.create t Search.Type typ in
+    let canonical_path = Type.path t.graph typ in
+    let search = Search.create t Search.Type canonical_path in
     Search.perform t search
 
   let find_class_type t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
     let subst, clty = Class_type.resolve t.graph clty in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     let path = Search.perform t search in
     (subst, path)
 
   let find_class_type_simple t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     Search.perform t search
 
   let find_module_type t path =
     update t;
     let mty = Graph.find_module_type t.graph path in
-    let search = Search.create t Search.Module_type mty in
+    let canonical_path = Module_type.path t.graph mty in
+    let search = Search.create t Search.Module_type canonical_path in
     Search.perform t search
 
   let find_module t path =
     update t;
     let md = Graph.find_module t.graph path in
-    let search = Search.create t Search.Module md in
+    let canonical_path = Module.path t.graph md in
+    let search = Search.create t Search.Module canonical_path in
     Search.perform t search
 
 end
@@ -1832,7 +1741,8 @@ module Basis = struct
     { name : string;
       depends : string list;
       alias_depends : string list;
-      desc : Desc.Module.t; }
+      desc : Desc.Module.t;
+      deprecated : Desc.deprecated; }
 
   type t =
     { mutable next_dep : Dependency.t;
@@ -1879,11 +1789,11 @@ module Basis = struct
   let update_shortest t additions loads =
     let components =
       List.map
-        (fun { name; desc; _ } ->
+        (fun { name; desc; deprecated; _ } ->
            let index = String_map.find name t.assignment in
            let origin = Origin.Dependency index in
            let id = Ident.global name in
-           Component.Module(origin, id, desc, Component.Global))
+           Component.Module(origin, id, desc, Component.Global, deprecated))
         loads
     in
     let components =
@@ -1927,8 +1837,9 @@ module Basis = struct
   let add t name =
     t.pending_additions <- String_set.add name t.pending_additions
 
-  let load t name depends alias_depends desc =
-    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+  let load t name depends alias_depends desc deprecated =
+    let load = { name; depends; alias_depends; desc; deprecated } in
+    t.pending_loads <- load :: t.pending_loads
 
 end
 

--- a/src/ocaml/typing/406/short_paths.mli
+++ b/src/ocaml/typing/406/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/406/short_paths_graph.ml
+++ b/src/ocaml/typing/406/short_paths_graph.ml
@@ -81,6 +81,10 @@ module Path_set = Set.Make(Path)
 
 module Desc = struct
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type = struct
 
     type t =
@@ -111,10 +115,10 @@ module Desc = struct
   module Module = struct
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -128,11 +132,15 @@ module Desc = struct
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -235,15 +243,39 @@ module Origin = struct
 
 end
 
-(* CR lwhite: Should probably short-circuit indirections if they are to
-    canonical entries older than the indirection. *)
+let hidden_name name =
+  if name <> "" && name.[0] = '_' then true
+  else
+    try
+      for i = 1 to String.length name - 2 do
+        if name.[i] = '_' && name.[i + 1] = '_' then
+          raise Exit
+      done;
+      false
+    with Exit -> true
+
+let hidden_ident id =
+  if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
+  else hidden_name (Ident.name id)
+
+let hidden_definition deprecated name =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_name name
+
+let hidden_base_definition deprecated id =
+  match deprecated with
+  | Desc.Deprecated -> true
+  | Desc.Not_deprecated -> hidden_ident id
+
 module rec Type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Type.t option -> t
+  val base : Origin.t -> Ident.t -> Desc.Type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Type.t option -> t
+  val child :
+    Module.normalized -> string -> Desc.Type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -252,6 +284,8 @@ module rec Type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -266,7 +300,7 @@ end = struct
   open Desc.Type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Nth of int
     | Subst of Path.t * int list
@@ -275,10 +309,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -288,28 +324,36 @@ end = struct
     | Some Fresh -> Defined
     | Some (Nth n) -> Nth n
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -330,7 +374,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Nth _ | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -372,7 +416,7 @@ end = struct
         | exception Not_found -> Path(None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -380,9 +424,12 @@ and Class_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Class_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Class_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Class_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Class_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -391,6 +438,8 @@ and Class_type : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -403,7 +452,7 @@ end = struct
   open Desc.Class_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Subst of Path.t * int list
     | Unknown
@@ -411,10 +460,12 @@ end = struct
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
@@ -423,28 +474,36 @@ end = struct
     | None -> Unknown
     | Some Fresh -> Defined
     | Some (Subst(p, ns)) -> Subst(p, ns)
-    | Some (Alias alias) -> Indirection alias
+    | Some (Alias alias) -> Alias alias
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition = definition_of_desc desc in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -465,7 +524,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown | Subst _ } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_class_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -503,7 +562,7 @@ end = struct
         | exception Not_found -> (None, t)
         | aliased -> subst ns (resolve root aliased)
       end
-    | Definition { definition = Indirection _ } -> assert false
+    | Definition { definition = Alias _ } -> assert false
 
 end
 
@@ -511,9 +570,12 @@ and Module_type : sig
 
   type t
 
-  val base : Origin.t -> Ident.t -> Desc.Module_type.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module_type.t option -> Desc.deprecated -> t
 
-  val child : Module.normalized -> string -> Desc.Module_type.t option -> t
+  val child :
+    Module.normalized -> string ->
+    Desc.Module_type.t option -> Desc.deprecated -> t
 
   val declare : Origin.t -> Ident.t -> t
 
@@ -523,6 +585,8 @@ and Module_type : sig
 
   val path : Graph.t -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : Graph.t -> t -> Sort.t
 
 end = struct
@@ -530,50 +594,60 @@ end = struct
   open Desc.Module_type
 
   type definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Defined
     | Unknown
 
   type t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot (Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
       | Some Fresh -> Defined
-      | Some (Alias alias) -> Indirection alias
+      | Some (Alias alias) -> Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -594,7 +668,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Defined | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module_type root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -625,9 +699,11 @@ and Module : sig
 
   type normalized
 
-  val base : Origin.t -> Ident.t -> Desc.Module.t option -> t
+  val base :
+    Origin.t -> Ident.t -> Desc.Module.t option -> Desc.deprecated -> t
 
-  val child : normalized -> string -> Desc.Module.t option -> t
+  val child :
+    normalized -> string -> Desc.Module.t option -> Desc.deprecated -> t
 
   val application : normalized -> t -> Desc.Module.t option -> t
 
@@ -638,6 +714,8 @@ and Module : sig
   val origin : Graph.t -> t -> Origin.t
 
   val path : Graph.t -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : Graph.t -> t -> Sort.t
 
@@ -682,7 +760,7 @@ end = struct
           modules : t String_map.t; }
 
   and definition =
-    | Indirection of Path.t
+    | Alias of Path.t
     | Signature of
         { mutable components : components }
     | Functor of
@@ -693,15 +771,18 @@ end = struct
   and t =
     | Declaration of
         { origin : Origin.t;
-          id : Ident.t; }
+          id : Ident.t;
+          hidden : bool; }
     | Definition of
         { origin : Origin.t;
           path : Path.t;
+          hidden : bool;
           sort : Sort.t;
           definition : definition; }
 
-  let base origin id desc =
+  let base origin id desc deprecated =
     let path = Path.Pident id in
+    let hidden = hidden_base_definition deprecated id in
     let sort = Sort.Defined in
     let definition =
       match desc with
@@ -713,14 +794,15 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
-  let child md name desc =
+  let child md name desc deprecated =
     let origin = Module.raw_origin md in
     let sort = Module.raw_sort md in
     let path = Path.Pdot(Module.raw_path md, name, 0) in
+    let hidden = hidden_definition deprecated name in
     let definition =
       match desc with
       | None -> Unknown
@@ -731,9 +813,9 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let application func arg desc =
     let func_origin = Module.raw_origin func in
@@ -745,6 +827,7 @@ end = struct
     let func_path = Module.raw_path func in
     let arg_path = Module.raw_path arg in
     let path = Path.Papply(func_path, arg_path) in
+    let hidden = false in
     let definition =
       match desc with
       | None -> Unknown
@@ -755,17 +838,23 @@ end = struct
           let applications = Path_map.empty in
           Functor { apply; applications }
       | Some (Alias alias) ->
-          Indirection alias
+          Alias alias
     in
-    Definition { origin; path; sort; definition }
+    Definition { origin; path; hidden; sort; definition }
 
   let declare origin id =
-    Declaration { origin; id }
+    let hidden = hidden_ident id in
+    Declaration { origin; id; hidden }
 
   let declaration t =
     match t with
     | Definition _ -> None
     | Declaration { origin; _} -> Some origin
+
+  let hidden t =
+    match t with
+    | Definition { hidden; _ } -> hidden
+    | Declaration { hidden; _ } -> hidden
 
   let raw_origin t =
     match t with
@@ -788,7 +877,7 @@ end = struct
     match t with
     | Declaration _ -> t
     | Definition { definition = Signature _ | Functor _ | Unknown } -> t
-    | Definition ({ definition = Indirection alias } as r) -> begin
+    | Definition ({ definition = Alias alias } as r) -> begin
         match Graph.find_module root alias with
         | exception Not_found -> Definition { r with definition = Unknown }
         | aliased -> normalize_loop root aliased
@@ -821,27 +910,27 @@ end = struct
   let force root t =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Unknown
     | Functor _
     | Signature { components = Forced _ } -> t
     | Signature ({ components = Unforced components; _} as r) -> begin
         let rec loop types class_types module_types modules = function
           | [] -> Forced { types; class_types; module_types; modules }
-          | Type(name, desc) :: rest ->
-              let typ = Type.child t name (Some desc) in
+          | Type(name, desc, dpr) :: rest ->
+              let typ = Type.child t name (Some desc) dpr in
               let types = String_map.add name typ types in
               loop types class_types module_types modules rest
-          | Class_type(name, desc) :: rest ->
-              let clty = Class_type.child t name (Some desc) in
+          | Class_type(name, desc, dpr) :: rest ->
+              let clty = Class_type.child t name (Some desc) dpr in
               let class_types = String_map.add name clty class_types in
               loop types class_types module_types modules rest
-          | Module_type(name, desc) :: rest ->
-              let mty = Module_type.child t name (Some desc) in
+          | Module_type(name, desc, dpr) :: rest ->
+              let mty = Module_type.child t name (Some desc) dpr in
               let module_types = String_map.add name mty module_types in
               loop types class_types module_types modules rest
-          | Module(name, desc) :: rest ->
-              let md = Module.child t name (Some desc) in
+          | Module(name, desc, dpr) :: rest ->
+              let md = Module.child t name (Some desc) dpr in
               let modules = String_map.add name md modules in
               loop types class_types module_types modules rest
         in
@@ -854,7 +943,7 @@ end = struct
   let types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -864,7 +953,7 @@ end = struct
   let class_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -874,7 +963,7 @@ end = struct
   let module_types root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -884,7 +973,7 @@ end = struct
   let modules root t =
     let t = force root t in
     match definition t with
-    | Indirection _ | Signature { components = Unforced _ } ->
+    | Alias _ | Signature { components = Unforced _ } ->
         assert false
     | Unknown | Functor _ ->
         None
@@ -894,11 +983,11 @@ end = struct
   let find_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Type.child t name None
+        Type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { types; _ }; _ } ->
@@ -907,11 +996,11 @@ end = struct
   let find_class_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Class_type.child t name None
+        Class_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { class_types; _ }; _ } ->
@@ -920,11 +1009,11 @@ end = struct
   let find_module_type root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module_type.child t name None
+        Module_type.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { module_types; _ }; _ } ->
@@ -933,11 +1022,11 @@ end = struct
   let find_module root t name =
     let t = force root t in
     match definition t with
-    | Indirection _
+    | Alias _
     | Signature { components = Unforced _ } ->
         assert false
     | Unknown ->
-        Module.child t name None
+        Module.child t name None Not_deprecated
     | Functor _ ->
         raise Not_found
     | Signature { components = Forced { modules; _ }; _ } ->
@@ -946,7 +1035,7 @@ end = struct
   let find_application root t path =
     let t = Module.normalize root t in
     match definition t with
-    | Indirection _ -> assert false
+    | Alias _ -> assert false
     | Signature _ -> raise Not_found
     | Unknown ->
         let arg = Graph.find_module root path in
@@ -1025,10 +1114,14 @@ and Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -1061,6 +1154,14 @@ and Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end = struct
 
@@ -1149,36 +1250,36 @@ end = struct
   let add t descs =
     let rec loop acc diff declarations = function
       | [] -> loop_declarations acc diff declarations
-      | Component.Type(origin, id, desc, source) :: rest ->
+      | Component.Type(origin, id, desc, source, dpr) :: rest ->
           let prev = previous_type acc id in
-          let typ = Type.base origin id (Some desc) in
+          let typ = Type.base origin id (Some desc) dpr in
           let types = Ident_map.add id typ acc.types in
           let type_names = add_name source id acc.type_names in
           let item = Diff.Item.Type(id, typ, prev) in
           let diff = item :: diff in
           let acc = { acc with types; type_names } in
           loop acc diff declarations rest
-      | Component.Class_type(origin,id, desc, source) :: rest ->
+      | Component.Class_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_class_type acc id in
-          let clty = Class_type.base origin id (Some desc) in
+          let clty = Class_type.base origin id (Some desc) dpr in
           let class_types = Ident_map.add id clty acc.class_types in
           let class_type_names = add_name source id acc.class_type_names in
           let item = Diff.Item.Class_type(id, clty, prev) in
           let diff = item :: diff in
           let acc = { acc with class_types; class_type_names } in
           loop acc diff declarations rest
-      | Component.Module_type(origin,id, desc, source) :: rest ->
+      | Component.Module_type(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module_type acc id in
-          let mty = Module_type.base origin id (Some desc) in
+          let mty = Module_type.base origin id (Some desc) dpr in
           let module_types = Ident_map.add id mty acc.module_types in
           let module_type_names = add_name source id acc.module_type_names in
           let item = Diff.Item.Module_type(id, mty, prev) in
           let diff = item :: diff in
           let acc = { acc with module_types; module_type_names } in
           loop acc diff declarations rest
-      | Component.Module(origin,id, desc, source) :: rest ->
+      | Component.Module(origin,id, desc, source, dpr) :: rest ->
           let prev = previous_module acc id in
-          let md = Module.base origin id (Some desc) in
+          let md = Module.base origin id (Some desc) dpr in
           let modules = Ident_map.add id md acc.modules in
           let module_names = add_name source id acc.module_names in
           let item = Diff.Item.Module(id, md, prev) in
@@ -1349,88 +1450,92 @@ end = struct
     | exception Not_found -> Path.Pident id
     | md -> Module.path t md
 
-  let rec is_module_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_path t) ids in
-            let path = canonical_module_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_path t) ids in
+        let path = canonical_module_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let rec is_module_path_visible t = function
+    | Path.Pident id -> is_module_ident_visible t id
     | Path.Pdot(path, _, _) ->
         is_module_path_visible t path
     | Path.Papply(path1, path2) ->
         is_module_path_visible t path1
         && is_module_path_visible t path2
 
-  let is_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_type_path t) ids in
-            let path = canonical_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_type_path t) ids in
+        let path = canonical_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_type_path_visible t = function
+    | Path.Pident id -> is_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_type_path_visible: \
            invalid type path"
 
-  let is_class_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.class_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_class_type_path t) ids in
-            let path = canonical_class_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_class_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.class_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_class_type_path t) ids in
+        let path = canonical_class_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_class_type_path_visible t = function
+    | Path.Pident id -> is_class_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith
           "Short_paths_graph.Graph.is_class_type_path_visible: \
            invalid class type path"
 
-  let is_module_type_path_visible t = function
-    | Path.Pident id -> begin
-        let name = Ident.name id in
-        match String_map.find name t.module_type_names with
-        | exception Not_found -> false
-        | Local id' -> Ident.equal id id'
-        | Global id' -> Ident.equal id id'
-        | Unambiguous id' -> Ident.equal id id'
-        | Ambiguous(id', ids) ->
-          if not (Ident.equal id id') then false
-          else begin
-            let paths = List.map (canonical_module_type_path t) ids in
-            let path = canonical_module_type_path t id in
-            List.for_all (Path.equal path) paths
-          end
+  let is_module_type_ident_visible t id =
+    let name = Ident.name id in
+    match String_map.find name t.module_type_names with
+    | exception Not_found -> false
+    | Local id' -> Ident.equal id id'
+    | Global id' -> Ident.equal id id'
+    | Unambiguous id' -> Ident.equal id id'
+    | Ambiguous(id', ids) ->
+      if not (Ident.equal id id') then false
+      else begin
+        let paths = List.map (canonical_module_type_path t) ids in
+        let path = canonical_module_type_path t id in
+        List.for_all (Path.equal path) paths
       end
+
+  let is_module_type_path_visible t = function
+    | Path.Pident id -> is_module_type_ident_visible t id
     | Path.Pdot(path, _, _) -> is_module_path_visible t path
     | Path.Papply _ ->
         failwith

--- a/src/ocaml/typing/406/short_paths_graph.mli
+++ b/src/ocaml/typing/406/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -479,8 +479,7 @@ and short_paths_addition =
   | Type_open of Path.t * (type_declaration * type_descriptions) comp_tbl
   | Class_type_open of Path.t * class_type_declaration comp_tbl
   | Module_type_open of Path.t * modtype_declaration comp_tbl
-  | Module_open of
-      Path.t * (Subst.t * module_declaration, module_declaration) EnvLazy.t comp_tbl
+  | Module_open of Path.t * module_components comp_tbl
 
 let copy_local ~from env =
   { env with
@@ -669,11 +668,25 @@ let register_pers_for_short_paths ps =
       ([], []) ps.ps_crcs
   in
   let path = Pident (Ident.create_persistent ps.ps_name) in
-  let desc =
-    Short_paths.Desc.Module.(Fresh
-      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  let components =
+    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
   in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Deprecated _ -> true
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name
+    deps alias_deps desc deprecated
 
 (* Reading persistent structures from .cmi files *)
 
@@ -1660,9 +1673,9 @@ let short_paths_module id decl comps old =
   if !Clflags.real_paths then old
   else Module(id, decl, comps) :: old
 
-let short_paths_module_open path decls old =
+let short_paths_module_open path comps old =
   if !Clflags.real_paths then old
-  else Module_open(path, decls) :: old
+  else Module_open(path, comps) :: old
 
 (* Compute structure descriptions *)
 
@@ -2103,13 +2116,13 @@ let add_components ?filter_modules slot root env0 comps =
     add_cltypes (fun x -> `Class_type x)
       comps.comp_cltypes env0.cltypes additions
   in
-  let components =
-    filter_and_add add (fun x -> `Component x)
-      comps.comp_components env0.components
+  let components, additions =
+    filter_and_add add_modules (fun x -> `Component x)
+      comps.comp_components env0.components additions
   in
-  let modules, additions =
-    filter_and_add add_modules (fun x -> `Module x)
-      comps.comp_modules env0.modules additions
+  let modules =
+    filter_and_add add (fun x -> `Module x)
+      comps.comp_modules env0.modules
   in
 
   { env0 with
@@ -2436,6 +2449,15 @@ let short_paths_module_type_desc mty =
   | Some (Mty_signature _ | Mty_functor _) -> Fresh
   | Some (Mty_alias _) -> assert false
 
+let deprecated_of_string_opt stro =
+  match stro with
+  | None -> Short_paths.Desc.Not_deprecated
+  | Some _ -> Short_paths.Desc.Deprecated
+
+let deprecated_of_attributes attrs =
+  deprecated_of_string_opt
+    (Builtin_attributes.deprecated_of_attrs attrs)
+
 let rec short_paths_module_desc env mpath mty comp =
   let open Short_paths.Desc.Module in
   match mty with
@@ -2464,7 +2486,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name ((decl, _), _) acc ->
              let desc = short_paths_type_desc decl in
-             let item = Short_paths.Desc.Module.Type(name, desc) in
+             let depr = deprecated_of_attributes decl.type_attributes in
+             let item = Short_paths.Desc.Module.Type(name, desc, depr) in
              item :: acc)
           c.comp_types []
       in
@@ -2472,7 +2495,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (clty, _) acc ->
              let desc = short_paths_class_type_desc clty in
-             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             let depr = deprecated_of_attributes clty.clty_attributes in
+             let item = Short_paths.Desc.Module.Class_type(name, desc, depr) in
              item :: acc)
           c.comp_cltypes comps
       in
@@ -2480,7 +2504,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (mtd, _) acc ->
              let desc = short_paths_module_type_desc mtd.mtd_type in
-             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             let depr = deprecated_of_attributes mtd.mtd_attributes in
+             let item = Short_paths.Desc.Module.Module_type(name, desc, depr) in
              item :: acc)
           c.comp_modtypes comps
       in
@@ -2495,7 +2520,8 @@ and short_paths_module_components_desc env mpath comp =
              let mty = EnvLazy.force subst_modtype_maker data in
              let mpath = Pdot(mpath, name, 0) in
              let desc = short_paths_module_desc env mpath mty.md_type comps in
-             let item = Short_paths.Desc.Module.Module(name, desc) in
+             let depr = deprecated_of_string_opt comps.deprecated in
+             let item = Short_paths.Desc.Module.Module(name, desc, depr) in
              item :: acc)
           c.comp_modules comps
       in
@@ -2527,47 +2553,65 @@ let short_paths_additions_desc env additions =
        match add with
        | Type(id, decl) ->
            let desc = short_paths_type_desc decl in
-           Short_paths.Desc.Type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes decl.type_attributes in
+           Short_paths.Desc.Type(id, desc, source, depr) :: acc
        | Class_type(id, clty) ->
            let desc = short_paths_class_type_desc clty in
-           Short_paths.Desc.Class_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes clty.clty_attributes in
+           Short_paths.Desc.Class_type(id, desc, source, depr) :: acc
        | Module_type(id, mtd) ->
            let desc = short_paths_module_type_desc mtd.mtd_type in
-           Short_paths.Desc.Module_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes mtd.mtd_attributes in
+           Short_paths.Desc.Module_type(id, desc, source, depr) :: acc
        | Module(id, md, comps) ->
-           let desc = short_paths_module_desc env (Pident id) md.md_type comps in
-           Short_paths.Desc.Module(id, desc, true) :: acc
+           let desc =
+             short_paths_module_desc env (Pident id) md.md_type comps
+           in
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_string_opt comps.deprecated in
+           Short_paths.Desc.Module(id, desc, source, depr) :: acc
        | Type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name ((decl, _), pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Type.Alias path in
-                Short_paths.Desc.Type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes decl.type_attributes in
+                Short_paths.Desc.Type(id, desc, source, depr) :: acc)
              decls acc
        | Class_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (clty, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Class_type.Alias path in
-                Short_paths.Desc.Class_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes clty.clty_attributes in
+                Short_paths.Desc.Class_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (mtd, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module_type.Alias path in
-                Short_paths.Desc.Module_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes mtd.mtd_attributes in
+                Short_paths.Desc.Module_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (comps, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module.Alias path in
-                Short_paths.Desc.Module(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_string_opt comps.deprecated in
+                Short_paths.Desc.Module(id, desc, source, depr) :: acc)
              decls acc)
     [] additions
 

--- a/src/ocaml/typing/407/short_paths.ml
+++ b/src/ocaml/typing/407/short_paths.ml
@@ -300,43 +300,7 @@ module Origin_range_tbl = struct
 
 end
 
-module Height = struct
-
-  include Natural.Make_no_zero()
-
-  let hidden_name name =
-    if name <> "" && name.[0] = '_' then true
-    else
-      try
-        for i = 1 to String.length name - 2 do
-          if name.[i] = '_' && name.[i + 1] = '_' then
-            raise Exit
-        done;
-        false
-      with Exit -> true
-
-  let hidden_ident id =
-    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
-    else hidden_name (Ident.name id)
-
-  let measure_name name =
-    if hidden_name name then maximum
-    else one
-
-  let measure_ident id =
-    if hidden_ident id then maximum
-    else one
-
-  let rec measure_path = function
-    | Path.Pident id ->
-        measure_ident id
-    | Path.Pdot(p, name, _) ->
-        if hidden_name name then maximum
-        else succ (measure_path p)
-    | Path.Papply(p1, p2) ->
-        plus (measure_path p1) (measure_path p2)
-
-end
+module Height = Natural.Make_no_zero()
 
 module Todo = struct
 
@@ -1121,8 +1085,9 @@ module Shortest = struct
     { kind; graph; sections; todos }
 
   let local_or_open conc =
-    if conc then Component.Local
-    else Component.Open
+    match conc with
+    | Desc.Local -> Component.Local
+    | Desc.Open -> Component.Open
 
   let env parent desc =
     update parent;
@@ -1132,14 +1097,14 @@ module Shortest = struct
       List.map
         (fun desc ->
            match desc with
-           | Desc.Type(id, desc, conc) ->
-               Component.Type(origin, id, desc, local_or_open conc)
-           | Desc.Class_type(id, desc, conc) ->
-               Component.Class_type(origin, id, desc, local_or_open conc)
-           | Desc.Module_type(id, desc, conc) ->
-               Component.Module_type(origin, id, desc, local_or_open conc)
-           | Desc.Module(id, desc, conc) ->
-               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Type(id, desc, conc, dpr) ->
+               Component.Type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Class_type(id, desc, conc, dpr) ->
+               Component.Class_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module_type(id, desc, conc, dpr) ->
+               Component.Module_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module(id, desc, conc, dpr) ->
+               Component.Module(origin, id, desc, local_or_open conc, dpr)
            | Desc.Declare_type id ->
                Component.Declare_type(origin, id)
            | Desc.Declare_class_type id ->
@@ -1244,28 +1209,28 @@ module Shortest = struct
     in
     String_map.iter
       (fun name typ ->
-         if not (Height.hidden_name name) then begin
+         if not (Type.hidden typ) then begin
            let path = Path.Pdot(path, name, 0) in
            process_type t height path typ
          end)
       types;
     String_map.iter
-      (fun name mty ->
-         if not (Height.hidden_name name) then begin
+      (fun name clty ->
+         if not (Class_type.hidden clty) then begin
            let path = Path.Pdot(path, name, 0) in
-           process_class_type t height path mty
+           process_class_type t height path clty
          end)
       class_types;
     String_map.iter
       (fun name mty ->
-         if not (Height.hidden_name name) then begin
+         if not (Module_type.hidden mty) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module_type t height path mty
          end)
       module_types;
     String_map.iter
       (fun name md ->
-         if not (Height.hidden_name name) then begin
+         if not (Module.hidden md) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module t height path seen md
          end)
@@ -1280,22 +1245,22 @@ module Shortest = struct
           List.iter
             (function
               | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Type.hidden typ) then begin
                     let path = Path.Pident id in
                     process_type t height path typ
                   end
-              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+              | Todo.Item.Base (Diff.Item.Class_type(id, clty, _)) ->
+                  if not (Class_type.hidden clty) then begin
                     let path = Path.Pident id in
-                    process_class_type t height path mty
+                    process_class_type t height path clty
                   end
               | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module_type.hidden mty) then begin
                     let path = Path.Pident id in
                     process_module_type t height path mty
                   end
               | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module.hidden md) then begin
                     let path = Path.Pident id in
                     process_module t height path Path_set.empty md
                   end
@@ -1413,10 +1378,6 @@ module Shortest = struct
       | Module_type : Module_type.t kind
       | Module : Module.t kind
 
-    type suffix =
-      { names : string list;
-        height : Height.t; }
-
     type name =
       { name : string;
         height : Height.t; }
@@ -1450,7 +1411,6 @@ module Shortest = struct
             max: Height.t;
             func : Module.t t;
             arg : Module.t t;
-            suffix : suffix option;
             func_first : bool;
             searched : bool;
             finished : bool; }
@@ -1459,6 +1419,16 @@ module Shortest = struct
       | Ident { min; _ } -> min
       | Dot { min; _ } -> min
       | Application { min; _ } -> min
+
+    let max_height = function
+      | Ident { max; _ } -> max
+      | Dot { max; _ } -> max
+      | Application { max; _ } -> max
+
+    let search_origin = function
+      | Ident { origin; _ } -> origin
+      | Dot { origin; _ } -> origin
+      | Application { origin; _ } -> origin
 
     let finished = function
       | Ident { finished; _ } -> finished
@@ -1470,163 +1440,99 @@ module Shortest = struct
       | Dot { best; _ } -> best
       | Application { best; _ } -> best
 
-    let min_application fst snd suffix =
-      let base = Height.plus (min_height fst) (min_height snd) in
-      match suffix with
-      | None -> base
-      | Some { names = _; height } -> Height.plus base height
+    let min_application fst snd =
+      Height.plus (min_height fst) (min_height snd)
+
+    let max_application fst snd =
+      Height.plus (max_height fst) (max_height snd)
 
     let min_dot parent name =
       let base = min_height parent in
       Height.plus base name.height
 
-    let path_application fst snd suffix =
-      let base = Path.Papply(best fst, best snd) in
-      match suffix with
-      | None -> base
-      | Some { names; _ } ->
-          List.fold_left
-            (fun acc name -> Path.Pdot(acc, name, 0))
-            base names
+    let path_application fst snd =
+      Path.Papply(best fst, best snd)
 
     let path_dot parent name =
-      let base = best parent in
-      Path.Pdot(base, name.name, 0)
+      Path.Pdot(best parent, name.name, 0)
 
-    let create (type k) shortest (kind : k kind) (node : k) =
-      let rec loop :
-        type k. k kind -> k -> Origin.t -> Path.t ->
-          Height.t -> string list -> Path.t -> k t =
-        fun kind node origin best max suffix path ->
+    let is_visible_ident (type k) graph (kind : k kind) id =
+      match kind with
+      | Type -> Graph.is_type_ident_visible graph id
+      | Class_type -> Graph.is_class_type_ident_visible graph id
+      | Module_type -> Graph.is_module_type_ident_visible graph id
+      | Module -> Graph.is_module_ident_visible graph id
+
+    let create (type k) shortest (kind : k kind) canonical_path =
+      let rec loop : type k. k kind -> Path.t -> k t =
+        fun kind path ->
+          let graph = shortest.graph in
+          let (node : k), origin, hidden =
+            match kind with
+            | Type ->
+                let node = Graph.find_type graph path in
+                let origin = Type.origin graph node in
+                let hidden = Type.hidden node in
+                node, origin, hidden
+            | Class_type ->
+                let node = Graph.find_class_type graph path in
+                let origin = Class_type.origin graph node in
+                let hidden = Class_type.hidden node in
+                node, origin, hidden
+            | Module_type ->
+                let node = Graph.find_module_type graph path in
+                let origin = Module_type.origin graph node in
+                let hidden = Module_type.hidden node in
+                node, origin, hidden
+            | Module ->
+                let node = Graph.find_module graph path in
+                let origin = Module.origin graph node in
+                let hidden = Module.hidden node in
+                node, origin, hidden
+          in
+          let best = path in
           match path with
-          | Path.Pident _ ->
+          | Path.Pident id ->
+              let max =
+                if is_visible_ident graph kind id && not hidden then
+                  Height.one
+                else
+                  Height.maximum
+              in
               let min = Height.one in
               let finished = false in
-              Ident
-                { kind; node; origin; best; min; max; finished; }
+              Ident { kind; node; origin; best; min; max; finished }
           | Path.Pdot(parent, name, _) ->
-              let graph = shortest.graph in
-              let parent_md = Graph.find_module graph parent in
-              let parent_max = Height.measure_path parent in
-              let parent_origin = Module.origin graph parent_md in
-              let parent =
-                loop Module parent_md parent_origin
-                  parent parent_max [] parent
-              in
+              let parent = loop Module parent in
               let finished = false in
-              let name =
-                let height = Height.measure_name name in
-                { name; height }
+              let name_height =
+                if not hidden then Height.one
+                else Height.maximum
               in
+              let name = { name; height = name_height } in
               let searched = false in
+              let max = Height.plus (max_height parent) name_height in
               let min = Height.one in
               Dot
                 { kind; node; origin; best; min; max;
                   parent; name; searched; finished }
           | Path.Papply(func, arg) ->
-              let graph = shortest.graph in
-              let func_md = Graph.find_module graph func in
-              let func_max = Height.measure_path func in
-              let func_origin = Module.origin graph func_md in
-              let func =
-                loop Module func_md func_origin func func_max [] func
-              in
-              let arg_md = Graph.find_module graph arg in
-              let arg_max = Height.measure_path arg in
-              let arg_origin = Module.origin graph arg_md in
-              let arg =
-                loop Module arg_md arg_origin arg arg_max [] arg
-              in
+              let func = loop Module func in
+              let arg = loop Module arg in
               let func_first =
-                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+                Rev_deps.before (rev_deps shortest)
+                  (search_origin arg) (search_origin func)
               in
               let finished = false in
-              let suffix =
-                match suffix with
-                | [] -> None
-                | fst :: rest ->
-                  let names = suffix in
-                  let height =
-                    List.fold_left
-                      (fun acc name ->
-                         Height.plus acc (Height.measure_name name))
-                      (Height.measure_name fst) rest
-                  in
-                  Some { names; height }
-              in
-              let searched, min =
-                match kind with
-                | Type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Class_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module ->
-                    (* There are no module aliases containing extended paths *)
-                    let searched = true in
-                    let min = min_application func arg suffix in
-                    searched, min
-              in
+              (* There are no module aliases containing extended paths *)
+              let searched = true in
+              let max = max_application func arg in
+              let min = min_application func arg in
               Application
                 { kind; node; origin; best; min; max;
-                  func; arg; suffix; func_first; searched; finished }
+                  func; arg; func_first; searched; finished }
       in
-      let graph = shortest.graph in
-      let canonical_path, origin, max =
-        match kind with
-        | Type ->
-            let canonical_path = Type.path graph node in
-            let origin = Type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Class_type ->
-            let canonical_path = Class_type.path graph node in
-            let origin = Class_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_class_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module_type ->
-            let canonical_path = Module_type.path graph node in
-            let origin = Module_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module ->
-            let canonical_path = Module.path graph node in
-            let origin = Module.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-      in
-      loop kind node origin canonical_path max [] canonical_path
+      loop kind canonical_path
 
     let find (type k) shortest origin height (kind : k kind) (node : k) =
       let sections = force shortest origin height in
@@ -1710,15 +1616,13 @@ module Shortest = struct
                 in
                 let fst, snd =
                   let should_try_app =
-                    Height.equal
-                      (min_application fst snd r.suffix) r.min
+                    Height.equal (min_application fst snd) r.min
                   in
                   if not should_try_app then fst, snd
                   else begin
                     let fst = step shortest fst in
                     let should_try_app =
-                      Height.equal
-                        (min_application fst snd r.suffix) r.min
+                      Height.equal (min_application fst snd) r.min
                     in
                     if not should_try_app then fst, snd
                     else fst, step shortest snd
@@ -1730,11 +1634,10 @@ module Shortest = struct
                 in
                 let found =
                   finished func && finished arg
-                  && Height.equal
-                       (min_application fst snd r.suffix) r.min
+                  && Height.equal (min_application fst snd) r.min
                 in
                 if found then begin
-                  let best = path_application func arg r.suffix in
+                  let best = path_application func arg in
                   let max = r.min in
                   let finished = true in
                   Application
@@ -1743,7 +1646,7 @@ module Shortest = struct
                   let finished =
                     searched
                     && Height.less_than_or_equal
-                         r.max (min_application fst snd r.suffix)
+                         r.max (min_application fst snd)
                   in
                   let min = if finished then r.max else Height.succ r.min in
                   Application
@@ -1778,7 +1681,8 @@ module Shortest = struct
     match Type.resolve t.graph typ with
     | Type.Nth n -> Nth n
     | Type.Path(subst, typ) ->
-      let search = Search.create t Search.Type typ in
+      let canonical_path = Type.path t.graph typ in
+      let search = Search.create t Search.Type canonical_path in
       let path = Search.perform t search in
       Path(subst, path)
 
@@ -1793,33 +1697,38 @@ module Shortest = struct
   let find_type_simple t path =
     update t;
     let typ = Graph.find_type t.graph path in
-    let search = Search.create t Search.Type typ in
+    let canonical_path = Type.path t.graph typ in
+    let search = Search.create t Search.Type canonical_path in
     Search.perform t search
 
   let find_class_type t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
     let subst, clty = Class_type.resolve t.graph clty in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     let path = Search.perform t search in
     (subst, path)
 
   let find_class_type_simple t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     Search.perform t search
 
   let find_module_type t path =
     update t;
     let mty = Graph.find_module_type t.graph path in
-    let search = Search.create t Search.Module_type mty in
+    let canonical_path = Module_type.path t.graph mty in
+    let search = Search.create t Search.Module_type canonical_path in
     Search.perform t search
 
   let find_module t path =
     update t;
     let md = Graph.find_module t.graph path in
-    let search = Search.create t Search.Module md in
+    let canonical_path = Module.path t.graph md in
+    let search = Search.create t Search.Module canonical_path in
     Search.perform t search
 
 end
@@ -1832,7 +1741,8 @@ module Basis = struct
     { name : string;
       depends : string list;
       alias_depends : string list;
-      desc : Desc.Module.t; }
+      desc : Desc.Module.t;
+      deprecated : Desc.deprecated; }
 
   type t =
     { mutable next_dep : Dependency.t;
@@ -1879,11 +1789,11 @@ module Basis = struct
   let update_shortest t additions loads =
     let components =
       List.map
-        (fun { name; desc; _ } ->
+        (fun { name; desc; deprecated; _ } ->
            let index = String_map.find name t.assignment in
            let origin = Origin.Dependency index in
            let id = Ident.global name in
-           Component.Module(origin, id, desc, Component.Global))
+           Component.Module(origin, id, desc, Component.Global, deprecated))
         loads
     in
     let components =
@@ -1927,8 +1837,9 @@ module Basis = struct
   let add t name =
     t.pending_additions <- String_set.add name t.pending_additions
 
-  let load t name depends alias_depends desc =
-    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+  let load t name depends alias_depends desc deprecated =
+    let load = { name; depends; alias_depends; desc; deprecated } in
+    t.pending_loads <- load :: t.pending_loads
 
 end
 

--- a/src/ocaml/typing/407/short_paths.mli
+++ b/src/ocaml/typing/407/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/407/short_paths_graph.mli
+++ b/src/ocaml/typing/407/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -479,8 +479,7 @@ and short_paths_addition =
   | Type_open of Path.t * (type_declaration * type_descriptions) comp_tbl
   | Class_type_open of Path.t * class_type_declaration comp_tbl
   | Module_type_open of Path.t * modtype_declaration comp_tbl
-  | Module_open of
-      Path.t * (Subst.t * module_declaration, module_declaration) EnvLazy.t comp_tbl
+  | Module_open of Path.t * module_components comp_tbl
 
 let copy_local ~from env =
   { env with
@@ -669,11 +668,25 @@ let register_pers_for_short_paths ps =
       ([], []) ps.ps_crcs
   in
   let path = Pident (Ident.create_persistent ps.ps_name) in
-  let desc =
-    Short_paths.Desc.Module.(Fresh
-      (Signature (lazy (!short_paths_module_components_desc' empty path ps.ps_comps))))
+  let components =
+    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
   in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name deps alias_deps desc
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Deprecated _ -> true
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load !short_paths_basis ps.ps_name
+    deps alias_deps desc deprecated
 
 (* Reading persistent structures from .cmi files *)
 
@@ -1661,9 +1674,9 @@ let short_paths_module id decl comps old =
   if !Clflags.real_paths then old
   else Module(id, decl, comps) :: old
 
-let short_paths_module_open path decls old =
+let short_paths_module_open path comps old =
   if !Clflags.real_paths then old
-  else Module_open(path, decls) :: old
+  else Module_open(path, comps) :: old
 
 (* Compute structure descriptions *)
 
@@ -2104,13 +2117,13 @@ let add_components ?filter_modules slot root env0 comps =
     add_cltypes (fun x -> `Class_type x)
       comps.comp_cltypes env0.cltypes additions
   in
-  let components =
-    filter_and_add add (fun x -> `Component x)
-      comps.comp_components env0.components
+  let components, additions =
+    filter_and_add add_modules (fun x -> `Component x)
+      comps.comp_components env0.components additions
   in
-  let modules, additions =
-    filter_and_add add_modules (fun x -> `Module x)
-      comps.comp_modules env0.modules additions
+  let modules =
+    filter_and_add add (fun x -> `Module x)
+      comps.comp_modules env0.modules
   in
 
   { env0 with
@@ -2437,6 +2450,15 @@ let short_paths_module_type_desc mty =
   | Some (Mty_signature _ | Mty_functor _) -> Fresh
   | Some (Mty_alias _) -> assert false
 
+let deprecated_of_string_opt stro =
+  match stro with
+  | None -> Short_paths.Desc.Not_deprecated
+  | Some _ -> Short_paths.Desc.Deprecated
+
+let deprecated_of_attributes attrs =
+  deprecated_of_string_opt
+    (Builtin_attributes.deprecated_of_attrs attrs)
+
 let rec short_paths_module_desc env mpath mty comp =
   let open Short_paths.Desc.Module in
   match mty with
@@ -2465,7 +2487,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name ((decl, _), _) acc ->
              let desc = short_paths_type_desc decl in
-             let item = Short_paths.Desc.Module.Type(name, desc) in
+             let depr = deprecated_of_attributes decl.type_attributes in
+             let item = Short_paths.Desc.Module.Type(name, desc, depr) in
              item :: acc)
           c.comp_types []
       in
@@ -2473,7 +2496,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (clty, _) acc ->
              let desc = short_paths_class_type_desc clty in
-             let item = Short_paths.Desc.Module.Class_type(name, desc) in
+             let depr = deprecated_of_attributes clty.clty_attributes in
+             let item = Short_paths.Desc.Module.Class_type(name, desc, depr) in
              item :: acc)
           c.comp_cltypes comps
       in
@@ -2481,7 +2505,8 @@ and short_paths_module_components_desc env mpath comp =
         Tbl.fold
           (fun name (mtd, _) acc ->
              let desc = short_paths_module_type_desc mtd.mtd_type in
-             let item = Short_paths.Desc.Module.Module_type(name, desc) in
+             let depr = deprecated_of_attributes mtd.mtd_attributes in
+             let item = Short_paths.Desc.Module.Module_type(name, desc, depr) in
              item :: acc)
           c.comp_modtypes comps
       in
@@ -2496,7 +2521,8 @@ and short_paths_module_components_desc env mpath comp =
              let mty = EnvLazy.force subst_modtype_maker data in
              let mpath = Pdot(mpath, name, 0) in
              let desc = short_paths_module_desc env mpath mty.md_type comps in
-             let item = Short_paths.Desc.Module.Module(name, desc) in
+             let depr = deprecated_of_string_opt comps.deprecated in
+             let item = Short_paths.Desc.Module.Module(name, desc, depr) in
              item :: acc)
           c.comp_modules comps
       in
@@ -2528,47 +2554,65 @@ let short_paths_additions_desc env additions =
        match add with
        | Type(id, decl) ->
            let desc = short_paths_type_desc decl in
-           Short_paths.Desc.Type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes decl.type_attributes in
+           Short_paths.Desc.Type(id, desc, source, depr) :: acc
        | Class_type(id, clty) ->
            let desc = short_paths_class_type_desc clty in
-           Short_paths.Desc.Class_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes clty.clty_attributes in
+           Short_paths.Desc.Class_type(id, desc, source, depr) :: acc
        | Module_type(id, mtd) ->
            let desc = short_paths_module_type_desc mtd.mtd_type in
-           Short_paths.Desc.Module_type(id, desc, true) :: acc
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_attributes mtd.mtd_attributes in
+           Short_paths.Desc.Module_type(id, desc, source, depr) :: acc
        | Module(id, md, comps) ->
-           let desc = short_paths_module_desc env (Pident id) md.md_type comps in
-           Short_paths.Desc.Module(id, desc, true) :: acc
+           let desc =
+             short_paths_module_desc env (Pident id) md.md_type comps
+           in
+           let source = Short_paths.Desc.Local in
+           let depr = deprecated_of_string_opt comps.deprecated in
+           Short_paths.Desc.Module(id, desc, source, depr) :: acc
        | Type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name ((decl, _), pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Type.Alias path in
-                Short_paths.Desc.Type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes decl.type_attributes in
+                Short_paths.Desc.Type(id, desc, source, depr) :: acc)
              decls acc
        | Class_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (clty, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Class_type.Alias path in
-                Short_paths.Desc.Class_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes clty.clty_attributes in
+                Short_paths.Desc.Class_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_type_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (mtd, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module_type.Alias path in
-                Short_paths.Desc.Module_type(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_attributes mtd.mtd_attributes in
+                Short_paths.Desc.Module_type(id, desc, source, depr) :: acc)
              decls acc
        | Module_open(root, decls) ->
            Tbl.fold
-             (fun name (_, pos) acc ->
+             (fun name (comps, pos) acc ->
                 let id = Ident.create name in
                 let path = Pdot(root, name, pos) in
                 let desc = Short_paths.Desc.Module.Alias path in
-                Short_paths.Desc.Module(id, desc, false) :: acc)
+                let source = Short_paths.Desc.Open in
+                let depr = deprecated_of_string_opt comps.deprecated in
+                Short_paths.Desc.Module(id, desc, source, depr) :: acc)
              decls acc)
     [] additions
 

--- a/src/ocaml/typing/407_0/short_paths.ml
+++ b/src/ocaml/typing/407_0/short_paths.ml
@@ -300,43 +300,7 @@ module Origin_range_tbl = struct
 
 end
 
-module Height = struct
-
-  include Natural.Make_no_zero()
-
-  let hidden_name name =
-    if name <> "" && name.[0] = '_' then true
-    else
-      try
-        for i = 1 to String.length name - 2 do
-          if name.[i] = '_' && name.[i + 1] = '_' then
-            raise Exit
-        done;
-        false
-      with Exit -> true
-
-  let hidden_ident id =
-    if !Clflags.unsafe_string && Ident.equal id Predef.ident_bytes then true
-    else hidden_name (Ident.name id)
-
-  let measure_name name =
-    if hidden_name name then maximum
-    else one
-
-  let measure_ident id =
-    if hidden_ident id then maximum
-    else one
-
-  let rec measure_path = function
-    | Path.Pident id ->
-        measure_ident id
-    | Path.Pdot(p, name, _) ->
-        if hidden_name name then maximum
-        else succ (measure_path p)
-    | Path.Papply(p1, p2) ->
-        plus (measure_path p1) (measure_path p2)
-
-end
+module Height = Natural.Make_no_zero()
 
 module Todo = struct
 
@@ -1121,8 +1085,9 @@ module Shortest = struct
     { kind; graph; sections; todos }
 
   let local_or_open conc =
-    if conc then Component.Local
-    else Component.Open
+    match conc with
+    | Desc.Local -> Component.Local
+    | Desc.Open -> Component.Open
 
   let env parent desc =
     update parent;
@@ -1132,14 +1097,14 @@ module Shortest = struct
       List.map
         (fun desc ->
            match desc with
-           | Desc.Type(id, desc, conc) ->
-               Component.Type(origin, id, desc, local_or_open conc)
-           | Desc.Class_type(id, desc, conc) ->
-               Component.Class_type(origin, id, desc, local_or_open conc)
-           | Desc.Module_type(id, desc, conc) ->
-               Component.Module_type(origin, id, desc, local_or_open conc)
-           | Desc.Module(id, desc, conc) ->
-               Component.Module(origin, id, desc, local_or_open conc)
+           | Desc.Type(id, desc, conc, dpr) ->
+               Component.Type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Class_type(id, desc, conc, dpr) ->
+               Component.Class_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module_type(id, desc, conc, dpr) ->
+               Component.Module_type(origin, id, desc, local_or_open conc, dpr)
+           | Desc.Module(id, desc, conc, dpr) ->
+               Component.Module(origin, id, desc, local_or_open conc, dpr)
            | Desc.Declare_type id ->
                Component.Declare_type(origin, id)
            | Desc.Declare_class_type id ->
@@ -1244,28 +1209,28 @@ module Shortest = struct
     in
     String_map.iter
       (fun name typ ->
-         if not (Height.hidden_name name) then begin
+         if not (Type.hidden typ) then begin
            let path = Path.Pdot(path, name, 0) in
            process_type t height path typ
          end)
       types;
     String_map.iter
-      (fun name mty ->
-         if not (Height.hidden_name name) then begin
+      (fun name clty ->
+         if not (Class_type.hidden clty) then begin
            let path = Path.Pdot(path, name, 0) in
-           process_class_type t height path mty
+           process_class_type t height path clty
          end)
       class_types;
     String_map.iter
       (fun name mty ->
-         if not (Height.hidden_name name) then begin
+         if not (Module_type.hidden mty) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module_type t height path mty
          end)
       module_types;
     String_map.iter
       (fun name md ->
-         if not (Height.hidden_name name) then begin
+         if not (Module.hidden md) then begin
            let path = Path.Pdot(path, name, 0) in
            process_module t height path seen md
          end)
@@ -1280,22 +1245,22 @@ module Shortest = struct
           List.iter
             (function
               | Todo.Item.Base (Diff.Item.Type(id, typ, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Type.hidden typ) then begin
                     let path = Path.Pident id in
                     process_type t height path typ
                   end
-              | Todo.Item.Base (Diff.Item.Class_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+              | Todo.Item.Base (Diff.Item.Class_type(id, clty, _)) ->
+                  if not (Class_type.hidden clty) then begin
                     let path = Path.Pident id in
-                    process_class_type t height path mty
+                    process_class_type t height path clty
                   end
               | Todo.Item.Base (Diff.Item.Module_type(id, mty, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module_type.hidden mty) then begin
                     let path = Path.Pident id in
                     process_module_type t height path mty
                   end
               | Todo.Item.Base (Diff.Item.Module(id, md, _)) ->
-                  if not (Height.hidden_ident id) then begin
+                  if not (Module.hidden md) then begin
                     let path = Path.Pident id in
                     process_module t height path Path_set.empty md
                   end
@@ -1413,10 +1378,6 @@ module Shortest = struct
       | Module_type : Module_type.t kind
       | Module : Module.t kind
 
-    type suffix =
-      { names : string list;
-        height : Height.t; }
-
     type name =
       { name : string;
         height : Height.t; }
@@ -1450,7 +1411,6 @@ module Shortest = struct
             max: Height.t;
             func : Module.t t;
             arg : Module.t t;
-            suffix : suffix option;
             func_first : bool;
             searched : bool;
             finished : bool; }
@@ -1459,6 +1419,16 @@ module Shortest = struct
       | Ident { min; _ } -> min
       | Dot { min; _ } -> min
       | Application { min; _ } -> min
+
+    let max_height = function
+      | Ident { max; _ } -> max
+      | Dot { max; _ } -> max
+      | Application { max; _ } -> max
+
+    let search_origin = function
+      | Ident { origin; _ } -> origin
+      | Dot { origin; _ } -> origin
+      | Application { origin; _ } -> origin
 
     let finished = function
       | Ident { finished; _ } -> finished
@@ -1470,163 +1440,99 @@ module Shortest = struct
       | Dot { best; _ } -> best
       | Application { best; _ } -> best
 
-    let min_application fst snd suffix =
-      let base = Height.plus (min_height fst) (min_height snd) in
-      match suffix with
-      | None -> base
-      | Some { names = _; height } -> Height.plus base height
+    let min_application fst snd =
+      Height.plus (min_height fst) (min_height snd)
+
+    let max_application fst snd =
+      Height.plus (max_height fst) (max_height snd)
 
     let min_dot parent name =
       let base = min_height parent in
       Height.plus base name.height
 
-    let path_application fst snd suffix =
-      let base = Path.Papply(best fst, best snd) in
-      match suffix with
-      | None -> base
-      | Some { names; _ } ->
-          List.fold_left
-            (fun acc name -> Path.Pdot(acc, name, 0))
-            base names
+    let path_application fst snd =
+      Path.Papply(best fst, best snd)
 
     let path_dot parent name =
-      let base = best parent in
-      Path.Pdot(base, name.name, 0)
+      Path.Pdot(best parent, name.name, 0)
 
-    let create (type k) shortest (kind : k kind) (node : k) =
-      let rec loop :
-        type k. k kind -> k -> Origin.t -> Path.t ->
-          Height.t -> string list -> Path.t -> k t =
-        fun kind node origin best max suffix path ->
+    let is_visible_ident (type k) graph (kind : k kind) id =
+      match kind with
+      | Type -> Graph.is_type_ident_visible graph id
+      | Class_type -> Graph.is_class_type_ident_visible graph id
+      | Module_type -> Graph.is_module_type_ident_visible graph id
+      | Module -> Graph.is_module_ident_visible graph id
+
+    let create (type k) shortest (kind : k kind) canonical_path =
+      let rec loop : type k. k kind -> Path.t -> k t =
+        fun kind path ->
+          let graph = shortest.graph in
+          let (node : k), origin, hidden =
+            match kind with
+            | Type ->
+                let node = Graph.find_type graph path in
+                let origin = Type.origin graph node in
+                let hidden = Type.hidden node in
+                node, origin, hidden
+            | Class_type ->
+                let node = Graph.find_class_type graph path in
+                let origin = Class_type.origin graph node in
+                let hidden = Class_type.hidden node in
+                node, origin, hidden
+            | Module_type ->
+                let node = Graph.find_module_type graph path in
+                let origin = Module_type.origin graph node in
+                let hidden = Module_type.hidden node in
+                node, origin, hidden
+            | Module ->
+                let node = Graph.find_module graph path in
+                let origin = Module.origin graph node in
+                let hidden = Module.hidden node in
+                node, origin, hidden
+          in
+          let best = path in
           match path with
-          | Path.Pident _ ->
+          | Path.Pident id ->
+              let max =
+                if is_visible_ident graph kind id && not hidden then
+                  Height.one
+                else
+                  Height.maximum
+              in
               let min = Height.one in
               let finished = false in
-              Ident
-                { kind; node; origin; best; min; max; finished; }
+              Ident { kind; node; origin; best; min; max; finished }
           | Path.Pdot(parent, name, _) ->
-              let graph = shortest.graph in
-              let parent_md = Graph.find_module graph parent in
-              let parent_max = Height.measure_path parent in
-              let parent_origin = Module.origin graph parent_md in
-              let parent =
-                loop Module parent_md parent_origin
-                  parent parent_max [] parent
-              in
+              let parent = loop Module parent in
               let finished = false in
-              let name =
-                let height = Height.measure_name name in
-                { name; height }
+              let name_height =
+                if not hidden then Height.one
+                else Height.maximum
               in
+              let name = { name; height = name_height } in
               let searched = false in
+              let max = Height.plus (max_height parent) name_height in
               let min = Height.one in
               Dot
                 { kind; node; origin; best; min; max;
                   parent; name; searched; finished }
           | Path.Papply(func, arg) ->
-              let graph = shortest.graph in
-              let func_md = Graph.find_module graph func in
-              let func_max = Height.measure_path func in
-              let func_origin = Module.origin graph func_md in
-              let func =
-                loop Module func_md func_origin func func_max [] func
-              in
-              let arg_md = Graph.find_module graph arg in
-              let arg_max = Height.measure_path arg in
-              let arg_origin = Module.origin graph arg_md in
-              let arg =
-                loop Module arg_md arg_origin arg arg_max [] arg
-              in
+              let func = loop Module func in
+              let arg = loop Module arg in
               let func_first =
-                Rev_deps.before (rev_deps shortest) arg_origin func_origin
+                Rev_deps.before (rev_deps shortest)
+                  (search_origin arg) (search_origin func)
               in
               let finished = false in
-              let suffix =
-                match suffix with
-                | [] -> None
-                | fst :: rest ->
-                  let names = suffix in
-                  let height =
-                    List.fold_left
-                      (fun acc name ->
-                         Height.plus acc (Height.measure_name name))
-                      (Height.measure_name fst) rest
-                  in
-                  Some { names; height }
-              in
-              let searched, min =
-                match kind with
-                | Type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Class_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module_type ->
-                    let searched = false in
-                    let min = Height.one in
-                    searched, min
-                | Module ->
-                    (* There are no module aliases containing extended paths *)
-                    let searched = true in
-                    let min = min_application func arg suffix in
-                    searched, min
-              in
+              (* There are no module aliases containing extended paths *)
+              let searched = true in
+              let max = max_application func arg in
+              let min = min_application func arg in
               Application
                 { kind; node; origin; best; min; max;
-                  func; arg; suffix; func_first; searched; finished }
+                  func; arg; func_first; searched; finished }
       in
-      let graph = shortest.graph in
-      let canonical_path, origin, max =
-        match kind with
-        | Type ->
-            let canonical_path = Type.path graph node in
-            let origin = Type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Class_type ->
-            let canonical_path = Class_type.path graph node in
-            let origin = Class_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_class_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module_type ->
-            let canonical_path = Module_type.path graph node in
-            let origin = Module_type.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_type_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-        | Module ->
-            let canonical_path = Module.path graph node in
-            let origin = Module.origin graph node in
-            let max =
-              let visible =
-                Graph.is_module_path_visible graph canonical_path
-              in
-              if visible then Height.measure_path canonical_path
-              else Height.maximum
-            in
-            canonical_path, origin, max
-      in
-      loop kind node origin canonical_path max [] canonical_path
+      loop kind canonical_path
 
     let find (type k) shortest origin height (kind : k kind) (node : k) =
       let sections = force shortest origin height in
@@ -1710,15 +1616,13 @@ module Shortest = struct
                 in
                 let fst, snd =
                   let should_try_app =
-                    Height.equal
-                      (min_application fst snd r.suffix) r.min
+                    Height.equal (min_application fst snd) r.min
                   in
                   if not should_try_app then fst, snd
                   else begin
                     let fst = step shortest fst in
                     let should_try_app =
-                      Height.equal
-                        (min_application fst snd r.suffix) r.min
+                      Height.equal (min_application fst snd) r.min
                     in
                     if not should_try_app then fst, snd
                     else fst, step shortest snd
@@ -1730,11 +1634,10 @@ module Shortest = struct
                 in
                 let found =
                   finished func && finished arg
-                  && Height.equal
-                       (min_application fst snd r.suffix) r.min
+                  && Height.equal (min_application fst snd) r.min
                 in
                 if found then begin
-                  let best = path_application func arg r.suffix in
+                  let best = path_application func arg in
                   let max = r.min in
                   let finished = true in
                   Application
@@ -1743,7 +1646,7 @@ module Shortest = struct
                   let finished =
                     searched
                     && Height.less_than_or_equal
-                         r.max (min_application fst snd r.suffix)
+                         r.max (min_application fst snd)
                   in
                   let min = if finished then r.max else Height.succ r.min in
                   Application
@@ -1778,7 +1681,8 @@ module Shortest = struct
     match Type.resolve t.graph typ with
     | Type.Nth n -> Nth n
     | Type.Path(subst, typ) ->
-      let search = Search.create t Search.Type typ in
+      let canonical_path = Type.path t.graph typ in
+      let search = Search.create t Search.Type canonical_path in
       let path = Search.perform t search in
       Path(subst, path)
 
@@ -1793,33 +1697,38 @@ module Shortest = struct
   let find_type_simple t path =
     update t;
     let typ = Graph.find_type t.graph path in
-    let search = Search.create t Search.Type typ in
+    let canonical_path = Type.path t.graph typ in
+    let search = Search.create t Search.Type canonical_path in
     Search.perform t search
 
   let find_class_type t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
     let subst, clty = Class_type.resolve t.graph clty in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     let path = Search.perform t search in
     (subst, path)
 
   let find_class_type_simple t path =
     update t;
     let clty = Graph.find_class_type t.graph path in
-    let search = Search.create t Search.Class_type clty in
+    let canonical_path = Class_type.path t.graph clty in
+    let search = Search.create t Search.Class_type canonical_path in
     Search.perform t search
 
   let find_module_type t path =
     update t;
     let mty = Graph.find_module_type t.graph path in
-    let search = Search.create t Search.Module_type mty in
+    let canonical_path = Module_type.path t.graph mty in
+    let search = Search.create t Search.Module_type canonical_path in
     Search.perform t search
 
   let find_module t path =
     update t;
     let md = Graph.find_module t.graph path in
-    let search = Search.create t Search.Module md in
+    let canonical_path = Module.path t.graph md in
+    let search = Search.create t Search.Module canonical_path in
     Search.perform t search
 
 end
@@ -1832,7 +1741,8 @@ module Basis = struct
     { name : string;
       depends : string list;
       alias_depends : string list;
-      desc : Desc.Module.t; }
+      desc : Desc.Module.t;
+      deprecated : Desc.deprecated; }
 
   type t =
     { mutable next_dep : Dependency.t;
@@ -1879,11 +1789,11 @@ module Basis = struct
   let update_shortest t additions loads =
     let components =
       List.map
-        (fun { name; desc; _ } ->
+        (fun { name; desc; deprecated; _ } ->
            let index = String_map.find name t.assignment in
            let origin = Origin.Dependency index in
            let id = Ident.global name in
-           Component.Module(origin, id, desc, Component.Global))
+           Component.Module(origin, id, desc, Component.Global, deprecated))
         loads
     in
     let components =
@@ -1927,8 +1837,9 @@ module Basis = struct
   let add t name =
     t.pending_additions <- String_set.add name t.pending_additions
 
-  let load t name depends alias_depends desc =
-    t.pending_loads <- { name; depends; alias_depends; desc } :: t.pending_loads
+  let load t name depends alias_depends desc deprecated =
+    let load = { name; depends; alias_depends; desc; deprecated } in
+    t.pending_loads <- load :: t.pending_loads
 
 end
 

--- a/src/ocaml/typing/407_0/short_paths.mli
+++ b/src/ocaml/typing/407_0/short_paths.mli
@@ -9,7 +9,8 @@ module Basis : sig
 
   val add : t -> string -> unit
 
-  val load : t -> string -> string list -> string list -> Desc.Module.t -> unit
+  val load : t -> string -> string list -> string list ->
+    Desc.Module.t -> Desc.deprecated -> unit
 
 end
 

--- a/src/ocaml/typing/407_0/short_paths_graph.mli
+++ b/src/ocaml/typing/407_0/short_paths_graph.mli
@@ -49,6 +49,10 @@ module Path_set : Set.S with type elt = Path.t
 
 module Desc : sig
 
+  type deprecated =
+    | Deprecated
+    | Not_deprecated
+
   module Type : sig
 
     type t =
@@ -88,10 +92,10 @@ module Desc : sig
   module Module : sig
 
     type component =
-      | Type of string * Type.t
-      | Class_type of string * Class_type.t
-      | Module_type of string * Module_type.t
-      | Module of string * t
+      | Type of string * Type.t * deprecated
+      | Class_type of string * Class_type.t * deprecated
+      | Module_type of string * Module_type.t * deprecated
+      | Module of string * t * deprecated
 
     and components = component list
 
@@ -105,11 +109,15 @@ module Desc : sig
 
   end
 
+  type source =
+    | Local
+    | Open
+
   type t =
-    | Type of Ident.t * Type.t * bool
-    | Class_type of Ident.t * Class_type.t * bool
-    | Module_type of Ident.t * Module_type.t * bool
-    | Module of Ident.t * Module.t * bool
+    | Type of Ident.t * Type.t * source * deprecated
+    | Class_type of Ident.t * Class_type.t * source * deprecated
+    | Module_type of Ident.t * Module_type.t * source * deprecated
+    | Module of Ident.t * Module.t * source * deprecated
     | Declare_type of Ident.t
     | Declare_class_type of Ident.t
     | Declare_module_type of Ident.t
@@ -152,6 +160,8 @@ module Type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved =
@@ -170,6 +180,8 @@ module Class_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
   type resolved = int list option * t
@@ -186,6 +198,8 @@ module Module_type : sig
 
   val path : graph -> t -> Path.t
 
+  val hidden : t -> bool
+
   val sort : graph -> t -> Sort.t
 
 end
@@ -197,6 +211,8 @@ module Module : sig
   val origin : graph -> t -> Origin.t
 
   val path : graph -> t -> Path.t
+
+  val hidden : t -> bool
 
   val sort : graph -> t -> Sort.t
 
@@ -240,10 +256,14 @@ module Component : sig
     | Open
 
   type t =
-    | Type of Origin.t * Ident.t * Desc.Type.t * source
-    | Class_type of Origin.t * Ident.t * Desc.Class_type.t * source
-    | Module_type of Origin.t * Ident.t * Desc.Module_type.t * source
-    | Module of Origin.t * Ident.t * Desc.Module.t * source
+    | Type of
+        Origin.t * Ident.t * Desc.Type.t * source * Desc.deprecated
+    | Class_type of
+        Origin.t * Ident.t * Desc.Class_type.t * source * Desc.deprecated
+    | Module_type of
+        Origin.t * Ident.t * Desc.Module_type.t * source * Desc.deprecated
+    | Module of
+        Origin.t * Ident.t * Desc.Module.t * source * Desc.deprecated
     | Declare_type of Origin.t * Ident.t
     | Declare_class_type of Origin.t * Ident.t
     | Declare_module_type of Origin.t * Ident.t
@@ -276,5 +296,13 @@ module Graph : sig
   val is_module_type_path_visible : t -> Path.t -> bool
 
   val is_module_path_visible : t -> Path.t -> bool
+
+  val is_type_ident_visible : t -> Ident.t -> bool
+
+  val is_class_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_type_ident_visible : t -> Ident.t -> bool
+
+  val is_module_ident_visible : t -> Ident.t -> bool
 
 end

--- a/tests/short-paths/test.ml
+++ b/tests/short-paths/test.ml
@@ -40,3 +40,26 @@ class test ?a =
 object
   method b = ()
 end
+
+(* *** Don't select deprecated paths *** *)
+
+include struct
+  [@@@warning "-3"]
+
+  module M = struct
+    type t = T
+    [@@deprecated "bad"]
+  end
+
+  type t = M.t
+  [@@deprecated "bad"]
+
+  module N = struct
+    module O = struct
+      type t = M.t
+    end
+  end
+
+  let f (x : t) : unit = x
+
+end

--- a/tests/short-paths/test.t
+++ b/tests/short-paths/test.t
@@ -118,6 +118,21 @@
         "sub": [],
         "valid": true,
         "message": "Warning 16: this optional argument cannot be erased."
+      },
+      {
+        "start": {
+          "line": 63,
+          "col": 25
+        },
+        "end": {
+          "line": 63,
+          "col": 26
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This expression has type t = M.t
+         but an expression was expected of type unit"
       }
     ],
     "notifications": []
@@ -243,6 +258,21 @@
         "sub": [],
         "valid": true,
         "message": "Warning 16: this optional argument cannot be erased."
+      },
+      {
+        "start": {
+          "line": 63,
+          "col": 25
+        },
+        "end": {
+          "line": 63,
+          "col": 26
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This expression has type N.O.t but an expression was expected of type
+           unit"
       }
     ],
     "notifications": []


### PR DESCRIPTION
This patch stops deprecated paths from being chosen in `-short-paths` mode. It also tidies up a few bits of the short paths code.