### PR TITLE
Re-align identifier numbers with compiler

### DIFF
--- a/src/ocaml/typing/403/btype.ml
+++ b/src/ocaml/typing/403/btype.ml
@@ -61,7 +61,6 @@ let is_Tvar = function {desc=Tvar _} -> true | _ -> false
 let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/403/btype.mli
+++ b/src/ocaml/typing/403/btype.mli
@@ -47,7 +47,6 @@ val newmarkedgenvar: unit -> type_expr
 val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/403/env.ml
+++ b/src/ocaml/typing/403/env.ml
@@ -1464,8 +1464,10 @@ let short_paths_type predef id path decl old =
     addition :: old
   end
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id path decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/403/env.mli
+++ b/src/ocaml/typing/403/env.mli
@@ -298,6 +298,10 @@ val fold_cltypes:
 val scrape_alias: t -> module_type -> module_type
 val check_value_name: string -> Location.t -> unit
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/403/typeclass.ml
+++ b/src/ocaml/typing/403/typeclass.ml
@@ -76,7 +76,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)

--- a/src/ocaml/typing/404/btype.ml
+++ b/src/ocaml/typing/404/btype.ml
@@ -61,7 +61,6 @@ let is_Tvar = function {desc=Tvar _} -> true | _ -> false
 let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/404/btype.mli
+++ b/src/ocaml/typing/404/btype.mli
@@ -47,7 +47,6 @@ val newmarkedgenvar: unit -> type_expr
 val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -1478,8 +1478,10 @@ let short_paths_type predef id path decl old =
     addition :: old
   end
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id path decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/404/env.mli
+++ b/src/ocaml/typing/404/env.mli
@@ -329,6 +329,10 @@ module Persistent_signature : sig
   val load : (unit_name:string -> t option) ref
 end
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/404/typeclass.ml
+++ b/src/ocaml/typing/404/typeclass.ml
@@ -100,7 +100,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)

--- a/src/ocaml/typing/405/btype.ml
+++ b/src/ocaml/typing/405/btype.ml
@@ -62,7 +62,6 @@ let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 let is_Tconstr = function {desc=Tconstr _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/405/btype.mli
+++ b/src/ocaml/typing/405/btype.mli
@@ -48,7 +48,6 @@ val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -1474,8 +1474,10 @@ let short_paths_type predef id path decl old =
     addition :: old
   end
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id path decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/405/env.mli
+++ b/src/ocaml/typing/405/env.mli
@@ -329,6 +329,10 @@ module Persistent_signature : sig
   val load : (unit_name:string -> t option) ref
 end
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/405/typeclass.ml
+++ b/src/ocaml/typing/405/typeclass.ml
@@ -100,7 +100,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)

--- a/src/ocaml/typing/406/btype.ml
+++ b/src/ocaml/typing/406/btype.ml
@@ -62,7 +62,6 @@ let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 let is_Tconstr = function {desc=Tconstr _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/406/btype.mli
+++ b/src/ocaml/typing/406/btype.mli
@@ -48,7 +48,6 @@ val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -1712,8 +1712,10 @@ let short_paths_type_open path decls old =
   if !Clflags.real_paths then old
   else Type_open(path, decls) :: old
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/406/env.mli
+++ b/src/ocaml/typing/406/env.mli
@@ -329,6 +329,10 @@ module Persistent_signature : sig
   val load : (unit_name:string -> t option) ref
 end
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/406/typeclass.ml
+++ b/src/ocaml/typing/406/typeclass.ml
@@ -100,7 +100,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)

--- a/src/ocaml/typing/407/btype.ml
+++ b/src/ocaml/typing/407/btype.ml
@@ -62,7 +62,6 @@ let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 let is_Tconstr = function {desc=Tconstr _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/407/btype.mli
+++ b/src/ocaml/typing/407/btype.mli
@@ -48,7 +48,6 @@ val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -1650,8 +1650,10 @@ let short_paths_type_open path decls old =
   if !Clflags.real_paths then old
   else Type_open(path, decls) :: old
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/407/env.mli
+++ b/src/ocaml/typing/407/env.mli
@@ -348,6 +348,10 @@ module Persistent_signature : sig
   val load : (unit_name:string -> t option) ref
 end
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/407/typeclass.ml
+++ b/src/ocaml/typing/407/typeclass.ml
@@ -101,7 +101,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)

--- a/src/ocaml/typing/407_0/btype.ml
+++ b/src/ocaml/typing/407_0/btype.ml
@@ -62,7 +62,6 @@ let is_Tunivar = function {desc=Tunivar _} -> true | _ -> false
 let is_Tconstr = function {desc=Tconstr _} -> true | _ -> false
 
 let dummy_method = "*dummy method*"
-let unbound_class = Path.Pident (Ident.create "*undef*")
 
 let default_mty = function
     Some mty -> mty

--- a/src/ocaml/typing/407_0/btype.mli
+++ b/src/ocaml/typing/407_0/btype.mli
@@ -48,7 +48,6 @@ val is_Tvar: type_expr -> bool
 val is_Tunivar: type_expr -> bool
 val is_Tconstr: type_expr -> bool
 val dummy_method: label
-val unbound_class: Path.t
 val default_mty: module_type option -> module_type
 
 val repr: type_expr -> type_expr

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -1651,8 +1651,10 @@ let short_paths_type_open path decls old =
   if !Clflags.real_paths then old
   else Type_open(path, decls) :: old
 
+let unbound_class = Path.Pident (Ident.create "*undef*")
+
 let is_dummy_class decl =
-  Path.same decl.clty_path Btype.unbound_class
+  Path.same decl.clty_path unbound_class
 
 let short_paths_class_type id decl old =
   if !Clflags.real_paths || is_dummy_class decl then old

--- a/src/ocaml/typing/407_0/env.mli
+++ b/src/ocaml/typing/407_0/env.mli
@@ -348,6 +348,10 @@ module Persistent_signature : sig
   val load : (unit_name:string -> t option) ref
 end
 
+(** dummy class path **)
+
+val unbound_class: Path.t
+
 (** merlin: manage internal state *)
 
 val state : Local_store.bindings

--- a/src/ocaml/typing/407_0/typeclass.ml
+++ b/src/ocaml/typing/407_0/typeclass.ml
@@ -101,7 +101,7 @@ let dummy_method = Btype.dummy_method
    Path associated to the temporary class type of a class being typed
    (its constructor is not available).
 *)
-let unbound_class = Btype.unbound_class
+let unbound_class = Env.unbound_class
 
 
                 (************************************)


### PR DESCRIPTION
Move `Btype.unbound_class` to `Env` so that it appears after `Predef` in
the dependency order and doesn't change the identifier stamps of the
predefined identifiers.