### PR TITLE
Remove stringext from merlin-lsp.opam

### DIFF
--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -21,7 +21,6 @@ depends: [
   "ocamlfind" {>= "1.5.2"}
   "yojson"
   "ppx_deriving_yojson"
-  "stringext"
   "mdx" {test & >= "1.2.0"}
 ]
 


### PR DESCRIPTION
This dependency is no longer required since #906