### PR TITLE
LSP: Add "Find references"

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -239,7 +239,7 @@ let on_request :
       return (store, Some resp)
     end
 
-  | Lsp.Rpc.Request.FindReferences {textDocument = {uri;}; position; context = _} ->
+  | Lsp.Rpc.Request.References {textDocument = {uri;}; position; context = _} ->
     Document_store.get store uri >>= fun doc ->
     let command = Query_protocol.Occurrences (`Ident_at (logical_of_position position)) in
     let locs : Warnings.loc list = Query_commands.dispatch (Document.pipeline doc) command in

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -612,6 +612,21 @@ module TypeDefinition = struct
   and result = Location.t list  (* wire: either a single one or an array *)
 end
 
+(* Find References request, method="textDocument/references" *)
+module FindReferences = struct
+  type params = {
+    textDocument: TextDocumentIdentifier.t;  (* the text document *)
+    position: position;  (* the position inside the text document *)
+    context: referenceContext;
+  } [@@deriving yojson { strict = false }]
+
+  and referenceContext = {
+    includeDeclaration: bool;
+  }
+
+  and result = Location.t list (* wire: either a single one or an array *)
+end
+
 (* Represents information about programming constructs like variables etc. *)
 module SymbolInformation = struct
 

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -612,8 +612,8 @@ module TypeDefinition = struct
   and result = Location.t list  (* wire: either a single one or an array *)
 end
 
-(* Find References request, method="textDocument/references" *)
-module FindReferences = struct
+(* References request, method="textDocument/references" *)
+module References = struct
   type params = {
     textDocument: TextDocumentIdentifier.t;  (* the text document *)
     position: position;  (* the position inside the text document *)

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -154,7 +154,7 @@ let send_response rpc (response : Response.t) =
   send rpc json
 
 module Server_notification = struct
-  open Protocol
+  open Protocol 
 
   type t =
     | PublishDiagnostics of PublishDiagnostics.params
@@ -196,7 +196,7 @@ module Request = struct
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
-    | FindReferences : FindReferences.params -> FindReferences.result t
+    | References : References.params -> References.result t
     | UnknownRequest : string * Yojson.Safe.json -> unit t
 
   let request_result_to_response (type a) id (req : a t) (result : a) =
@@ -223,8 +223,8 @@ module Request = struct
     | DebugTextDocumentGet _, result ->
       let json = DebugTextDocumentGet.result_to_yojson result in
       Some (Response.make id json)
-    | FindReferences _, result ->
-      let json = FindReferences.result_to_yojson result in
+    | References _, result ->
+      let json = References.result_to_yojson result in
       Some (Response.make id json)
     | UnknownRequest _, _resp -> None
 end
@@ -263,8 +263,8 @@ module Message = struct
         TypeDefinition.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, TextDocumentTypeDefinition params))
       | "textDocument/references" ->
-        FindReferences.params_of_yojson packet.params >>= fun params ->
-        Ok (Request (id, FindReferences params))
+        References.params_of_yojson packet.params >>= fun params ->
+        Ok (Request (id, References params))
       | "debug/echo" ->
         DebugEcho.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, DebugEcho params))

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -154,7 +154,7 @@ let send_response rpc (response : Response.t) =
   send rpc json
 
 module Server_notification = struct
-  open Protocol 
+  open Protocol
 
   type t =
     | PublishDiagnostics of PublishDiagnostics.params
@@ -196,6 +196,7 @@ module Request = struct
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
+    | FindReferences : FindReferences.params -> FindReferences.result t
     | UnknownRequest : string * Yojson.Safe.json -> unit t
 
   let request_result_to_response (type a) id (req : a t) (result : a) =
@@ -221,6 +222,9 @@ module Request = struct
       Some (Response.make id json)
     | DebugTextDocumentGet _, result ->
       let json = DebugTextDocumentGet.result_to_yojson result in
+      Some (Response.make id json)
+    | FindReferences _, result ->
+      let json = FindReferences.result_to_yojson result in
       Some (Response.make id json)
     | UnknownRequest _, _resp -> None
 end
@@ -258,6 +262,9 @@ module Message = struct
       | "textDocument/typeDefinition" ->
         TypeDefinition.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, TextDocumentTypeDefinition params))
+      | "textDocument/references" ->
+        FindReferences.params_of_yojson packet.params >>= fun params ->
+        Ok (Request (id, FindReferences params))
       | "debug/echo" ->
         DebugEcho.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, DebugEcho params))

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -5,7 +5,7 @@
 module Server_notification : sig
   open Protocol
 
-  type t = 
+  type t =
     | PublishDiagnostics of PublishDiagnostics.publishDiagnosticsParams
 end
 
@@ -32,6 +32,7 @@ module Request : sig
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
+    | FindReferences : FindReferences.params -> FindReferences.result t
     | UnknownRequest : string * Yojson.Safe.json -> unit t
 end
 

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -5,7 +5,7 @@
 module Server_notification : sig
   open Protocol
 
-  type t =
+  type t = 
     | PublishDiagnostics of PublishDiagnostics.publishDiagnosticsParams
 end
 
@@ -32,7 +32,7 @@ module Request : sig
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
-    | FindReferences : FindReferences.params -> FindReferences.result t
+    | References : References.params -> References.result t
     | UnknownRequest : string * Yojson.Safe.json -> unit t
 end
 

--- a/tests-lsp/__tests__/textDocument-references.test.ts
+++ b/tests-lsp/__tests__/textDocument-references.test.ts
@@ -1,0 +1,89 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/references", () => {
+  let languageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        source
+      )
+    });
+  }
+
+  async function query(position) {
+    return await languageServer.sendRequest("textDocument/references", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      position,
+      context: { includeDeclaration: false }
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("finds references in a file", async () => {
+    await openDocument(outdent`
+      let num = 42
+      let sum = num + 13
+      let sum2 = sum + num
+    `);
+
+    let result = await query(Types.Position.create(0, 4));
+
+    expect(result).toMatchObject([
+      {
+        range: {
+          end: {
+            character: 7,
+            line: 0
+          },
+          start: {
+            character: 4,
+            line: 0
+          }
+        },
+        uri: "file:///test.ml"
+      },
+      {
+        range: {
+          end: {
+            character: 13,
+            line: 1
+          },
+          start: {
+            character: 10,
+            line: 1
+          }
+        },
+        uri: "file:///test.ml"
+      },
+      {
+        range: {
+          end: {
+            character: 20,
+            line: 2
+          },
+          start: {
+            character: 17,
+            line: 2
+          }
+        },
+        uri: "file:///test.ml"
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
Support `text/findReferences`, analogue of `occurances`
https://microsoft.github.io/language-server-protocol/specification#textDocument_references

/cc @andreypopp 