### PR TITLE
Run LSP tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,16 @@ language: c
 sudo: true
 dist: xenial
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+script: |
+  bash -ex .travis-opam.sh
+  # Run LSP test suite
+  if [ "$TESTS_LSP" = "true" ]; then
+    opam config exec -- make build ocamlmerlin-lsp
+    sudo apt-get install -y nodejs
+    cd tests-lsp/
+    npm install
+    npm run test
+  fi
 env:
   global:
   - PINS="mdx.dev:https://github.com/realworldocaml/mdx.git"
@@ -20,5 +29,9 @@ env:
     PACKAGE=merlin
   - OCAML_VERSION=4.07
     PACKAGE=merlin
+  - OCAML_VERSION=4.07
+    PACKAGE=merlin-lsp
+    TESTS_LSP=true
+    TESTS=false
 os:
   - linux

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -34,90 +34,15 @@ describe("textDocument/completion", () => {
     languageServer = null;
   });
 
-  it("completes identifier at top level", async () => {
-    await openDocument(outdent`
-      Strin
-    `);
-
-    let result = await queryCompletion(Types.Position.create(0, 5));
-
-    expect(result).toMatchObject({
-      isIncomplete: false,
-      items: [
-        { label: "StringLabels", detail: "" },
-        { label: "String", detail: "" }
-      ]
-    });
-  });
-
-  it("completes identifier at top level", async () => {
-    openDocument(outdent`
-      String.
-    `);
-
-    let result: any = await queryCompletion(Types.Position.create(0, 7));
-    let items = result.items.map(item => item.label);
-    expect(items).toMatchObject([
-      "blit",
-      "capitalize",
-      "capitalize_ascii",
-      "compare",
-      "concat",
-      "contains",
-      "contains_from",
-      "copy",
-      "create",
-      "equal",
-      "escaped",
-      "fill",
-      "get",
-      "index",
-      "index_from",
-      "index_from_opt",
-      "index_opt",
-      "init",
-      "iter",
-      "iteri",
-      "length",
-      "lowercase",
-      "lowercase_ascii",
-      "make",
-      "map",
-      "mapi",
-      "rcontains_from",
-      "rindex",
-      "rindex_from",
-      "rindex_from_opt",
-      "rindex_opt",
-      "set",
-      "split_on_char",
-      "sub",
-      "trim",
-      "uncapitalize",
-      "uncapitalize_ascii",
-      "unsafe_blit",
-      "unsafe_fill",
-      "unsafe_get",
-      "unsafe_set",
-      "uppercase",
-      "uppercase_ascii",
-      "t"
-    ]);
-  });
-
   it("can start completion at arbitrary position (after the dot)", async () => {
     openDocument(outdent`
       Strin.func
     `);
 
     let result = await queryCompletion(Types.Position.create(0, 5));
-    expect(result).toMatchObject({
-      isIncomplete: false,
-      items: [
-        { label: "StringLabels" },
-        { label: "String" }
-      ]
-    });
+    let items = result.items.map(item => item.label);
+    items.sort();
+    expect(items).toMatchObject(["String", "StringLabels"]);
   });
 
   it("can start completion at arbitrary position", async () => {
@@ -126,12 +51,24 @@ describe("textDocument/completion", () => {
     `);
 
     let result = await queryCompletion(Types.Position.create(0, 6));
-    expect(result).toMatchObject({
-      isIncomplete: false,
-      items: [
-        { label: "StringLabels" },
-        { label: "String" }
-      ]
-    });
+    let items = result.items.map(item => item.label);
+    items.sort();
+    expect(items).toMatchObject(["String", "StringLabels"]);
   });
+
+  it("completes identifier at top level", async () => {
+    openDocument(outdent`
+      let somenum = 42
+      let somestring = "hello"
+
+      let () =
+        some
+    `);
+
+    let result: any = await queryCompletion(Types.Position.create(4, 6));
+    let items = result.items.map(item => item.label);
+    items.sort();
+    expect(items).toMatchObject(["somenum", "somestring"]);
+  });
+
 });

--- a/tests-lsp/package.json
+++ b/tests-lsp/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --forceExit"
   },
   "author": "",
   "license": "MIT",

--- a/tests-lsp/src/LanguageServer.ts
+++ b/tests-lsp/src/LanguageServer.ts
@@ -62,6 +62,7 @@ export const startAndInitialize = async (opts?: cp.SpawnOptions) => {
 export const exit = async languageServer => {
   let ret = new Promise((resolve, reject) => {
     languageServer.onClose(() => {
+      languageServer.dispose();
       resolve();
     });
   });


### PR DESCRIPTION
- Fixes tests for LSP frontend and makes deterministic (sort output of completion, not sure why it's different across machines but this is what original protocol tests are doing too)
- Add new job which tests LSP frontend with 4.07