### PR TITLE
LSP: provide sortText in completion items

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -445,7 +445,7 @@ let on_request :
     in
     let completions = Query_commands.dispatch (Document.pipeline doc) command in
     let items =
-      let f (entry : Query_protocol.Compl.entry) =
+      let f i (entry : Query_protocol.Compl.entry) =
         {
           Lsp.Protocol.Completion.
           label = entry.name;
@@ -454,13 +454,15 @@ let on_request :
           inlineDetail = None;
           itemType = None;
           documentation = None;
-          sortText = None;
+          (* Without this field the client is not forced to respect the order
+             provided by merlin. *)
+          sortText = Some (Printf.sprintf "%04d" i);
           filterText = None;
           insertText = None;
           insertTextFormat = None;
         }
       in
-      List.map f completions.Query_protocol.Compl.entries
+      List.mapi f completions.Query_protocol.Compl.entries
     in
     let resp = {Lsp.Protocol.Completion. isIncomplete = false; items;} in
     return (store, resp)

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -19,9 +19,15 @@ describe("textDocument/completion", () => {
   }
 
   async function queryCompletion(position) {
-    return await languageServer.sendRequest("textDocument/completion", {
+    let result = await languageServer.sendRequest("textDocument/completion", {
       textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
       position
+    });
+    return result.items.map(item => {
+      return {
+        label: item.label,
+        sortText: item.sortText
+      };
     });
   }
 
@@ -39,10 +45,11 @@ describe("textDocument/completion", () => {
       Strin.func
     `);
 
-    let result = await queryCompletion(Types.Position.create(0, 5));
-    let items = result.items.map(item => item.label);
-    items.sort();
-    expect(items).toMatchObject(["String", "StringLabels"]);
+    let items = await queryCompletion(Types.Position.create(0, 5));
+    expect(items).toMatchObject([
+      { label: "String", sortText: "0000" },
+      { label: "StringLabels", sortText: "0001" }
+    ]);
   });
 
   it("can start completion at arbitrary position", async () => {
@@ -50,10 +57,11 @@ describe("textDocument/completion", () => {
       StringLabels
     `);
 
-    let result = await queryCompletion(Types.Position.create(0, 6));
-    let items = result.items.map(item => item.label);
-    items.sort();
-    expect(items).toMatchObject(["String", "StringLabels"]);
+    let items = await queryCompletion(Types.Position.create(0, 6));
+    expect(items).toMatchObject([
+      { label: "String", sortText: "0000" },
+      { label: "StringLabels", sortText: "0001" }
+    ]);
   });
 
   it("completes identifier at top level", async () => {
@@ -65,10 +73,10 @@ describe("textDocument/completion", () => {
         some
     `);
 
-    let result: any = await queryCompletion(Types.Position.create(4, 6));
-    let items = result.items.map(item => item.label);
-    items.sort();
-    expect(items).toMatchObject(["somenum", "somestring"]);
+    let items = await queryCompletion(Types.Position.create(4, 6));
+    expect(items).toMatchObject([
+      { label: "somestring", sortText: "0000" },
+      { label: "somenum", sortText: "0001" }
+    ]);
   });
-
 });


### PR DESCRIPTION
This PR adds fills the `sortText` field of completion items in `textDocument/completion` response. This is necessary to make sure that the client will respect the order decided by merlin.

Tested on emacs only.

https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
https://github.com/tigersoldier/company-lsp/issues/56#issuecomment-424593632

> Per [specification](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion), the server can specify `sortText` for each candidate. Candidates should be sorted by `sortText` if the server populates them, or sorted by the labels if `sortText` is not populated.