### PR TITLE
LSP: change hover response from string to code

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -237,7 +237,7 @@ let on_request :
       in
       let resp = {
         Lsp.Protocol.Hover.
-        contents = [MarkedString contents];
+        contents = [MarkedCode { language = "OCaml"; value = contents } ];
         range = None;
       } in
       return (store, Some resp)

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -28,34 +28,6 @@ module Command = struct
   } [@@deriving yojson]
 end
 
-module MarkedString = struct
-
-  type code = {
-    language : string;
-    value : string;
-  } [@@deriving yojson { strict = false }]
-
-  (* markedString can be used to render human readable text. It is either a
-   * markdown string or a code-block that provides a language and a code snippet.
-   * Note that markdown strings will be sanitized by the client - including
-   * escaping html *)
-  type t =
-    | MarkedString of string
-    | MarkedCode of code
-
-  let to_yojson = function
-    | MarkedString v -> `String v
-    | MarkedCode code -> code_to_yojson code
-
-  let of_yojson = function
-    | `String v -> Ok (MarkedString v)
-    | json ->
-      begin match code_of_yojson json with
-      | Ok code -> Ok (MarkedCode code)
-      | Error err -> Error err
-      end
-end
-
 module MarkupKind = struct
   type t =
     | Plaintext
@@ -70,6 +42,13 @@ module MarkupKind = struct
     | `String "markdown" -> Ok Markdown
     | `String _ -> Ok Plaintext
     | _ -> Error "invalid contentFormat"
+end
+
+module MarkupContent = struct
+  type t = {
+    value: string;
+    kind: MarkupKind.t;
+  } [@@deriving yojson { strict = false }]
 end
 
 module Location = struct
@@ -391,12 +370,14 @@ end
 
 (* Hover request, method="textDocument/hover" *)
 module Hover = struct
-  type params = TextDocumentPositionParams.t [@@deriving yojson { strict = false }]
+  type params =
+    TextDocumentPositionParams.t
+    [@@deriving yojson { strict = false }]
 
   and result = hoverResult option [@default None]
 
   and hoverResult = {
-    contents: MarkedString.t list; (* wire: either a single one or an array *)
+    contents: MarkupContent.t;
     range: range option [@default None];
   }
 end

--- a/tests-lsp/__tests__/TextDocument.test.ts
+++ b/tests-lsp/__tests__/TextDocument.test.ts
@@ -268,26 +268,4 @@ describe("TextDocument", () => {
       await LanguageServer.exit(languageServer);
     });
   });
-
-  describe("hover", () => {
-    it("rerurns the type of the identifier at position", async () => {
-      let languageServer = await LanguageServer.startAndInitialize();
-      await languageServer.sendNotification("textDocument/didOpen", {
-        textDocument: Types.TextDocumentItem.create(
-          "file:///test.ml",
-          "txt",
-          0,
-          "let x = 1\n"
-        )
-      });
-
-      let result = await languageServer.sendRequest("textDocument/hover", {
-        textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
-        position: Types.Position.create(0, 4)
-      });
-
-      expect(result).toMatchObject({ contents: ["int"] });
-      await LanguageServer.exit(languageServer);
-    });
-  });
 });

--- a/tests-lsp/__tests__/textDocument-hover.test.ts
+++ b/tests-lsp/__tests__/textDocument-hover.test.ts
@@ -1,0 +1,61 @@
+import * as LanguageServer from "./../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/hover", () => {
+  let languageServer;
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+  });
+
+  it("returns type inferred under cursor", async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        "let x = 1\n"
+      )
+    });
+
+    let result = await languageServer.sendRequest("textDocument/hover", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      position: Types.Position.create(0, 4)
+    });
+
+    expect(result).toMatchObject({
+      contents: { kind: "plaintext", value: "int" }
+    });
+  });
+
+  it("returns type inferred under cursor (markdown formatting)", async () => {
+    languageServer = await LanguageServer.startAndInitialize({
+      textDocument: {
+        hover: {
+          dynamicRegistration: true,
+          contentFormat: ["markdown", "plaintext"]
+        }
+      }
+    });
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        "let x = 1\n"
+      )
+    });
+
+    let result = await languageServer.sendRequest("textDocument/hover", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      position: Types.Position.create(0, 4)
+    });
+
+    expect(result).toMatchObject({
+      contents: { kind: "markdown", value: "```ocaml\nint\n```" }
+    });
+  });
+});

--- a/tests-lsp/src/LanguageServer.ts
+++ b/tests-lsp/src/LanguageServer.ts
@@ -40,10 +40,12 @@ export const start = (opts?: cp.SpawnOptions) => {
   return connection as LanguageServer;
 };
 
-export const startAndInitialize = async (opts?: cp.SpawnOptions) => {
-  let languageServer = start(opts);
+export const startAndInitialize = async (
+  capabilities?: Partial<Protocol.ClientCapabilities>
+) => {
+  let languageServer = start();
 
-  let capabilities: Protocol.ClientCapabilities = {};
+  capabilities = capabilities || {};
 
   let initializeParameters: Protocol.InitializeParams = {
     processId: process.pid,


### PR DESCRIPTION
I am not sure about this one. But I have the impression that the value returned by hover will always be some kind of ocaml/reason code. So the answer should be a MarkedCode instead of a MarkedString.