### PR TITLE
LSP: switch detail and doc in completion answer

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -460,10 +460,10 @@ let on_request :
           Lsp.Protocol.Completion.
           label = entry.name;
           kind;
-          detail = Some entry.info;
+          detail = Some entry.desc;
           inlineDetail = None;
           itemType = Some entry.desc;
-          documentation = None;
+          documentation = Some entry.info;
           (* Without this field the client is not forced to respect the order
              provided by merlin. *)
           sortText = Some (Printf.sprintf "%04d" i);


### PR DESCRIPTION
The content of `entry.info` is long and correspond to the documentation. The type (`entry.desc`) must be in detail to be displayed.

![emacs-merlin-completion](https://user-images.githubusercontent.com/974142/53543311-3079fc00-3b1a-11e9-901b-7e2970081fb6.png)
