### PR TITLE
LSP: add support for textDocument/rename

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -557,27 +557,9 @@ let on_request :
       {Lsp.Protocol.TextEdit. newText = newName; range;}
     ) locs
     in
-    let documentChanges =
-      let textDocument = {
-        Lsp.Protocol.VersionedTextDocumentIdentifier.
-        uri;
-        version;
-      }
-      in
-      let edits = {
-        Lsp.Protocol.TextDocumentEdit.
-        edits;
-        textDocument;
-      }
-      in
-      Lsp.Protocol.WorkspaceEdit.Edits [edits]
-    in
-    (* TODO: the capabilities of the client must be checked *)
-    let workspace_edits = {
-      Lsp.Protocol.WorkspaceEdit.
-      changes = None;
-      documentChanges = Some documentChanges;
-    }
+    let workspace_edits =
+      let documentChanges = client_capabilities.workspace.workspaceEdit.documentChanges in
+      Lsp.Protocol.WorkspaceEdit.make ~documentChanges ~uri ~version ~edits
     in
     return (store, workspace_edits)
   | Lsp.Rpc.Request.UnknownRequest _ -> errorf "got unknown request"

--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -29,7 +29,7 @@ let initializeInfo: Lsp.Protocol.Initialize.result = {
     documentFormattingProvider = false;
     documentRangeFormattingProvider = false;
     documentOnTypeFormattingProvider = None;
-    renameProvider = false;
+    renameProvider = true;
     documentLinkProvider = None;
     executeCommandProvider = None;
     typeCoverageProvider = false;
@@ -539,6 +539,9 @@ let on_request :
     in
     let resp = {Lsp.Protocol.Completion. isIncomplete = false; items;} in
     return (store, resp)
+
+  | Lsp.Rpc.Request.TextDocumentRename { textDocument; position; newName } ->
+    errorf "got rename request"
   | Lsp.Rpc.Request.UnknownRequest _ -> errorf "got unknown request"
 
 let on_notification rpc store (notification : Lsp.Rpc.Client_notification.t) =

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -214,11 +214,7 @@ module WorkspaceEdit = struct
   let changes_to_yojson changes =
     let changes =
       List.map (fun (uri, edits) ->
-        let uri =
-          match documentUri_to_yojson uri with
-          | `String uri -> uri
-          | _ -> failwith "uri must be a string in workspace edit"
-        in
+        let uri = Uri.to_string uri in
         let edits = `List (List.map TextEdit.to_yojson edits) in
         uri, edits
       ) changes

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -258,6 +258,35 @@ module WorkspaceEdit = struct
     changes: changes option;
     documentChanges: documentChanges option;
   } [@@deriving yojson { strict = false }]
+
+  let empty = {
+    changes = None;
+    documentChanges = None;
+  }
+
+  (** Create a {!type:t} based on the capabilites of the client. *)
+  let make ~documentChanges ~uri ~version ~edits =
+    match documentChanges with
+    | false ->
+      let changes = Some [ uri, edits ] in
+      { empty with changes }
+    | true ->
+      let documentChanges =
+        let textDocument = {
+          VersionedTextDocumentIdentifier.
+          uri;
+          version;
+        }
+        in
+        let edits = {
+          TextDocumentEdit.
+          edits;
+          textDocument;
+        }
+        in
+        Some (Edits [edits])
+      in
+      { empty with documentChanges }
 end
 
 (* PublishDiagnostics notification, method="textDocument/PublishDiagnostics" *)

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -224,16 +224,19 @@ module WorkspaceEdit = struct
   type documentChanges = TextDocumentEdit.t list [@@deriving to_yojson]
 
   (**
-     Depending on the client capability [workspace.workspaceEdit.resourceOperations] document changes
-     are either an array of [TextDocumentEdit]s to express changes to n different text documents
-     where each text document edit addresses a specific version of a text document. Or it can contain
-     above [TextDocumentEdit]s mixed with create, rename and delete file / folder operations.
+     Depending on the client capability
+     [workspace.workspaceEdit.resourceOperations] document changes are either an
+     array of [TextDocumentEdit]s to express changes to n different text
+     documents where each text document edit addresses a specific version of a
+     text document. Or it can contain above [TextDocumentEdit]s mixed with
+     create, rename and delete file / folder operations.
 
      Whether a client supports versioned document edits is expressed via
      [workspace.workspaceEdit.documentChanges] client capability.
 
-     If a client neither supports [documentChanges] nor [workspace.workspaceEdit.resourceOperations] then
-     only plain [TextEdit]s using the [changes] property are supported.
+     If a client neither supports [documentChanges] nor
+     [workspace.workspaceEdit.resourceOperations] then only plain [TextEdit]s
+     using the [changes] property are supported.
   *)
   type t = {
     changes: changes option;

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -221,22 +221,7 @@ module WorkspaceEdit = struct
     in
     `Assoc changes
 
-  let changes_of_yojson _json = assert false
-
-  (** (TextDocumentEdit | CreateFile | RenameFile | DeleteFile) *)
-  type resource_operation = [ `Unimplemented ]
-
-  type documentChanges =
-    | Edits of TextDocumentEdit.t list
-    | ResourceOperations of resource_operation list
-
-  let documentChanges_to_yojson = function
-    | ResourceOperations _ -> failwith "ResourceOperations are not supported yet"
-    | Edits edits ->
-      let edits = List.map TextDocumentEdit.to_yojson edits in
-      `List edits
-
-  let documentChanges_of_yojson _json = assert false
+  type documentChanges = TextDocumentEdit.t list [@@deriving to_yojson]
 
   (**
      Depending on the client capability [workspace.workspaceEdit.resourceOperations] document changes
@@ -253,7 +238,7 @@ module WorkspaceEdit = struct
   type t = {
     changes: changes option;
     documentChanges: documentChanges option;
-  } [@@deriving yojson { strict = false }]
+  } [@@deriving to_yojson { strict = false }]
 
   let empty = {
     changes = None;
@@ -280,7 +265,7 @@ module WorkspaceEdit = struct
           textDocument;
         }
         in
-        Some (Edits [edits])
+        Some [edits]
       in
       { empty with documentChanges }
 end
@@ -937,7 +922,7 @@ module Rename = struct
                         appropriate message set. *)
   } [@@deriving yojson]
 
-  and result = WorkspaceEdit.t
+  type result = WorkspaceEdit.t [@@deriving to_yojson]
 end
 
 module DebugEcho = struct

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -133,9 +133,9 @@ module DocumentHighlight = struct
 
   (** The highlight kind, default is DocumentHighlightKind.Text. *)
   type kind =
-    | Text (* 1: A textual occurrence. *)
-    | Read (* 2: Read-access of a symbol, like reading a variable. *)
-    | Write (* 3: Write-access of a symbol, like writing a variable. *)
+    | Text (** 1: A textual occurrence. *)
+    | Read (** 2: Read-access of a symbol, like reading a variable. *)
+    | Write (** 3: Write-access of a symbol, like writing a variable. *)
 
   let kind_to_yojson = function
     | Text -> `Int 1
@@ -153,6 +153,111 @@ module DocumentHighlight = struct
     kind: kind option;
   } [@@deriving yojson { strict = false }]
 
+end
+
+(**
+   Complex text manipulations are described with an array of
+   TextEdit's, representing a single change to the document.
+
+   All text edits ranges refer to positions in the original
+   document. Text edits ranges must never overlap, that means no part of
+   the original document must be manipulated by more than one
+   edit. However, it is possible that multiple edits have the same start
+   position: multiple inserts, or any number of inserts followed by a
+   single remove or replace edit. If multiple inserts have the same
+   position, the order in the array defines the order in which the
+   inserted strings appear in the resulting text.
+*)
+module TextEdit = struct
+  type t = {
+    (** The range of the text document to be manipulated. To insert text into
+        a document create a range where start === end. *)
+    range: range;
+    (** The string to be inserted. For delete operations use an empty string. *)
+    newText: string;
+  } [@@deriving yojson { strict = false }]
+end
+
+
+(**
+   Describes textual changes on a single text document. The text
+   document is referred to as a VersionedTextDocumentIdentifier to
+   allow clients to check the text document version before an edit is
+   applied. A TextDocumentEdit describes all changes on a version Si
+   and after they are applied move the document to version Si+1. So
+   the creator of a TextDocumentEdit doesn't need to sort the array or
+   do any kind of ordering. However the edits must be non overlapping.
+*)
+module TextDocumentEdit = struct
+  type t = {
+    textDocument: VersionedTextDocumentIdentifier.t; (** The text document to change. *)
+    edits: TextEdit.t list; (** The edits to be applied. *)
+  } [@@deriving yojson { strict = false }]
+end
+
+(**
+   A workspace edit represents changes to many resources managed in
+   the workspace. The edit should either provide [changes] or
+   [documentChanges]. If the client can handle versioned document edits
+   and if [documentChanges] are present, the latter are preferred over
+   [changes].
+*)
+module WorkspaceEdit = struct
+
+  (** Holds changes to existing resources.
+
+      The json representation is an object with URIs as keys and edits
+      as values.
+  *)
+  type changes = (documentUri * TextEdit.t list) list
+
+  let changes_to_yojson changes =
+    let changes =
+      List.map (fun (uri, edits) ->
+        let uri =
+          match documentUri_to_yojson uri with
+          | `String uri -> uri
+          | _ -> failwith "uri must be a string in workspace edit"
+        in
+        let edits = `List (List.map TextEdit.to_yojson edits) in
+        uri, edits
+      ) changes
+    in
+    `Assoc changes
+
+  let changes_of_yojson json = assert false
+
+  (** (TextDocumentEdit | CreateFile | RenameFile | DeleteFile) *)
+  type resource_operation = [ `Unimplemented ]
+
+  type documentChanges =
+    | Edits of TextDocumentEdit.t list
+    | ResourceOperations of resource_operation list
+
+  let documentChanges_to_yojson = function
+    | ResourceOperations _ -> failwith "ResourceOperations are not supported yet"
+    | Edits edits ->
+      let edits = List.map TextDocumentEdit.to_yojson edits in
+      `List edits
+
+  let documentChanges_of_yojson json = assert false
+
+  (**
+     Depending on the client capability [workspace.workspaceEdit.resourceOperations] document changes
+     are either an array of [TextDocumentEdit]s to express changes to n different text documents
+     where each text document edit addresses a specific version of a text document. Or it can contain
+     above [TextDocumentEdit]s mixed with create, rename and delete file / folder operations.
+
+     Whether a client supports versioned document edits is expressed via
+     [workspace.workspaceEdit.documentChanges] client capability.
+
+     If a client neither supports [documentChanges] nor [workspace.workspaceEdit.resourceOperations] then
+     only plain [TextEdit]s using the [changes] property are supported.
+  *)
+  type t = {
+    changes: changes option;
+    documentChanges: documentChanges option;
+  } [@@deriving yojson { strict = false }]
 end
 
 (* PublishDiagnostics notification, method="textDocument/PublishDiagnostics" *)
@@ -794,6 +899,20 @@ module CodeLens = struct
     range: range;
     command: Command.t option;
   }
+end
+
+(** Rename symbol request, metho="textDocument/rename" *)
+module Rename = struct
+ type params = {
+   textDocument: TextDocumentIdentifier.t; (** The document to rename. *)
+   position: position; (** The position at which this request was sent. *)
+   newName: string; (** The new name of the symbol. If the given name
+                        is not valid the request must return a
+                        [ResponseError](#ResponseError) with an
+                        appropriate message set. *)
+  } [@@deriving yojson]
+
+  and result = WorkspaceEdit.t
 end
 
 module DebugEcho = struct

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -225,7 +225,7 @@ module WorkspaceEdit = struct
     in
     `Assoc changes
 
-  let changes_of_yojson json = assert false
+  let changes_of_yojson _json = assert false
 
   (** (TextDocumentEdit | CreateFile | RenameFile | DeleteFile) *)
   type resource_operation = [ `Unimplemented ]
@@ -240,7 +240,7 @@ module WorkspaceEdit = struct
       let edits = List.map TextDocumentEdit.to_yojson edits in
       `List edits
 
-  let documentChanges_of_yojson json = assert false
+  let documentChanges_of_yojson _json = assert false
 
   (**
      Depending on the client capability [workspace.workspaceEdit.resourceOperations] document changes

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -194,6 +194,7 @@ module Request = struct
     | TextDocumentTypeDefinition : TypeDefinition.params -> TypeDefinition.result t
     | TextDocumentCompletion : Completion.params -> Completion.result t
     | TextDocumentCodeLens : CodeLens.params -> CodeLens.result t
+    | TextDocumentRename : Rename.params -> Rename.result t
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
@@ -218,6 +219,9 @@ module Request = struct
       Some (Response.make id json)
     | TextDocumentCodeLens _, result ->
       let json = CodeLens.result_to_yojson result in
+      Some (Response.make id json)
+    | TextDocumentRename _, result ->
+      let json = Rename.result_to_yojson result in
       Some (Response.make id json)
     | DocumentSymbol _, result ->
       let json = DocumentSymbol.result_to_yojson result in
@@ -276,6 +280,9 @@ module Message = struct
       | "textDocument/codeLens" ->
         CodeLens.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, TextDocumentCodeLens params))
+      | "textDocument/rename" ->
+        Rename.params_of_yojson packet.params >>= fun params ->
+        Ok (Request (id, TextDocumentRename params))
       | "textDocument/documentHighlight" ->
         TextDocumentHighlight.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, TextDocumentHighlight params))

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -30,6 +30,7 @@ module Request : sig
     | TextDocumentTypeDefinition : TypeDefinition.params -> TypeDefinition.result t
     | TextDocumentCompletion : Completion.params -> Completion.result t
     | TextDocumentCodeLens : CodeLens.params -> CodeLens.result t
+    | TextDocumentRename : Rename.params -> Rename.result t
     | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t

--- a/src/lsp/uri.ml
+++ b/src/lsp/uri.ml
@@ -1,5 +1,7 @@
 type t = string [@@deriving yojson { strict = false }]
 
+let to_string uri = uri
+
 let to_path (uri : t) =
   let proto =
     match Sys.win32 with

--- a/src/lsp/uri.mli
+++ b/src/lsp/uri.mli
@@ -6,4 +6,6 @@ val to_yojson : t -> Yojson.Safe.json
 val to_path : t -> string
 val of_path : string -> t
 
+val to_string : t -> string
+
 val pp : Format.formatter -> t -> unit

--- a/tests-lsp/__tests__/textDocument-rename.test.ts
+++ b/tests-lsp/__tests__/textDocument-rename.test.ts
@@ -1,0 +1,88 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/rename", () => {
+  let languageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        source
+      )
+    });
+  }
+
+  async function query(position) {
+    return await languageServer.sendRequest("textDocument/rename", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml"),
+      position,
+      newName: "new_num"
+    });
+  }
+
+  beforeEach(async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+  });
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("rename value in a file", async () => {
+    await openDocument(outdent`
+      let num = 42
+      let num = num + 13
+      let num2 = num
+    `);
+
+    let result = await query(Types.Position.create(0, 4));
+
+    expect(result).toMatchObject(
+      {
+        "documentChanges": [
+          {
+            "textDocument": {
+              "version": 0,
+              "uri": "file:///test.ml"
+            },
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 7
+                  }
+                },
+                "newText": "new_num"
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 13
+                  }
+                },
+                "newText": "new_num"
+              }
+            ]
+          }
+        ],
+        "changes": null
+      });
+  });
+});


### PR DESCRIPTION
The implementation is as complete as it could be, but it works for me. Tested in emacs and vscode.

- I did not implement all the parts of the yojson conversion that were not needed for rename support. So `WorspaceEdit` can be in a response but not a request. 
- I did not implemented all the `CreateFile | RenameFile | DeleteFile` types for `resource_operation` to be usable. They are not yet necessary for now as merlin doesn't work on multiple files. The type exist to reflect what is in the spec.
- in `WorkspaceEdit.changes` there is a hack to get a uri as a string. This is necessary because the spec for `changes` is `{ [uri: string]: TextEdit[]; }`.
- the capabilities of the client are not checked before to create the response, for now it always assumes that `workspace.workspaceEdit.documentChanges` is true.
- there are no tests