### PR TITLE
Lessminus recover

### DIFF
--- a/src/ocaml/preprocess/402/parser_raw.mlyp
+++ b/src/ocaml/preprocess/402/parser_raw.mlyp
@@ -400,7 +400,7 @@ let let_operator startpos endpos op bindings cont =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"] [@symbol "<ident>"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/402/parser_recover.ml
+++ b/src/ocaml/preprocess/402/parser_recover.ml
@@ -2098,7 +2098,7 @@ let recover =
   | 247 -> One (r158)
   | 248 -> One (r159)
   | 259 -> One (r160)
-  | 262 | 463 | 1039 -> One (r161)
+  | 262 | 430 | 463 | 1039 -> One (r161)
   | 347 -> One (r162)
   | 346 -> One (r163)
   | 345 -> One (r165)
@@ -2844,7 +2844,4 @@ let recover =
   | 152 -> Select (function
     | 1177 -> r80
     | _ -> r106)
-  | 430 -> Select (function
-    | -1 -> r161
-    | _ -> r99)
   | _ -> raise Not_found

--- a/src/ocaml/preprocess/403/parser_raw.mlyp
+++ b/src/ocaml/preprocess/403/parser_raw.mlyp
@@ -689,7 +689,7 @@ let expr_of_lwt_bindings ~loc lbs body =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/403/parser_recover.ml
+++ b/src/ocaml/preprocess/403/parser_recover.ml
@@ -2067,7 +2067,7 @@ let recover =
   | 1000 -> One (r45)
   | 83 -> One (r46)
   | 86 -> One (r47)
-  | 88 | 631 | 871 -> One (r48)
+  | 88 | 529 | 631 | 871 -> One (r48)
   | 1482 -> One (r49)
   | 1481 -> One (r50)
   | 90 -> One (r51)
@@ -2938,9 +2938,6 @@ let recover =
   | 338 -> Select (function
     | 351 -> r247
     | _ -> Sub (r118) :: r253)
-  | 529 -> Select (function
-    | -1 -> r48
-    | _ -> r132)
   | 173 -> Select (function
     | 978 -> r78
     | _ -> r141)

--- a/src/ocaml/preprocess/404/parser_raw.mlyp
+++ b/src/ocaml/preprocess/404/parser_raw.mlyp
@@ -689,7 +689,7 @@ let expr_of_lwt_bindings ~loc lbs body =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/404/parser_recover.ml
+++ b/src/ocaml/preprocess/404/parser_recover.ml
@@ -2111,7 +2111,7 @@ let recover =
   | 1035 -> One (r45)
   | 83 -> One (r46)
   | 86 -> One (r47)
-  | 88 | 642 | 898 -> One (r48)
+  | 88 | 529 | 642 | 898 -> One (r48)
   | 1517 -> One (r49)
   | 1516 -> One (r50)
   | 90 -> One (r51)
@@ -3004,9 +3004,6 @@ let recover =
   | 338 -> Select (function
     | 351 -> r247
     | _ -> Sub (r118) :: r253)
-  | 529 -> Select (function
-    | -1 -> r48
-    | _ -> r132)
   | 173 -> Select (function
     | 1013 -> r78
     | _ -> r141)

--- a/src/ocaml/preprocess/405/parser_raw.mlyp
+++ b/src/ocaml/preprocess/405/parser_raw.mlyp
@@ -641,7 +641,7 @@ let expr_of_lwt_bindings ~loc lbs body =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/405/parser_recover.ml
+++ b/src/ocaml/preprocess/405/parser_recover.ml
@@ -2112,7 +2112,7 @@ let recover =
   | 1040 -> One (r45)
   | 83 -> One (r46)
   | 86 -> One (r47)
-  | 88 | 647 | 903 -> One (r48)
+  | 88 | 534 | 647 | 903 -> One (r48)
   | 1517 -> One (r49)
   | 1516 -> One (r50)
   | 90 -> One (r51)
@@ -3004,9 +3004,6 @@ let recover =
   | 338 -> Select (function
     | 351 -> r247
     | _ -> Sub (r118) :: r253)
-  | 534 -> Select (function
-    | -1 -> r48
-    | _ -> r132)
   | 173 -> Select (function
     | 1018 -> r78
     | _ -> r141)

--- a/src/ocaml/preprocess/406/parser_raw.mlyp
+++ b/src/ocaml/preprocess/406/parser_raw.mlyp
@@ -646,7 +646,7 @@ let expr_of_lwt_bindings ~loc lbs body =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/406/parser_recover.ml
+++ b/src/ocaml/preprocess/406/parser_recover.ml
@@ -2158,7 +2158,7 @@ let recover =
   | 86 -> One (r44)
   | 1586 -> One (r45)
   | 1585 -> One (r46)
-  | 88 | 618 | 950 -> One (r47)
+  | 88 | 513 | 618 | 950 -> One (r47)
   | 1576 -> One (r48)
   | 1575 -> One (r49)
   | 90 -> One (r50)
@@ -3083,9 +3083,6 @@ let recover =
   | 354 -> Select (function
     | 372 -> r247
     | _ -> Sub (r194) :: r253)
-  | 513 -> Select (function
-    | -1 -> r47
-    | _ -> r201)
   | 255 -> Select (function
     | 1071 -> r82
     | _ -> r183)

--- a/src/ocaml/preprocess/407/parser_raw.ml
+++ b/src/ocaml/preprocess/407/parser_raw.ml
@@ -32011,7 +32011,7 @@ end
 
 # 32013 "parser_raw.ml"
 
-# 269 "/usr/local/home/trefis/opam2/default/lib/menhir/standard.mly"
+# 269 "/usr/local/home/trefis/opam2/4.07.0/lib/menhir/standard.mly"
   
 
 # 32018 "parser_raw.ml"

--- a/src/ocaml/preprocess/407/parser_raw.mlyp
+++ b/src/ocaml/preprocess/407/parser_raw.mlyp
@@ -652,7 +652,7 @@ let expr_of_lwt_bindings ~loc lbs body =
 %token LBRACKETPERCENT [@symbol "[%"]
 %token LBRACKETPERCENTPERCENT [@symbol "[%%"]
 %token LESS [@symbol "<"]
-%token LESSMINUS [@symbol "<-"]
+%token LESSMINUS [@symbol "<-"] [@cost 2]
 %token LET [@symbol "let"]
 %token <string> LIDENT [@cost 2] [@recovery "_"][@printer Printf.sprintf "LIDENT(%S)"]
 %token LPAREN [@symbol ")"]

--- a/src/ocaml/preprocess/407/parser_recover.ml
+++ b/src/ocaml/preprocess/407/parser_recover.ml
@@ -2159,7 +2159,7 @@ let recover =
   | 86 -> One (r44)
   | 1587 -> One (r45)
   | 1586 -> One (r46)
-  | 88 | 619 | 951 -> One (r47)
+  | 88 | 514 | 619 | 951 -> One (r47)
   | 1577 -> One (r48)
   | 1576 -> One (r49)
   | 90 -> One (r50)
@@ -3084,9 +3084,6 @@ let recover =
   | 355 -> Select (function
     | 373 -> r247
     | _ -> Sub (r221) :: r253)
-  | 514 -> Select (function
-    | -1 -> r47
-    | _ -> r200)
   | 255 -> Select (function
     | 1072 -> r82
     | _ -> r183)

--- a/src/ocaml/preprocess/recover/recover_attrib.ml
+++ b/src/ocaml/preprocess/recover/recover_attrib.ml
@@ -25,19 +25,19 @@ module Make (G : Cmly_api.GRAMMAR) : S with module G = G = struct
       0. (prj attrs)
 
   let cost_of_symbol =
-    let measure ~default prj attrs =
-      if List.exists (Attribute.has_label "recovery") (prj attrs) then
-        cost_of_attributes prj attrs
-      else default
+    let measure ~has_default prj attrs =
+      if List.exists (Attribute.has_label "recovery") (prj attrs) || has_default
+      then cost_of_attributes prj attrs
+      else infinity
     in
     let ft = Terminal.tabulate
         (fun t ->
            if Terminal.typ t = None
-           then measure ~default:0.0 Terminal.attributes t
-           else measure ~default:infinity Terminal.attributes t)
+           then measure ~has_default:true Terminal.attributes t
+           else measure ~has_default:false Terminal.attributes t)
     in
     let fn =
-      Nonterminal.tabulate (measure ~default:infinity Nonterminal.attributes)
+      Nonterminal.tabulate (measure ~has_default:false Nonterminal.attributes)
     in
     function
     | T t -> ft t

--- a/tests/recovery/test.t
+++ b/tests/recovery/test.t
@@ -88,3 +88,17 @@ FIXME: the syntax error message is off the mark.
     ],
     "notifications": []
   }
+
+  $ echo "let test x = match x with | None -> exit 1 | Some pkg -> pkg end" | \
+  > $MERLIN single dump -what parsetree -filename "lessminus.ml" | \
+  > sed 's/ $//g'
+  {
+    "class": "return",
+    "value": "let test x =
+    match x with
+    | None -> ((exit 1)[@merlin.loc ])
+    | Some pkg -> ((pkg)[@merlin.loc ])
+  
+  ",
+    "notifications": []
+  }


### PR DESCRIPTION
This PR address bug #940. The bug had two parts:
- computation of recovery costs was incorrect for non-parameterized tokens
- `<-` was picked because it had a null recovery cost (making it a favorite candidate for the parser), which led to problematic recovery decisions.

The first fix might affect other recovery decisions. I will test this branch for some time to ensure this does not introduce any regression.