### PR TITLE
Activate on Reason file types

### DIFF
--- a/vim/merlin/ftplugin/reason.vim
+++ b/vim/merlin/ftplugin/reason.vim
@@ -1,0 +1,2 @@
+" Activate merlin on current buffer
+call merlin#Register()


### PR DESCRIPTION
Hello and thanks for the work!

I think it would be useful to make merlin's vim plugin automatically
activate itself on Reason filetype buffers too. That was preventing
me from using it with a BuckleScript project recently.