### PR TITLE
LSP: optionally return hierarchical document outline

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -324,10 +324,6 @@ let on_request :
     let module DocumentSymbol = Lsp.Protocol.DocumentSymbol in
     let module SymbolKind = Lsp.Protocol.SymbolKind in
 
-    Document_store.get store uri >>= fun doc ->
-    let command = Query_protocol.Outline in
-    let outline = Query_commands.dispatch (Document.pipeline doc) command in
-
     let kind item =
       match item.Query_protocol.outline_kind with
       | `Value -> SymbolKind.Function
@@ -384,6 +380,9 @@ let on_request :
       info::children
     in
 
+    Document_store.get store uri >>= fun doc ->
+    let command = Query_protocol.Outline in
+    let outline = Query_commands.dispatch (Document.pipeline doc) command in
     let symbols =
       let caps = client_capabilities.textDocument.documentSymbol in
       match caps.hierarchicalDocumentSymbolSupport with

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -195,7 +195,7 @@ module Request = struct
     | TextDocumentCompletion : Completion.params -> Completion.result t
     | TextDocumentCodeLens : CodeLens.params -> CodeLens.result t
     | TextDocumentRename : Rename.params -> Rename.result t
-    | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
+    | DocumentSymbol : TextDocumentDocumentSymbol.params -> TextDocumentDocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
     | TextDocumentReferences : References.params -> References.result t
@@ -224,7 +224,7 @@ module Request = struct
       let json = Rename.result_to_yojson result in
       Some (Response.make id json)
     | DocumentSymbol _, result ->
-      let json = DocumentSymbol.result_to_yojson result in
+      let json = TextDocumentDocumentSymbol.result_to_yojson result in
       Some (Response.make id json)
     | DebugEcho _, result ->
       let json = DebugEcho.result_to_yojson result in
@@ -263,7 +263,7 @@ module Message = struct
         Completion.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, TextDocumentCompletion params))
       | "textDocument/documentSymbol" ->
-        DocumentSymbol.params_of_yojson packet.params >>= fun params ->
+        TextDocumentDocumentSymbol.params_of_yojson packet.params >>= fun params ->
         Ok (Request (id, DocumentSymbol params))
       | "textDocument/hover" ->
         Hover.params_of_yojson packet.params >>= fun params ->

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -31,7 +31,7 @@ module Request : sig
     | TextDocumentCompletion : Completion.params -> Completion.result t
     | TextDocumentCodeLens : CodeLens.params -> CodeLens.result t
     | TextDocumentRename : Rename.params -> Rename.result t
-    | DocumentSymbol : DocumentSymbol.params -> DocumentSymbol.result t
+    | DocumentSymbol : TextDocumentDocumentSymbol.params -> TextDocumentDocumentSymbol.result t
     | DebugEcho : DebugEcho.params -> DebugEcho.result t
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
     | TextDocumentReferences : References.params -> References.result t

--- a/tests-lsp/__tests__/textDocument-documentSymbol.ts
+++ b/tests-lsp/__tests__/textDocument-documentSymbol.ts
@@ -1,0 +1,206 @@
+import outdent from "outdent";
+import * as LanguageServer from "../src/LanguageServer";
+
+import * as Protocol from "vscode-languageserver-protocol";
+import * as Types from "vscode-languageserver-types";
+
+describe("textDocument/documentSymbol", () => {
+  let languageServer = null;
+
+  async function openDocument(source) {
+    await languageServer.sendNotification("textDocument/didOpen", {
+      textDocument: Types.TextDocumentItem.create(
+        "file:///test.ml",
+        "txt",
+        0,
+        source
+      )
+    });
+  }
+
+  async function query() {
+    return await languageServer.sendRequest("textDocument/documentSymbol", {
+      textDocument: Types.TextDocumentIdentifier.create("file:///test.ml")
+    });
+  }
+
+  afterEach(async () => {
+    await LanguageServer.exit(languageServer);
+    languageServer = null;
+  });
+
+  it("returns a list of symbol infos", async () => {
+    languageServer = await LanguageServer.startAndInitialize();
+    await openDocument(outdent`
+      let num = 42
+      let string = "Hello"
+
+      module M = struct
+        let m a b = a + b
+        let n = 32
+      end
+    `);
+
+    let result = await query();
+
+    expect(result).toMatchObject([
+      {
+        kind: 2,
+        location: {
+          range: {
+            end: { character: 3, line: 6 },
+            start: { character: 0, line: 3 }
+          },
+          uri: "file:///test.ml"
+        },
+        name: "M"
+      },
+      {
+        containerName: "M",
+        kind: 12,
+        location: {
+          range: {
+            end: { character: 12, line: 5 },
+            start: { character: 2, line: 5 }
+          },
+          uri: "file:///test.ml"
+        },
+        name: "n"
+      },
+      {
+        containerName: "M",
+        kind: 12,
+        location: {
+          range: {
+            end: { character: 19, line: 4 },
+            start: { character: 2, line: 4 }
+          },
+          uri: "file:///test.ml"
+        },
+        name: "m"
+      },
+      {
+        kind: 12,
+        location: {
+          range: {
+            end: { character: 20, line: 1 },
+            start: { character: 0, line: 1 }
+          },
+          uri: "file:///test.ml"
+        },
+        name: "string"
+      },
+      {
+        kind: 12,
+        location: {
+          range: {
+            end: { character: 12, line: 0 },
+            start: { character: 0, line: 0 }
+          },
+          uri: "file:///test.ml"
+        },
+        name: "num"
+      }
+    ]);
+  });
+
+  it("returns a hierarchy of symbols", async () => {
+    languageServer = await LanguageServer.startAndInitialize({
+      textDocument: {
+        documentSymbol: {
+          hierarchicalDocumentSymbolSupport: true
+        }
+      }
+    });
+    await openDocument(outdent`
+      let num = 42
+      let string = "Hello"
+
+      module M = struct
+        let m a b = a + b
+        let n = 32
+      end
+    `);
+
+    let result = await query();
+
+    expect(result).toMatchObject([
+      {
+        children: [
+          {
+            children: [],
+            deprecated: false,
+            detail: "int",
+            kind: 12,
+            name: "n",
+            range: {
+              end: { character: 12, line: 5 },
+              start: { character: 2, line: 5 }
+            },
+            selectionRange: {
+              end: { character: 12, line: 5 },
+              start: { character: 2, line: 5 }
+            }
+          },
+          {
+            children: [],
+            deprecated: false,
+            detail: "int -> int -> int",
+            kind: 12,
+            name: "m",
+            range: {
+              end: { character: 19, line: 4 },
+              start: { character: 2, line: 4 }
+            },
+            selectionRange: {
+              end: { character: 19, line: 4 },
+              start: { character: 2, line: 4 }
+            }
+          }
+        ],
+        deprecated: false,
+        detail: null,
+        kind: 2,
+        name: "M",
+        range: {
+          end: { character: 3, line: 6 },
+          start: { character: 0, line: 3 }
+        },
+        selectionRange: {
+          end: { character: 3, line: 6 },
+          start: { character: 0, line: 3 }
+        }
+      },
+      {
+        children: [],
+        deprecated: false,
+        detail: "string",
+        kind: 12,
+        name: "string",
+        range: {
+          end: { character: 20, line: 1 },
+          start: { character: 0, line: 1 }
+        },
+        selectionRange: {
+          end: { character: 20, line: 1 },
+          start: { character: 0, line: 1 }
+        }
+      },
+      {
+        children: [],
+        deprecated: false,
+        detail: "int",
+        kind: 12,
+        name: "num",
+        range: {
+          end: { character: 12, line: 0 },
+          start: { character: 0, line: 0 }
+        },
+        selectionRange: {
+          end: { character: 12, line: 0 },
+          start: { character: 0, line: 0 }
+        }
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
We check for hierarchicalDocumentSymbolSupport capability and returns a list of
document symbols instead of a flat list of symbol infos.

TODO:

- [ ] Check if we need to return outline in the correct order
- [ ] Filter out `let _ = ` bindings from outline (those are generated by ppx deriving and are noisy, wondering if those should be removed in original merlin protocol too cc @trefis)