### PR TITLE
LSP: add expand-prefix and labels support

### DIFF
--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -511,7 +511,8 @@ module Completion = struct
     filterText: string option [@default None];  (* used for filtering; if absent, uses label *)
     insertText: string option [@default None];  (* used for inserting; if absent, uses label *)
     insertTextFormat: insertTextFormat option [@default None];
-    (* textEdits: TextEdit.t list;  (1* wire: split into hd and tl *1) *)
+    textEdit: TextEdit.t option [@default None];
+    additionalTextEdits: TextEdit.t list [@default []];
     (* command: Command.t option [@default None];  (1* if present, is executed after completion *1) *)
     (* data: Hh_json.json option [@default None]; *)
   }

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -205,4 +205,80 @@ describe("textDocument/completion", () => {
       }
     ]);
   });
+
+  it("completes with invalid prefix is buggy, it gives suggestions for LL instead of L", async () => {
+    openDocument(outdent`
+      let f = L.
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 10));
+    let items_top5 = items.slice(0, 5);
+    expect(items_top5).toMatchObject([
+      {
+        label: "ListLabels.append",
+        sortText: "0000",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 10 }
+          },
+          newText: "ListLabels.append"
+        }
+      },
+      {
+        label: "ListLabels.assoc",
+        sortText: "0001",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 10 }
+          },
+          newText: "ListLabels.assoc"
+        }
+      },
+      {
+        label: "ListLabels.assoc_opt",
+        sortText: "0002",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 10 }
+          },
+          newText: "ListLabels.assoc_opt"
+        }
+      },
+      {
+        label: "ListLabels.assq",
+        sortText: "0003",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 10 }
+          },
+          newText: "ListLabels.assq"
+        }
+      },
+      {
+        label: "ListLabels.assq_opt",
+        sortText: "0004",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 10 }
+          },
+          newText: "ListLabels.assq_opt"
+        }
+      },
+    ]);
+  });
+
+  it("completes with invalid prefix is buggy", async () => {
+    openDocument(outdent`
+      let f = LL.
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 11));
+    expect(items).toMatchObject([]);
+  });
+
 });

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -41,7 +41,7 @@ describe("textDocument/completion", () => {
     languageServer = null;
   });
 
-  it("can start completion at arbitrary position (after the dot)", async () => {
+  it("can start completion at arbitrary position (before the dot)", async () => {
     openDocument(outdent`
       Strin.func
     `);
@@ -89,6 +89,24 @@ describe("textDocument/completion", () => {
     expect(items).toMatchObject([
       { label: "somestring", sortText: "0000" },
       { label: "somenum", sortText: "0001" }
+    ]);
+  });
+
+  it("completes from a module", async () => {
+    openDocument(outdent`
+      let f = List.m
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 14));
+    expect(items).toMatchObject([
+      { label: "map", sortText: "0000" },
+      { label: "map2", sortText: "0001" },
+      { label: "mapi", sortText: "0002" },
+      { label: "mem", sortText: "0003" },
+      { label: "mem_assoc", sortText: "0004" },
+      { label: "mem_assq", sortText: "0005" },
+      { label: "memq", sortText: "0006" },
+      { label: "merge", sortText: "0007" },
     ]);
   });
 

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -297,4 +297,20 @@ describe("textDocument/completion", () => {
     expect(items).toMatchObject([]);
   });
 
+  it("completes labels", async () => {
+    openDocument(outdent`
+      let f = ListLabels.map 
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 23));
+    let items_top5 = items.slice(0, 5)
+    expect(items_top5).toMatchObject([
+      {label: "~f", sortText: "0000", textEdit: undefined},
+      {label: "::", sortText: "0001", textEdit: undefined},
+      {label: "[]", sortText: "0002", textEdit: undefined},
+      {label: "!", sortText: "0003", textEdit: undefined},
+      {label: "exit", sortText: "0004", textEdit: undefined}
+    ]);
+  });
+
 });

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -110,6 +110,22 @@ describe("textDocument/completion", () => {
     ]);
   });
 
+  it("completes a module name", async () => {
+    openDocument(outdent`
+      let f = L
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 9));
+    let items_top5 = items.slice(0, 5);
+    expect(items_top5).toMatchObject([
+      { label: "LargeFile", sortText: "0000" },
+      { label: "Lazy", sortText: "0001" },
+      { label: "Lexing", sortText: "0002" },
+      { label: "List", sortText: "0003" },
+      { label: "ListLabels", sortText: "0004" },
+    ]);
+  });
+
   it("completes without prefix", async () => {
     openDocument(outdent`
       let somenum = 42

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -129,4 +129,80 @@ describe("textDocument/completion", () => {
       { label: "min_int", sortText: "0004", textEdit: undefined },
     ]);
   });
+
+  it("completes with invalid prefix", async () => {
+    openDocument(outdent`
+      let f = Li.ma
+    `);
+
+    let items = await queryCompletion(Types.Position.create(0, 13));
+    expect(items).toMatchObject([
+      {
+        label: "ListLabels.map",
+        sortText: "0000",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "ListLabels.map"
+        }
+      },
+      {
+        label: "ListLabels.map2",
+        sortText: "0001",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "ListLabels.map2"
+        }
+      },
+      {
+        label: "ListLabels.mapi",
+        sortText: "0002",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "ListLabels.mapi"
+        }
+      },
+      {
+        label: "List.map",
+        sortText: "0003",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "List.map"
+        }
+      },
+      {
+        label: "List.map2",
+        sortText: "0004",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "List.map2"
+        }
+      },
+      {
+        label: "List.mapi",
+        sortText: "0005",
+        textEdit: {
+          range: {
+            start: { "line": 0, "character": 8 },
+            end: { "line": 0, "character": 13 }
+          },
+          newText: "List.mapi"
+        }
+      }
+    ]);
+  });
 });

--- a/tests-lsp/__tests__/textDocument-completion.test.ts
+++ b/tests-lsp/__tests__/textDocument-completion.test.ts
@@ -26,7 +26,8 @@ describe("textDocument/completion", () => {
     return result.items.map(item => {
       return {
         label: item.label,
-        sortText: item.sortText
+        sortText: item.sortText,
+        textEdit: item.textEdit,
       };
     });
   }
@@ -88,6 +89,26 @@ describe("textDocument/completion", () => {
     expect(items).toMatchObject([
       { label: "somestring", sortText: "0000" },
       { label: "somenum", sortText: "0001" }
+    ]);
+  });
+
+  it("completes without prefix", async () => {
+    openDocument(outdent`
+      let somenum = 42
+      let somestring = "hello"
+
+      let plus_42 (x:int) (y:int) =
+        somenum + 
+    `);
+
+    let items = await queryCompletion(Types.Position.create(4, 12));
+    let items_top5 = items.slice(0, 5);
+    expect(items_top5).toMatchObject([
+      { label: "y", sortText: "0000", textEdit: undefined },
+      { label: "x", sortText: "0001", textEdit: undefined },
+      { label: "somenum", sortText: "0002", textEdit: undefined },
+      { label: "max_int", sortText: "0003", textEdit: undefined },
+      { label: "min_int", sortText: "0004", textEdit: undefined },
     ]);
   });
 });


### PR DESCRIPTION
This PR adds support for expand-prefix in addition to completion-prefix in LSP. It should allow to complete invalid prefix such as `L.m` to `List.map`.