### PR TITLE
LSP: migrate to ppx_protocol_conv

### DIFF
--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -20,7 +20,7 @@ depends: [
   "dune"  {build & >= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"
-  "ppx_protocol_conv_json" {>= "4.0.0"}
+  "ppx_protocol_conv_json" {>= "5.0.0"}
   "mdx" {test & >= "1.3.0"}
 ]
 

--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -20,7 +20,7 @@ depends: [
   "dune"  {build & >= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"
-  "ppx_protocol_conv_json"
+  "ppx_protocol_conv_json" {>= "4.0.0"}
   "mdx" {test & >= "1.3.0"}
 ]
 

--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -20,7 +20,7 @@ depends: [
   "dune"  {build & >= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"
-  "ppx_deriving_yojson"
+  "ppx_protocol_conv_json"
   "mdx" {test & >= "1.3.0"}
 ]
 

--- a/src/lsp/dune
+++ b/src/lsp/dune
@@ -1,6 +1,6 @@
 (library
   (name lsp)
-  (libraries merlin_utils yojson ppx_deriving_yojson.runtime threads)
-  (preprocess (pps ppx_deriving_yojson)))
+  (libraries merlin_utils yojson ppx_protocol_conv_json threads)
+  (preprocess (pps ppx_protocol_conv)))
 
 (ocamllex (modules text_document_text))

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -8,6 +8,12 @@
  *)
 
 open Protocol_conv_json
+module Json = Json.Make(
+  struct
+    let field_name str = str
+    let singleton_constr_as_string = false
+    let omit_default_values = true
+  end)
 
 type documentUri = Uri.t [@@deriving protocol ~driver:(module Json)]
 
@@ -673,9 +679,9 @@ module Initialize = struct
     processId: int option [@default None];  (* pid of parent process *)
     rootPath: string option [@default None];  (* deprecated *)
     rootUri: documentUri option [@default None];  (* the root URI of the workspace *)
-    client_capabilities: client_capabilities [@key "capabilities"] [@default client_capabilities_empty];
+    client_capabilities: client_capabilities [@key "capabilities"];
     trace: trace [@default Off];  (* the initial trace setting, default="off" *)
-  } [@@deriving protocol ~driver:(module Json)]
+  } [@@deriving_inline protocol ~driver:(module Json)]
 
   and result = {
     server_capabilities: server_capabilities [@key "capabilities"];
@@ -749,7 +755,515 @@ module Initialize = struct
 
   and saveOptions = {
     includeText: bool;  (* the client should include content on save *)
-  }
+    }
+ 
+let _ = fun (_ : params) -> ()
+let _ = fun (_ : result) -> ()
+let _ = fun (_ : errorData) -> ()
+let _ = fun (_ : server_capabilities) -> ()
+let _ = fun (_ : completionOptions) -> ()
+let _ = fun (_ : codeLensOptions) -> ()
+let _ = fun (_ : documentOnTypeFormattingOptions) -> ()
+let _ = fun (_ : documentLinkOptions) -> ()
+let _ = fun (_ : executeCommandOptions) -> ()
+let _ = fun (_ : textDocumentSyncOptions) -> ()
+let _ = fun (_ : saveOptions) -> ()
+let rec params_to_json t =
+  (fun { processId; rootPath; rootUri; client_capabilities; trace } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("processId", processId,
+               ((fun t -> Json.of_option t) (fun t -> Json.of_int t)),
+               (Some None)),
+              (Cons
+                 (("rootPath", rootPath,
+                    ((fun t -> Json.of_option t) (fun t -> Json.of_string t)),
+                    (Some None)),
+                   (Cons
+                      (("rootUri", rootUri,
+                         ((fun t -> Json.of_option t) documentUri_to_json),
+                         (Some None)),
+                        (Cons
+                           (("capabilities", client_capabilities,
+                              client_capabilities_to_json, None),
+                             (Cons
+                                (("trace", trace, trace_to_json, (Some Off)),
+                                  Nil))))))))))) t[@@ocaml.warning "-39"]
+and result_to_json t =
+  (fun { server_capabilities } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("capabilities", server_capabilities,
+               server_capabilities_to_json, None), Nil))) t[@@ocaml.warning
+                                                             "-39"]
+and errorData_to_json t =
+  (fun { retry } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons (("retry", retry, (fun t -> Json.of_bool t), None), Nil))) t
+[@@ocaml.warning "-39"]
+and server_capabilities_to_json t =
+  (fun
+     { textDocumentSync; hoverProvider; completionProvider;
+       definitionProvider; typeDefinitionProvider; referencesProvider;
+       documentHighlightProvider; documentSymbolProvider;
+       workspaceSymbolProvider; codeActionProvider; codeLensProvider;
+       documentFormattingProvider; documentRangeFormattingProvider;
+       documentOnTypeFormattingProvider; renameProvider;
+       documentLinkProvider; executeCommandProvider; typeCoverageProvider;
+       rageProvider }
+     ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("textDocumentSync", textDocumentSync,
+               textDocumentSyncOptions_to_json, None),
+              (Cons
+                 (("hoverProvider", hoverProvider, (fun t -> Json.of_bool t),
+                    None),
+                   (Cons
+                      (("completionProvider", completionProvider,
+                         ((fun t -> Json.of_option t)
+                            completionOptions_to_json), (Some None)),
+                        (Cons
+                           (("definitionProvider", definitionProvider,
+                              (fun t -> Json.of_bool t), None),
+                             (Cons
+                                (("typeDefinitionProvider",
+                                   typeDefinitionProvider,
+                                   (fun t -> Json.of_bool t), None),
+                                  (Cons
+                                     (("referencesProvider",
+                                        referencesProvider,
+                                        (fun t -> Json.of_bool t), None),
+                                       (Cons
+                                          (("documentHighlightProvider",
+                                             documentHighlightProvider,
+                                             (fun t -> Json.of_bool t), None),
+                                            (Cons
+                                               (("documentSymbolProvider",
+                                                  documentSymbolProvider,
+                                                  (fun t -> Json.of_bool t),
+                                                  None),
+                                                 (Cons
+                                                    (("workspaceSymbolProvider",
+                                                       workspaceSymbolProvider,
+                                                       (fun t ->
+                                                          Json.of_bool t),
+                                                       None),
+                                                      (Cons
+                                                         (("codeActionProvider",
+                                                            codeActionProvider,
+                                                            (fun t ->
+                                                               Json.of_bool t),
+                                                            None),
+                                                           (Cons
+                                                              (("codeLensProvider",
+                                                                 codeLensProvider,
+                                                                 ((fun t ->
+                                                                    Json.of_option
+                                                                    t)
+                                                                    codeLensOptions_to_json),
+                                                                 (Some None)),
+                                                                (Cons
+                                                                   (("documentFormattingProvider",
+                                                                    documentFormattingProvider,
+                                                                    (fun t ->
+                                                                    Json.of_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("documentRangeFormattingProvider",
+                                                                    documentRangeFormattingProvider,
+                                                                    (fun t ->
+                                                                    Json.of_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("documentOnTypeFormattingProvider",
+                                                                    documentOnTypeFormattingProvider,
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.of_option
+                                                                    t)
+                                                                    documentOnTypeFormattingOptions_to_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("renameProvider",
+                                                                    renameProvider,
+                                                                    (fun t ->
+                                                                    Json.of_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("documentLinkProvider",
+                                                                    documentLinkProvider,
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.of_option
+                                                                    t)
+                                                                    documentLinkOptions_to_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("executeCommandProvider",
+                                                                    executeCommandProvider,
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.of_option
+                                                                    t)
+                                                                    executeCommandOptions_to_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("typeCoverageProvider",
+                                                                    typeCoverageProvider,
+                                                                    (fun t ->
+                                                                    Json.of_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("rageProvider",
+                                                                    rageProvider,
+                                                                    (fun t ->
+                                                                    Json.of_bool
+                                                                    t), None),
+                                                                    Nil)))))))))))))))))))))))))))))))))))))))
+    t[@@ocaml.warning "-39"]
+and completionOptions_to_json t =
+  (fun { resolveProvider; triggerCharacters } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("resolveProvider", resolveProvider, (fun t -> Json.of_bool t),
+               None),
+              (Cons
+                 (("triggerCharacters", triggerCharacters,
+                    ((fun t -> Json.of_list t) (fun t -> Json.of_string t)),
+                    None), Nil))))) t[@@ocaml.warning "-39"]
+and codeLensOptions_to_json t =
+  (fun { codelens_resolveProvider } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("resolveProvider", codelens_resolveProvider,
+               (fun t -> Json.of_bool t), None), Nil))) t[@@ocaml.warning
+                                                           "-39"]
+and documentOnTypeFormattingOptions_to_json t =
+  (fun { firstTriggerCharacter; moreTriggerCharacter } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("firstTriggerCharacter", firstTriggerCharacter,
+               (fun t -> Json.of_string t), None),
+              (Cons
+                 (("moreTriggerCharacter", moreTriggerCharacter,
+                    ((fun t -> Json.of_list t) (fun t -> Json.of_string t)),
+                    None), Nil))))) t[@@ocaml.warning "-39"]
+and documentLinkOptions_to_json t =
+  (fun { doclink_resolveProvider } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("doclink_resolveProvider", doclink_resolveProvider,
+               (fun t -> Json.of_bool t), None), Nil))) t[@@ocaml.warning
+                                                           "-39"]
+and executeCommandOptions_to_json t =
+  (fun { commands } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("commands", commands,
+               ((fun t -> Json.of_list t) (fun t -> Json.of_string t)), None),
+              Nil))) t[@@ocaml.warning "-39"]
+and textDocumentSyncOptions_to_json t =
+  (fun { openClose; change; willSave; willSaveWaitUntil; didSave } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("openClose", openClose, (fun t -> Json.of_bool t), None),
+              (Cons
+                 (("change", change, textDocumentSyncKind_to_json, None),
+                   (Cons
+                      (("willSave", willSave, (fun t -> Json.of_bool t),
+                         None),
+                        (Cons
+                           (("willSaveWaitUntil", willSaveWaitUntil,
+                              (fun t -> Json.of_bool t), None),
+                             (Cons
+                                (("didSave", didSave,
+                                   ((fun t -> Json.of_option t)
+                                      saveOptions_to_json), (Some None)),
+                                  Nil))))))))))) t[@@ocaml.warning "-39"]
+and saveOptions_to_json t =
+  (fun { includeText } ->
+     (fun t -> Json.of_record t)
+       (let open! Protocol_conv.Runtime.Record_in in
+          Cons
+            (("includeText", includeText, (fun t -> Json.of_bool t), None),
+              Nil))) t[@@ocaml.warning "-39"]
+let _ = params_to_json
+and _ = result_to_json
+and _ = errorData_to_json
+and _ = server_capabilities_to_json
+and _ = completionOptions_to_json
+and _ = codeLensOptions_to_json
+and _ = documentOnTypeFormattingOptions_to_json
+and _ = documentLinkOptions_to_json
+and _ = executeCommandOptions_to_json
+and _ = textDocumentSyncOptions_to_json
+and _ = saveOptions_to_json
+let rec params_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("processId",
+            ((fun t -> Json.to_option t) (fun t -> Json.to_int t)),
+            (Some None)),
+           (Cons
+              (("rootPath",
+                 ((fun t -> Json.to_option t) (fun t -> Json.to_string t)),
+                 (Some None)),
+                (Cons
+                   (("rootUri",
+                      ((fun t -> Json.to_option t) documentUri_of_json),
+                      (Some None)),
+                     (Cons
+                        (("capabilities", client_capabilities_of_json, None),
+                          (Cons (("trace", trace_of_json, (Some Off)), Nil))))))))) in
+   let constructor processId rootPath rootUri client_capabilities trace =
+     { processId; rootPath; rootUri; client_capabilities; trace } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and result_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons (("capabilities", server_capabilities_of_json, None), Nil) in
+   let constructor server_capabilities = { server_capabilities } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and errorData_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons (("retry", (fun t -> Json.to_bool t), None), Nil) in
+   let constructor retry = { retry } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and server_capabilities_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("textDocumentSync", textDocumentSyncOptions_of_json, None),
+           (Cons
+              (("hoverProvider", (fun t -> Json.to_bool t), None),
+                (Cons
+                   (("completionProvider",
+                      ((fun t -> Json.to_option t) completionOptions_of_json),
+                      (Some None)),
+                     (Cons
+                        (("definitionProvider", (fun t -> Json.to_bool t),
+                           None),
+                          (Cons
+                             (("typeDefinitionProvider",
+                                (fun t -> Json.to_bool t), None),
+                               (Cons
+                                  (("referencesProvider",
+                                     (fun t -> Json.to_bool t), None),
+                                    (Cons
+                                       (("documentHighlightProvider",
+                                          (fun t -> Json.to_bool t), None),
+                                         (Cons
+                                            (("documentSymbolProvider",
+                                               (fun t -> Json.to_bool t),
+                                               None),
+                                              (Cons
+                                                 (("workspaceSymbolProvider",
+                                                    (fun t -> Json.to_bool t),
+                                                    None),
+                                                   (Cons
+                                                      (("codeActionProvider",
+                                                         (fun t ->
+                                                            Json.to_bool t),
+                                                         None),
+                                                        (Cons
+                                                           (("codeLensProvider",
+                                                              ((fun t ->
+                                                                  Json.to_option
+                                                                    t)
+                                                                 codeLensOptions_of_json),
+                                                              (Some None)),
+                                                             (Cons
+                                                                (("documentFormattingProvider",
+                                                                   (fun t ->
+                                                                    Json.to_bool
+                                                                    t), None),
+                                                                  (Cons
+                                                                    (("documentRangeFormattingProvider",
+                                                                    (fun t ->
+                                                                    Json.to_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("documentOnTypeFormattingProvider",
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.to_option
+                                                                    t)
+                                                                    documentOnTypeFormattingOptions_of_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("renameProvider",
+                                                                    (fun t ->
+                                                                    Json.to_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("documentLinkProvider",
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.to_option
+                                                                    t)
+                                                                    documentLinkOptions_of_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("executeCommandProvider",
+                                                                    ((fun t
+                                                                    ->
+                                                                    Json.to_option
+                                                                    t)
+                                                                    executeCommandOptions_of_json),
+                                                                    (Some
+                                                                    None)),
+                                                                    (Cons
+                                                                    (("typeCoverageProvider",
+                                                                    (fun t ->
+                                                                    Json.to_bool
+                                                                    t), None),
+                                                                    (Cons
+                                                                    (("rageProvider",
+                                                                    (fun t ->
+                                                                    Json.to_bool
+                                                                    t), None),
+                                                                    Nil))))))))))))))))))))))))))))))))))))) in
+   let constructor textDocumentSync hoverProvider completionProvider
+     definitionProvider typeDefinitionProvider referencesProvider
+     documentHighlightProvider documentSymbolProvider workspaceSymbolProvider
+     codeActionProvider codeLensProvider documentFormattingProvider
+     documentRangeFormattingProvider documentOnTypeFormattingProvider
+     renameProvider documentLinkProvider executeCommandProvider
+     typeCoverageProvider rageProvider =
+     {
+       textDocumentSync;
+       hoverProvider;
+       completionProvider;
+       definitionProvider;
+       typeDefinitionProvider;
+       referencesProvider;
+       documentHighlightProvider;
+       documentSymbolProvider;
+       workspaceSymbolProvider;
+       codeActionProvider;
+       codeLensProvider;
+       documentFormattingProvider;
+       documentRangeFormattingProvider;
+       documentOnTypeFormattingProvider;
+       renameProvider;
+       documentLinkProvider;
+       executeCommandProvider;
+       typeCoverageProvider;
+       rageProvider
+     } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and completionOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("resolveProvider", (fun t -> Json.to_bool t), None),
+           (Cons
+              (("triggerCharacters",
+                 ((fun t -> Json.to_list t) (fun t -> Json.to_string t)),
+                 None), Nil))) in
+   let constructor resolveProvider triggerCharacters =
+     { resolveProvider; triggerCharacters } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and codeLensOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons (("resolveProvider", (fun t -> Json.to_bool t), None), Nil) in
+   let constructor codelens_resolveProvider = { codelens_resolveProvider } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and documentOnTypeFormattingOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("firstTriggerCharacter", (fun t -> Json.to_string t), None),
+           (Cons
+              (("moreTriggerCharacter",
+                 ((fun t -> Json.to_list t) (fun t -> Json.to_string t)),
+                 None), Nil))) in
+   let constructor firstTriggerCharacter moreTriggerCharacter =
+     { firstTriggerCharacter; moreTriggerCharacter } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and documentLinkOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("doclink_resolveProvider", (fun t -> Json.to_bool t), None), Nil) in
+   let constructor doclink_resolveProvider = { doclink_resolveProvider } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and executeCommandOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("commands",
+            ((fun t -> Json.to_list t) (fun t -> Json.to_string t)), None),
+           Nil) in
+   let constructor commands = { commands } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and textDocumentSyncOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons
+         (("openClose", (fun t -> Json.to_bool t), None),
+           (Cons
+              (("change", textDocumentSyncKind_of_json, None),
+                (Cons
+                   (("willSave", (fun t -> Json.to_bool t), None),
+                     (Cons
+                        (("willSaveWaitUntil", (fun t -> Json.to_bool t),
+                           None),
+                          (Cons
+                             (("didSave",
+                                ((fun t -> Json.to_option t)
+                                   saveOptions_of_json), (Some None)), Nil))))))))) in
+   let constructor openClose change willSave willSaveWaitUntil didSave =
+     { openClose; change; willSave; willSaveWaitUntil; didSave } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+and saveOptions_of_json t =
+  (let of_funcs =
+     let open Protocol_conv.Runtime.Record_in in
+       Cons (("includeText", (fun t -> Json.to_bool t), None), Nil) in
+   let constructor includeText = { includeText } in
+   (fun t -> Json.to_record t) of_funcs constructor) t[@@ocaml.warning "-39"]
+let _ = params_of_json
+and _ = result_of_json
+and _ = errorData_of_json
+and _ = server_capabilities_of_json
+and _ = completionOptions_of_json
+and _ = codeLensOptions_of_json
+and _ = documentOnTypeFormattingOptions_of_json
+and _ = documentLinkOptions_of_json
+and _ = executeCommandOptions_of_json
+and _ = textDocumentSyncOptions_of_json
+and _ = saveOptions_of_json
+          [@@@end]
+let params_of_json t =
+  let {Logger. log} = Logger.for_section "lsp" in
+  log ~title:"debug" "so much fun";
+  try
+    let p = params_of_json t in
+    log ~title:"debug" "so much fun again";
+    p
+  with exn ->
+    log ~title:"debug" "wtf here %s" (Printexc.to_string exn);
+    raise exn
+
 end
 
 (* Goto Definition request, method="textDocument/definition" *)

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -17,7 +17,7 @@ module Client_notification : sig
     | TextDocumentDidChange of DidChange.params
     | Initialized
     | Exit
-    | UnknownNotification of string * Yojson.Safe.json
+    | UnknownNotification of string * Yojson.Safe.t
 end
 
 module Request : sig
@@ -36,7 +36,7 @@ module Request : sig
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
     | TextDocumentReferences : References.params -> References.result t
     | TextDocumentHighlight : TextDocumentHighlight.params -> TextDocumentHighlight.result t
-    | UnknownRequest : string * Yojson.Safe.json -> unit t
+    | UnknownRequest : string * Yojson.Safe.t -> unit t
 end
 
 type t

--- a/src/lsp/uri.ml
+++ b/src/lsp/uri.ml
@@ -1,4 +1,6 @@
-type t = string [@@deriving yojson { strict = false }]
+open Protocol_conv_json
+
+type t = string [@@deriving protocol ~driver:(module Json)]
 
 let to_string uri = uri
 

--- a/src/lsp/uri.mli
+++ b/src/lsp/uri.mli
@@ -1,7 +1,6 @@
-type t
+open Protocol_conv_json
 
-val of_yojson : Yojson.Safe.json -> (t, string) result
-val to_yojson : t -> Yojson.Safe.json
+type t [@@deriving protocol ~driver:(module Json)]
 
 val to_path : t -> string
 val of_path : string -> t

--- a/tests-lsp/src/LanguageServer.ts
+++ b/tests-lsp/src/LanguageServer.ts
@@ -29,7 +29,7 @@ export const toURI = s => {
 
 export const start = (opts?: cp.SpawnOptions) => {
   opts = opts || {
-    env: { ...process.env, MERLIN_LOG: "-" }
+    env: { ...process.env, MERLIN_LOG: "/tmp/merlin.log" }
   };
   let childProcess = cp.spawn(serverPath, [], opts);
 


### PR DESCRIPTION
Beginning of the work on #937.

So I started to translate the code from ppx_deriving_yojson to ppx_protocol_conv_json. There are some good things. For example it can translate a constructor with no argument to a string. So there is no need to write the conversion functions by hand in this case. On the other hand, it uses exception instead of the result type, which is a bit sad and annoying. So either the code must be adapted to catch the exceptions. Or we can ask upstream if using the result type would be possible.

The code doesn't compile yet but I haven't had time to work on it in the past few days. Pushing it here in case someone wants to help.