### PR TITLE
Fix Env.check_state_consistency to check for cmi on build path

### DIFF
--- a/src/ocaml/typing/402/env.ml
+++ b/src/ocaml/typing/402/env.ml
@@ -493,13 +493,15 @@ let reset_cache_toplevel () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store (_, ps_sig) -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/403/env.ml
+++ b/src/ocaml/typing/403/env.ml
@@ -2522,13 +2522,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store (_, ps_sig) -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -2559,13 +2559,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -2555,13 +2555,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -2761,13 +2761,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   not ps.loaded || match ps.cell with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -2736,13 +2736,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -2737,13 +2737,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/src/ocaml/typing/408/env.ml
+++ b/src/ocaml/typing/408/env.ml
@@ -3142,13 +3142,15 @@ let () =
 
 let check_state_consistency () =
   Std.Hashtbl.forall !persistent_structures @@ fun name ps ->
+  let has_cmi =
+    match find_in_path_uncap !load_path (name ^ ".cmi") with
+    | _ -> true
+    | exception Not_found -> false
+  in
   match ps with
-  | None ->
-    begin match find_in_path_uncap !Config.load_path (name ^ ".cmi") with
-      | _ -> false
-      | exception Not_found -> true
-    end
+  | None -> not has_cmi
   | Some cell ->
+    has_cmi &&
     begin match !(Cmi_cache.(read cell.ps_filename).Cmi_cache.cmi_cache) with
       | Cmi_cache_store ps_sig -> Std.lazy_eq ps_sig cell.ps_sig
       | _ -> false

--- a/tests/errors/consistent_env.t
+++ b/tests/errors/consistent_env.t
@@ -1,0 +1,56 @@
+When we change merlin configuration server should invalidate typing env
+accordingly.
+
+  $ $MERLIN server stop-server
+
+First we query server with `./deps` in build path and we see no errors reported:
+
+  $ $MERLIN server errors -filename consistent_env.ml -build-path ./deps <<EOF \
+  > let f x = A.value \
+  > EOF
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }
+
+Then we query server with no `./deps` in build path and should get an error
+about unbound module:
+
+  $ $MERLIN server errors -filename consistent_env.ml <<EOF \
+  > let f x = A.value \
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 10
+        },
+        "end": {
+          "line": 1,
+          "col": 17
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module A"
+      }
+    ],
+    "notifications": []
+  }
+
+Finally if we query server again with `./deps` in build path back we should see
+no errors as in the first query:
+
+  $ $MERLIN server errors -filename consistent_env.ml -build-path ./deps <<EOF \
+  > let f x = A.value \
+  > EOF
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }
+
+  $ $MERLIN server stop-server

--- a/tests/errors/deps/a.ml
+++ b/tests/errors/deps/a.ml
@@ -1,0 +1,1 @@
+let value = 3

--- a/tests/errors/dune
+++ b/tests/errors/dune
@@ -1,0 +1,9 @@
+(alias
+ (name runtest)
+ (deps (:t consistent_env.t) deps/a.ml)
+ (action
+   (progn
+     (run %{ocamlc} -c -bin-annot deps/a.ml)
+     (setenv MERLIN %{exe:../merlin-wrapper}
+       (run %{bin:mdx} test --syntax=cram %{t}))
+     (diff? %{t} %{t}.corrected))))


### PR DESCRIPTION
See the first commit which adds a test for a case where build path config is
being reconfigured.

I found this edge case by checking if merlin refreshes diagnostics if I remove a library from `dune` config. Turns out it didn't. This is a fix.