### PR TITLE
Fixing misspellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,7 +499,7 @@ give, but here are some key points (from an user perspective):
   - locate now works on MLI files
   - automatic reloading of .merlin files (when they are update or created), it
     is no longer necessary to restart merlin
-  - introduced a small refactoring command: rename, who renames all occurences
+  - introduced a small refactoring command: rename, who renames all occurrences
     of an identifier. See: http://yawdp.com/~def/rename.webm
 
 
@@ -521,7 +521,7 @@ This release also marks the apparition of a proper opam install script.
   + backend:
     - fixes on locate
     - print manifests even when -short-paths is set
-    - add an "occurences" command to list every occurence of an identifier ( #156 )
+    - add an "occurrences" command to list every occurrence of an identifier ( #156 )
     - new "version" command ( #180 )
     - add CPU time to log files ( #192 )
     - better error reporting from locate ( #190 )
@@ -535,7 +535,7 @@ This release also marks the apparition of a proper opam install script.
     - numerous fixes
 
   + vim:
-    - add error list independant from syntastic
+    - add error list independent from syntastic
     - fix completion for vim<=703 (#223)
 
 merlin 1.6
@@ -576,7 +576,7 @@ Sat Dec 14 19:45:06 CET 2013
 
   + backend:
     - better handling of paths (both sources and build)
-    - splitted build path into cmi and cmt path.
+    - split build path into cmi and cmt path.
       New directives "CMI" and "CMT" are now available in .merlin files ("B"
       still works as previously)
     - doesn't get confused anymore when the user switch between buffers (the

--- a/doc/dev/ARCHITECTURE.md
+++ b/doc/dev/ARCHITECTURE.md
@@ -123,7 +123,7 @@ Definitions useful to all versions of the typechecker.
 `fake.ml`: generate fake pieces of AST that implement the semantics of
 extensions from `src/kernel/extensions.ml`
 
-`msupport.ml`: bridge betwen extensions to OCaml typecheker and Merlin kernel.
+`msupport.ml`: bridge between extensions to OCaml typecheker and Merlin kernel.
 Mainly for warning and location management, capture of type errors and
 annotation of erroneous AST nodes
 

--- a/doc/dev/CACHING.md
+++ b/doc/dev/CACHING.md
@@ -18,7 +18,7 @@ Using `File_id.with_cache (fun () -> <body>)`, the results of calls to
 # Caching file contents, the `File_cache` functor
 
 The `File_cache` functor caches the contents of a computation based on a
-filename for as long as the file dont't change (as determined by `File_id`).
+filename for as long as the file don't change (as determined by `File_id`).
 
 For instance `Cmi_format.read` loads a cmi file from the disk. The OCaml
 compiler calls it directly as a cmi is not supposed to change while the

--- a/doc/dev/OLD-PROTOCOL.md
+++ b/doc/dev/OLD-PROTOCOL.md
@@ -47,7 +47,7 @@ Responses are always of the form `[kind,payload]` where `payload` depends on the
 
 `"error"` when something wrong prevented Merlin from answering: invalid files (for instance wrong OCaml version), missing packages, etc.  `payload` is a string describing the error, user should be notified to fix the environment.
 
-`"exception"` when something unexpected happened.  Merlin should be fixed, please report the error.  `payload` is an arbitraty json value.
+`"exception"` when something unexpected happened.  Merlin should be fixed, please report the error.  `payload` is an arbitrary json value.
 
     
 ## Synchronization
@@ -227,7 +227,7 @@ Entries is the list of possible completion. Each entry is made of:
 - a name, the text that should be put in the buffer if selected
 - a kind, one of `"value"`, `"variant"`, `"constructor"`, `"label"`, `"module"`, `"signature"`, `"type"`, `"method"`, `"#"` (for method calls), `"exn"`, `"class"`
 - a description, most of the time a type or a definition line, to be put next to the name in completion box
-- optional informations which might not fit in the completion box, like signatures for modules or documentation string.
+- optional information which might not fit in the completion box, like signatures for modules or documentation string.
 
 
 ```javascript
@@ -306,7 +306,7 @@ The value is a list where each item as the shape:
   "end"   : position,
   "valid" : bool,
   "message" : string,
-  "type"  : ("type"|"parser"|"env"|"warning"|"unkown")
+  "type"  : ("type"|"parser"|"env"|"warning"|"unknown")
 }
 ```
 
@@ -336,7 +336,7 @@ It returns a `cursor state` object describind the state of the checked out buffe
 ```
 
 Switch to "default" buffer for "ml", "mli".
-It will be in the state you left it last time it was used, unless Merlin decided to garbage collect because of memory pressure (any buffer left in background is either untouched or resetted because of collection).
+It will be in the state you left it last time it was used, unless Merlin decided to garbage collect because of memory pressure (any buffer left in background is either untouched or reset because of collection).
 
 
 ```javascript

--- a/doc/dev/PROTOCOL.md
+++ b/doc/dev/PROTOCOL.md
@@ -221,7 +221,7 @@ Entries is the list of possible completion. Each entry is made of:
 - a name, the text that should be put in the buffer if selected
 - a kind, one of `'value'`, `'variant'`, `'constructor'`, `'label'`, `'module'`, `'signature'`, `'type'`, `'method'`, `'#'` (for method calls), `'exn'`, `'class'`
 - a description, most of the time a type or a definition line, to be put next to the name in completion box
-- optional informations which might not fit in the completion box, like signatures for modules or documentation string.
+- optional information which might not fit in the completion box, like signatures for modules or documentation string.
 
 ### `document -position <position> [ -identifier <string> ]`
 

--- a/doc/next/Protocol.wiki
+++ b/doc/next/Protocol.wiki
@@ -1,7 +1,7 @@
 Next merlin protocol should be stateless.
 Also worth taking a look: [[https://github.com/Microsoft/language-server-protocol|Microsoft/language-server-protocol]].
 
-The protocol is still implemented as a serie of request/answer.
+The protocol is still implemented as a series of request/answer.
 
 {{{
   request-format:

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1066,7 +1066,7 @@ An ocaml atom is any string containing [a-z_0-9A-Z`.]."
     ))
 
 (defun merlin--type-display (bounds type &optional quiet)
-  "Display the type TYPE of the expression occuring at BOUNDS.
+  "Display the type TYPE of the expression occurring at BOUNDS.
 If QUIET is non nil, then an overlay and the merlin types can be used."
   (if (not type)
       (unless quiet (message "<no information>"))
@@ -1300,7 +1300,7 @@ strictly within, or nil if there is no such element."
 
 (defun merlin--project-get ()
   "Returns a pair of two string lists (dot_merlins . failures) with a list of
-.merlins file loaded and a list of error messages, if any error occured during
+.merlins file loaded and a list of error messages, if any error occurred during
 loading"
   (let ((ret (merlin/call "check-configuration")))
     (setq merlin--project-cache
@@ -1691,7 +1691,7 @@ Empty string defaults to jumping to all these."
                  ;; correct version is used rather than the version that
                  ;; happens to be on the path
 
-                 ;; this was originally done via `opam exec' but that doesnt
+                 ;; this was originally done via `opam exec' but that does not
                  ;; work for opam 1, and added a performance hit
                  (setq merlin-opam-bin-path (list (concat "PATH=" bin-path)))
                  (concat bin-path "/ocamlmerlin"))

--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -683,10 +683,10 @@ let application_context ~prefix path =
     | (_, Expression earg) ::
       (_, Expression ({ exp_desc = Texp_apply (efun, _); _ } as app)) :: _
       when earg != efun ->
-      (* Type variables shared accross arguments should all be
+      (* Type variables shared across arguments should all be
          printed with the same name.
          [Printtyp.type_scheme] ensure that a name is unique within a given
-         type, but not accross different invocations.
+         type, but not across different invocations.
          [reset] followed by calls to [mark_loops] and [type_sch] provide
          that *)
       Printtyp.reset ();

--- a/src/analysis/destruct.mli
+++ b/src/analysis/destruct.mli
@@ -43,7 +43,7 @@
           [let module M = (val e) in (??)]
 
       - a pattern context:
-          Here two differents behaviors can be observed:
+          Here two different behaviors can be observed:
           + if your matching is not exhaustive, it will be made exhaustive.
           + if your matching is exhaustive, it will refine the subpattern under
             the cursor if possible (i.e. if your cursor is on a variable or _ ).
@@ -54,7 +54,7 @@
 
     Final remarks:
       - Destruct will refuse to work on expression (resp. patterns) with a
-        functionnal or polymorphic type.
+        functional or polymorphic type.
 
       - Constructors of variant types will be prefixed by their path (if
         necessary) but record labels will not.

--- a/src/analysis/typedtrie.ml
+++ b/src/analysis/typedtrie.ml
@@ -496,7 +496,7 @@ let rec follow ~remember_loc ~state scopes ?before trie path =
   match Namespaced_path.head_exn path with
   | Applied_to path ->
     (* FIXME: That's wrong. The scope should be the one where the query was
-       emited. Not the point where we finally arrive on the application. *)
+       emitted. Not the point where we finally arrive on the application. *)
     let functor_argument =
       let scopes = (trie, before) :: scopes in
       Handled (path, scopes)

--- a/src/frontend/new/new_commands.ml
+++ b/src/frontend/new/new_commands.ml
@@ -125,7 +125,7 @@ Entries is the list of possible completion. Each entry is made of:
 - a name, the text that should be put in the buffer if selected
 - a kind, one of `'value'`, `'variant'`, `'constructor'`, `'label'`, `'module'`, `'signature'`, `'type'`, `'method'`, `'#'` (for method calls), `'exn'`, `'class'`
 - a description, most of the time a type or a definition line, to be put next to the name in completion box
-- optional informations which might not fit in the completion box, like signatures for modules or documentation string."
+- optional information which might not fit in the completion box, like signatures for modules or documentation string."
     ~default:("",`None,[],false,true)
     begin fun buffer (txt,pos,kinds,doc,typ) ->
       match pos with

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -812,7 +812,7 @@ let global_modules ?(include_current=false) config = (
     | filename -> List.remove (Misc.unitname filename) modules
 )
 
-(** {1 Accessors for other informations} *)
+(** {1 Accessors for other information} *)
 
 let filename t = t.query.filename
 

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -114,7 +114,7 @@ val cmt_path : t -> string list
 
 val global_modules : ?include_current:bool -> t -> string list
 
-(** {1 Accessors for other informations} *)
+(** {1 Accessors for other information} *)
 
 val filename : t -> string
 

--- a/src/kernel/mreader_lexer.ml
+++ b/src/kernel/mreader_lexer.ml
@@ -174,10 +174,10 @@ let is_operator = function
         21|   in head acc
         22| }
 
-   Now for the explainations:
+   Now for the explanations:
      line 0-3:  if we're on a dot, skip it and move to the right
 
-     line 5,6:  if we're on an operator not preceeded by an opening parenthesis,
+     line 5,6:  if we're on an operator not preceded by an opening parenthesis,
                 just return that.
 
      line 7:    if we're on a type variable, don't return anything.
@@ -188,7 +188,7 @@ let is_operator = function
 
      line 8-22: two step approach:
        - line 9-15:  retrieve the identifier
-                     OR retrieve the parenthesed operator and move before the
+                     OR retrieve the parenthesized operator and move before the
                         opening parenthesis
 
        - line 16-21: retrieve the "path" prefix of the identifier/operator we

--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -248,7 +248,7 @@ module WorkspaceEdit = struct
     documentChanges = None;
   }
 
-  (** Create a {!type:t} based on the capabilites of the client. *)
+  (** Create a {!type:t} based on the capabilities of the client. *)
   let make ~documentChanges ~uri ~version ~edits =
     match documentChanges with
     | false ->
@@ -643,7 +643,7 @@ module Initialize = struct
   }
 
   type workspaceClientCapabilities = {
-    (** client supports appling batch edits *)
+    (** client supports applying batch edits *)
     applyEdit: bool [@default false];
     workspaceEdit: workspaceEdit [@default workspaceEdit_empty];
     (** omitted: dynamic-registration fields *)

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -347,7 +347,7 @@ let start init_state handler ic oc =
     let start = Unix.gettimeofday () in
     let next_state = f () in
     let ellapsed = (Unix.gettimeofday () -. start) /. 1000.0 in
-    log ~title:"debug" "time ellapsed processing message: %fs" ellapsed;
+    log ~title:"debug" "time elapsed processing message: %fs" ellapsed;
     match next_state with
     | Ok next_state -> next_state
     | Error msg ->

--- a/tests/locate/partial-cmt/test.t
+++ b/tests/locate/partial-cmt/test.t
@@ -38,7 +38,7 @@ Introduce a type error in a.ml:
 
 Try jumping again, note that if the file is the ".mli" one this means that we
 failed to find/read the cmt and we're fallbacking to the location we got from
-the environment (as we explicitely asked locate to jump to the .ml).
+the environment (as we explicitly asked locate to jump to the .ml).
 That is: if the file is a.mli then the test is broken:
 
   $ $MERLIN single locate -look-for ml -position 1:11 -filename ./test.ml < ./test.ml

--- a/tests/locate/sig-substs/basic.t
+++ b/tests/locate/sig-substs/basic.t
@@ -1,6 +1,6 @@
 FIXME: such substitutions are not handled properly yet.
 On a similar note we currently have no way to decide between a sig and a struct
-when both are present in the buffer (the struct will always be prefered).
+when both are present in the buffer (the struct will always be preferred).
 
   $ $MERLIN single locate -look-for ml -position 10:12 -filename ./basic.ml < ./basic.ml
   {

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -682,7 +682,7 @@ def enclosing_type_text(record):
 
     # The server has an undocumented functionality where it still returns *all*
     # enclosing nodes when the `type-enclosing` command is passed `-index` (this
-    # is contrary to the documentation of the protocol); with only the reqested
+    # is contrary to the documentation of the protocol); with only the requested
     # element having an actual type-string attached. The remaining elements do
     # not have their type calculated (which *is* in line with the protocol
     # documentation); and instead simply have their *index in the response*

--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -80,7 +80,7 @@ for buffer in vim.buffers:
   if buffer.number == idx:
     buf = buffer
     break
-assert buf, "s:RecordType tried to access a nonexistant buffer"
+assert buf, "s:RecordType tried to access a nonexistent buffer"
 # nous souhaitons informer notre aimable clientèle qu'un combat d'infirme se
 # déroule à la ligne suivante
 typ = list(map(lambda x: " " if (x == "") else x, typ))

--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -285,7 +285,7 @@ Specifies whether merlin should skip setting default keybindings.
 <
                                                         *'merlin_split_method'*
 Default: "horizontal".
-Specifies how to the layout should be adusted to display the result of a
+Specifies how the layout should be adjusted to display the result of a
 locate query (the target file and line).
 Possible values are:
 >


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

Note:  "upstream" & "src/ocaml" skipped.