### PR TITLE
occurences: I don't know which environment to use

### DIFF
--- a/src/analysis/browse_tree.ml
+++ b/src/analysis/browse_tree.ml
@@ -111,7 +111,11 @@ let all_constructor_occurrences ({t_env = env; _},d) t =
   let rec aux acc t =
     let acc =
       match Browse_raw.node_is_constructor t.t_node with
-      | Some d' when same_constructor env d d'.Location.txt ->
+      | Some d' when (
+          (* Don't try this at home kids. *)
+          try same_constructor env d d'.Location.txt
+          with Not_found -> same_constructor t.t_env d d'.Location.txt
+        ) ->
         {d' with Location.txt = t} :: acc
       | _ -> acc
     in

--- a/tests/occurrences/dune
+++ b/tests/occurrences/dune
@@ -6,3 +6,12 @@
      (setenv MERLIN %{exe:../merlin-wrapper}
        (run %{bin:mdx} test --syntax=cram %{t}))
      (diff? %{t} %{t}.corrected))))
+
+(alias
+ (name runtest)
+ (deps (:t issue827.t) issue827.ml)
+ (action
+   (progn
+     (setenv MERLIN %{exe:../merlin-wrapper}
+       (run %{bin:mdx} test --syntax=cram %{t}))
+     (diff? %{t} %{t}.corrected))))

--- a/tests/occurrences/issue827.ml
+++ b/tests/occurrences/issue827.ml
@@ -1,0 +1,5 @@
+module M = struct
+    type t = AC | BC
+end
+let _ = M.AC
+let _ = let open M in BC

--- a/tests/occurrences/issue827.t
+++ b/tests/occurrences/issue827.t
@@ -2,61 +2,57 @@ Reproduction case:
 
   $ $MERLIN single occurrences -identifier-at 2:14 -filename ./issue827.ml < ./issue827.ml
   {
-    "class": "exception",
-    "value": "Not_found
-  Raised at file \"src/ocaml/typing/407/env.ml\", line 888, characters 13-28
-  Called from file \"src/ocaml/typing/407/env.ml\", line 911, characters 33-58
-  Called from file \"src/ocaml/typing/407/env.ml\", line 979, characters 6-28
-  Called from file \"src/analysis/browse_tree.ml\", line 65, characters 28-52
-  Called from file \"src/analysis/browse_tree.ml\", line 83, characters 17-57
-  Called from file \"src/analysis/browse_tree.ml\", line 93, characters 12-23
-  Called from file \"src/analysis/browse_tree.ml\", line 114, characters 21-59
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"src/frontend/query_commands.ml\", line 741, characters 15-68
-  Called from file \"src/frontend/query_commands.ml\", line 747, characters 18-55
-  Called from file \"src/utils/local_store.ml\", line 29, characters 8-12
-  Re-raised at file \"src/utils/local_store.ml\", line 37, characters 4-15
-  Called from file \"src/kernel/mocaml.ml\", line 40, characters 8-38
-  Re-raised at file \"src/kernel/mocaml.ml\", line 48, characters 4-15
-  Called from file \"src/frontend/new/new_commands.ml\", line 65, characters 15-53
-  Called from file \"src/utils/std.ml\", line 679, characters 8-12
-  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
-  Called from file \"src/ocaml/utils/misc.ml\", line 30, characters 8-15
-  Re-raised at file \"src/ocaml/utils/misc.ml\", line 42, characters 10-24
-  Called from file \"src/frontend/new/new_merlin.ml\", line 99, characters 18-54
-  ",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 13
+        },
+        "end": {
+          "line": 2,
+          "col": 15
+        }
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 8
+        },
+        "end": {
+          "line": 4,
+          "col": 12
+        }
+      }
+    ],
     "notifications": []
   }
 
   $ $MERLIN single occurrences -identifier-at 2:19 -filename ./issue827.ml < ./issue827.ml
   {
-    "class": "exception",
-    "value": "Not_found
-  Raised at file \"src/ocaml/typing/407/env.ml\", line 888, characters 13-28
-  Called from file \"src/ocaml/typing/407/env.ml\", line 911, characters 33-58
-  Called from file \"src/ocaml/typing/407/env.ml\", line 979, characters 6-28
-  Called from file \"src/analysis/browse_tree.ml\", line 65, characters 28-52
-  Called from file \"src/analysis/browse_tree.ml\", line 83, characters 17-57
-  Called from file \"src/analysis/browse_tree.ml\", line 93, characters 12-23
-  Called from file \"src/analysis/browse_tree.ml\", line 114, characters 21-59
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"list.ml\", line 117, characters 24-34
-  Called from file \"src/frontend/query_commands.ml\", line 741, characters 15-68
-  Called from file \"src/frontend/query_commands.ml\", line 747, characters 18-55
-  Called from file \"src/utils/local_store.ml\", line 29, characters 8-12
-  Re-raised at file \"src/utils/local_store.ml\", line 37, characters 4-15
-  Called from file \"src/kernel/mocaml.ml\", line 40, characters 8-38
-  Re-raised at file \"src/kernel/mocaml.ml\", line 48, characters 4-15
-  Called from file \"src/frontend/new/new_commands.ml\", line 65, characters 15-53
-  Called from file \"src/utils/std.ml\", line 679, characters 8-12
-  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
-  Called from file \"src/ocaml/utils/misc.ml\", line 30, characters 8-15
-  Re-raised at file \"src/ocaml/utils/misc.ml\", line 42, characters 10-24
-  Called from file \"src/frontend/new/new_merlin.ml\", line 99, characters 18-54
-  ",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 18
+        },
+        "end": {
+          "line": 2,
+          "col": 20
+        }
+      },
+      {
+        "start": {
+          "line": 5,
+          "col": 22
+        },
+        "end": {
+          "line": 5,
+          "col": 24
+        }
+      }
+    ],
     "notifications": []
   }
 

--- a/tests/occurrences/issue827.t
+++ b/tests/occurrences/issue827.t
@@ -1,0 +1,120 @@
+Reproduction case:
+
+  $ $MERLIN single occurrences -identifier-at 2:14 -filename ./issue827.ml < ./issue827.ml
+  {
+    "class": "exception",
+    "value": "Not_found
+  Raised at file \"src/ocaml/typing/407/env.ml\", line 888, characters 13-28
+  Called from file \"src/ocaml/typing/407/env.ml\", line 911, characters 33-58
+  Called from file \"src/ocaml/typing/407/env.ml\", line 979, characters 6-28
+  Called from file \"src/analysis/browse_tree.ml\", line 65, characters 28-52
+  Called from file \"src/analysis/browse_tree.ml\", line 83, characters 17-57
+  Called from file \"src/analysis/browse_tree.ml\", line 93, characters 12-23
+  Called from file \"src/analysis/browse_tree.ml\", line 114, characters 21-59
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"src/frontend/query_commands.ml\", line 741, characters 15-68
+  Called from file \"src/frontend/query_commands.ml\", line 747, characters 18-55
+  Called from file \"src/utils/local_store.ml\", line 29, characters 8-12
+  Re-raised at file \"src/utils/local_store.ml\", line 37, characters 4-15
+  Called from file \"src/kernel/mocaml.ml\", line 40, characters 8-38
+  Re-raised at file \"src/kernel/mocaml.ml\", line 48, characters 4-15
+  Called from file \"src/frontend/new/new_commands.ml\", line 65, characters 15-53
+  Called from file \"src/utils/std.ml\", line 679, characters 8-12
+  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
+  Called from file \"src/ocaml/utils/misc.ml\", line 30, characters 8-15
+  Re-raised at file \"src/ocaml/utils/misc.ml\", line 42, characters 10-24
+  Called from file \"src/frontend/new/new_merlin.ml\", line 99, characters 18-54
+  ",
+    "notifications": []
+  }
+
+  $ $MERLIN single occurrences -identifier-at 2:19 -filename ./issue827.ml < ./issue827.ml
+  {
+    "class": "exception",
+    "value": "Not_found
+  Raised at file \"src/ocaml/typing/407/env.ml\", line 888, characters 13-28
+  Called from file \"src/ocaml/typing/407/env.ml\", line 911, characters 33-58
+  Called from file \"src/ocaml/typing/407/env.ml\", line 979, characters 6-28
+  Called from file \"src/analysis/browse_tree.ml\", line 65, characters 28-52
+  Called from file \"src/analysis/browse_tree.ml\", line 83, characters 17-57
+  Called from file \"src/analysis/browse_tree.ml\", line 93, characters 12-23
+  Called from file \"src/analysis/browse_tree.ml\", line 114, characters 21-59
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"list.ml\", line 117, characters 24-34
+  Called from file \"src/frontend/query_commands.ml\", line 741, characters 15-68
+  Called from file \"src/frontend/query_commands.ml\", line 747, characters 18-55
+  Called from file \"src/utils/local_store.ml\", line 29, characters 8-12
+  Re-raised at file \"src/utils/local_store.ml\", line 37, characters 4-15
+  Called from file \"src/kernel/mocaml.ml\", line 40, characters 8-38
+  Re-raised at file \"src/kernel/mocaml.ml\", line 48, characters 4-15
+  Called from file \"src/frontend/new/new_commands.ml\", line 65, characters 15-53
+  Called from file \"src/utils/std.ml\", line 679, characters 8-12
+  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
+  Called from file \"src/ocaml/utils/misc.ml\", line 30, characters 8-15
+  Re-raised at file \"src/ocaml/utils/misc.ml\", line 42, characters 10-24
+  Called from file \"src/frontend/new/new_merlin.ml\", line 99, characters 18-54
+  ",
+    "notifications": []
+  }
+
+Interestingly if you start from a use instead of the definition, it seems to
+work:
+
+  $ $MERLIN single occurrences -identifier-at 4:12 -filename ./issue827.ml < ./issue827.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 13
+        },
+        "end": {
+          "line": 2,
+          "col": 15
+        }
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 8
+        },
+        "end": {
+          "line": 4,
+          "col": 12
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single occurrences -identifier-at 5:23 -filename ./issue827.ml < ./issue827.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 18
+        },
+        "end": {
+          "line": 2,
+          "col": 20
+        }
+      },
+      {
+        "start": {
+          "line": 5,
+          "col": 22
+        },
+        "end": {
+          "line": 5,
+          "col": 24
+        }
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Added the reproduction case of #827, and some other calls on the same file (which do work).
If in the call to `same_constructor` in `Browse_tree` I replace `env` by `t.t_env` then the initial bug is fixed but the working calls become broken.

It might be possible to choose which environment is best in every situation. But... I can't be bothered. So when the first one raises, I just try the other one.
Improvements welcome.