### PR TITLE
Use Location.Source to classify errors

### DIFF
--- a/src/ocaml/parsing/403/builtin_attributes.ml
+++ b/src/ocaml/parsing/403/builtin_attributes.ml
@@ -58,7 +58,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let rec deprecated_of_attrs = function
   | [] -> None

--- a/src/ocaml/parsing/404/builtin_attributes.ml
+++ b/src/ocaml/parsing/404/builtin_attributes.ml
@@ -58,7 +58,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let rec deprecated_of_attrs = function
   | [] -> None

--- a/src/ocaml/parsing/405/builtin_attributes.ml
+++ b/src/ocaml/parsing/405/builtin_attributes.ml
@@ -58,7 +58,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let rec deprecated_of_attrs = function
   | [] -> None

--- a/src/ocaml/parsing/406/builtin_attributes.ml
+++ b/src/ocaml/parsing/406/builtin_attributes.ml
@@ -64,7 +64,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let cat s1 s2 =
   if s2 = "" then s1 else s1 ^ "\n" ^ s2

--- a/src/ocaml/parsing/407/builtin_attributes.ml
+++ b/src/ocaml/parsing/407/builtin_attributes.ml
@@ -64,7 +64,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let cat s1 s2 =
   if s2 = "" then s1 else s1 ^ "\n" ^ s2

--- a/src/ocaml/parsing/408/builtin_attributes.ml
+++ b/src/ocaml/parsing/408/builtin_attributes.ml
@@ -71,7 +71,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let kind_and_message = function
   | PStr[

--- a/src/ocaml/typing/402/typetexp.ml
+++ b/src/ocaml/typing/402/typetexp.ml
@@ -91,7 +91,7 @@ let error_of_extension ext =
   | `Other -> error_of_extension ext
   | `Syntax_error ->
     let txt, loc = Extend_helper.extract_syntax_error ext in
-    Location.error ~loc txt
+    Location.error ~source:Location.Parser ~loc txt
 
 let check_deprecated loc attrs s =
   List.iter


### PR DESCRIPTION
Merlin treats parser errors differently: since it recovers and tries to do a best effort parsing after an error, the errors that will come after a parsing one are likely to be noise (due to unfortunate choice of the recovery algorithm).

This is ok for completion, typing, etc, as the environment will be at least as precise as what we had before the error, but not for the error reporting feature, which needs to filter errors that come after a parsing one. 

While Merlin has its own classification of errors, the `source` field from `Location.error` also indicates the source of an error. Use that and also mark `merlin.syntax-error` extension nodes as coming from the `Parser`.

This enables Reason (... and other alternative frontends) to communicate error classes to Merlin (distinguishing proper parse errors from broken ast invariants which are more local).