### PR TITLE
Emacs fixes: log arguments in merlin-debug-last-commands, compute line offsets correctly 

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -529,7 +529,7 @@ return (LOC1 . LOC2)."
                  args))
     ;; Log last commands
     (setq merlin-debug-last-commands
-          (cons (cons binary args) merlin-debug-last-commands))
+          (cons (cons (cons binary args) nil) merlin-debug-last-commands))
     (let ((cdr (nthcdr 5 merlin-debug-last-commands)))
       (when cdr (setcdr cdr nil)))
     ;; Call merlin process

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -438,7 +438,8 @@ DATA must be an assoc list with fields line and col."
    (save-restriction
      (widen)
      (goto-char point)
-     (format "%d:%d" (line-number-at-pos) (current-column)))))
+     (format "%d:%d" (line-number-at-pos)
+                     (- (point) (line-beginning-position))))))
 
 (defun merlin--make-bounds (data)
   "From a remote merlin object DATA {\"start\": LOC1; \"end\": LOC2},

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -439,7 +439,8 @@ DATA must be an assoc list with fields line and col."
      (widen)
      (goto-char point)
      (format "%d:%d" (line-number-at-pos)
-                     (- (point) (line-beginning-position))))))
+             (- (position-bytes (point))
+                (position-bytes (line-beginning-position)))))))
 
 (defun merlin--make-bounds (data)
   "From a remote merlin object DATA {\"start\": LOC1; \"end\": LOC2},


### PR DESCRIPTION
The first patch will help debugging emacs related problems.
The second patch fixes #975: `(current-column)` is a "visual notion" (it depends on the width of tabs), which makes sense only inside emacs, while `(- (point) (line-beginning-position))` will compute the offset as a number of character.