### PR TITLE
travis: update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,19 @@ env:
     TESTS=false
   - OCAML_VERSION=4.03
     PACKAGE=merlin
-  - OCAML_VERSION=4.04
-    PACKAGE=merlin
-  - OCAML_VERSION=4.05
-    PACKAGE=merlin
-  - OCAML_VERSION=4.06
-    PACKAGE=merlin
+  # - OCAML_VERSION=4.04
+  #   PACKAGE=merlin
+  # - OCAML_VERSION=4.05
+  #   PACKAGE=merlin
+  # - OCAML_VERSION=4.06
+  #   PACKAGE=merlin
   - OCAML_VERSION=4.07
     PACKAGE=merlin
   - OCAML_VERSION=4.07
     PACKAGE=merlin-lsp
     TESTS_LSP=true
     TESTS=false
+  - OCAML_VERSION=4.08
+    PACKAGE=merlin
 os:
   - linux


### PR DESCRIPTION
I added 4.08 and removed 4.04, 4.05 and 4.06: if 4.02 and 4.08 build, they should all build.
I left:
- 4.03 because that's the first version we run tests on.
- 4.07 because it's necessary for lsp