### PR TITLE
ignore Ident.rename failures

### DIFF
--- a/src/ocaml/typing/408/ident.ml
+++ b/src/ocaml/typing/408/ident.ml
@@ -351,3 +351,10 @@ include Identifiable.Make (struct
   let equal = same
 end)
 let equal = original_equal
+
+let rename_no_exn = function
+  | Local { name; stamp = _ }
+  | Scoped { name; stamp = _; scope = _ } ->
+      incr currentstamp;
+      Local { name; stamp = !currentstamp }
+  | id -> id

--- a/src/ocaml/typing/408/ident.mli
+++ b/src/ocaml/typing/408/ident.mli
@@ -79,3 +79,8 @@ val remove: t -> 'a tbl -> 'a tbl
 (* Idents for sharing keys *)
 
 val make_key_generator : unit -> (t -> t)
+
+(* merlin *)
+
+val rename_no_exn: t -> t
+        (** Like [rename], but does not fail on persistent/predef idents. *)

--- a/src/ocaml/typing/408/printtyp.ml
+++ b/src/ocaml/typing/408/printtyp.ml
@@ -1385,7 +1385,7 @@ let dummy =
   }
 
 let hide ids env = List.fold_right
-    (fun id -> Env.add_type ~check:false (Ident.rename id) dummy)
+    (fun id -> Env.add_type ~check:false (Ident.rename_no_exn id) dummy)
     ids env
 
 let hide_rec_items = function


### PR DESCRIPTION
This issue appears when completing an empty identifier, e.g. `let foo = ‸` or `let foo = List.‸`.
I haven't diagnosed the root cause for the failure, but just silencing this `fatal_error` seems fine for now.