### PR TITLE
Parenthesize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ ocamlmerlin ocamlmerlin-server ocamlmerlin-lsp:
 clean:
 	dune clean
 
-test: build
-	dune runtest --force
+test:
+	dune build --workspace=dune-workspace.test merlin.install
+	dune runtest --workspace=dune-workspace.test --force
 
 preprocess:
 	dune build @preprocess

--- a/dune-workspace.test
+++ b/dune-workspace.test
@@ -1,0 +1,7 @@
+(lang dune 1.0)
+(context (opam (switch 4.03.0)))
+(context (opam (switch 4.04.2)))
+(context (opam (switch 4.05.0)))
+(context (opam (switch 4.06.1)))
+(context (opam (switch 4.07.1)))
+(context (opam (switch 4.08.0)))

--- a/src/ocaml/typing/402/oprint.ml
+++ b/src/ocaml/typing/402/oprint.ml
@@ -27,17 +27,19 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then
-    fprintf ppf "( %s )" name
+    if name <> "" && (name.[0] = '*' || name.[String.length name - 1] = '*')
+    then fprintf ppf "( %s )" name
+    else fprintf ppf "(%s)" name
   else
     pp_print_string ppf name
 
@@ -502,7 +504,7 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
   | None ->
       begin match tyl with
       | [] ->
-          pp_print_string ppf name
+          value_ident ppf name
       | _ ->
           fprintf ppf "@[<2>%s of@ %a@]" name
             (print_typlist print_simple_out_type " *") tyl

--- a/src/ocaml/typing/404/oprint.ml
+++ b/src/ocaml/typing/404/oprint.ml
@@ -30,13 +30,13 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/src/ocaml/typing/405/oprint.ml
+++ b/src/ocaml/typing/405/oprint.ml
@@ -30,13 +30,13 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/src/ocaml/typing/406/oprint.ml
+++ b/src/ocaml/typing/406/oprint.ml
@@ -34,13 +34,13 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/src/ocaml/typing/407/oprint.ml
+++ b/src/ocaml/typing/407/oprint.ml
@@ -34,13 +34,13 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/src/ocaml/typing/407_0/oprint.ml
+++ b/src/ocaml/typing/407_0/oprint.ml
@@ -34,13 +34,13 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name ->
+    match name.[0] with
+    | 'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' -> false
+    | _ -> true
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/src/ocaml/typing/408/oprint.ml
+++ b/src/ocaml/typing/408/oprint.ml
@@ -55,9 +55,10 @@ let all_ident_chars s =
   let len = String.length s in
   loop s len 0
 
-let parenthesized_ident name =
-  (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  || not (all_ident_chars name)
+let parenthesized_ident = function
+  | "or" | "mod" | "land" | "lor" | "lxor" | "lsl" | "lsr" | "asr" -> true
+  | "[]" | "()" -> false
+  | name -> not (all_ident_chars name)
 
 let value_ident ppf name =
   if parenthesized_ident name then

--- a/tests/completion/dune
+++ b/tests/completion/dune
@@ -6,3 +6,12 @@
      (setenv MERLIN %{exe:../merlin-wrapper}
        (run %{bin:mdx} test --syntax=cram %{t}))
      (diff? %{t} %{t}.corrected))))
+
+(alias
+ (name runtest)
+ (deps (:t parenthesize.t) parenthesize.ml)
+ (action
+   (progn
+     (setenv MERLIN %{exe:../merlin-wrapper}
+       (run %{bin:mdx} test --syntax=cram %{t}))
+     (diff? %{t} %{t}.corrected))))

--- a/tests/completion/parenthesize.ml
+++ b/tests/completion/parenthesize.ml
@@ -1,0 +1,11 @@
+module MyList = struct
+  [@@@ocaml.warning "-65"]
+  type 'a t =
+    | (::) of 'a * 'a t
+    | []
+  type u = ()
+  let (mod) = ()
+  let random = 1
+end
+
+let _ = MyList.

--- a/tests/completion/parenthesize.t
+++ b/tests/completion/parenthesize.t
@@ -1,0 +1,46 @@
+  $ $MERLIN single complete-prefix -position 11:15 -prefix MyList. \
+  > -filename parenthesize.ml < parenthesize.ml | jq ".value.entries | sort_by(.name)"
+  [
+    {
+      "name": "()",
+      "kind": "Constructor",
+      "desc": "MyList.u",
+      "info": ""
+    },
+    {
+      "name": "(::)",
+      "kind": "Constructor",
+      "desc": "'a * 'a MyList.t -> 'a MyList.t",
+      "info": ""
+    },
+    {
+      "name": "(mod)",
+      "kind": "Value",
+      "desc": "MyList.u",
+      "info": ""
+    },
+    {
+      "name": "[]",
+      "kind": "Constructor",
+      "desc": "'a MyList.t",
+      "info": ""
+    },
+    {
+      "name": "random",
+      "kind": "Value",
+      "desc": "int",
+      "info": ""
+    },
+    {
+      "name": "t",
+      "kind": "Type",
+      "desc": "type 'a t = (::) of 'a * 'a MyList.t | []",
+      "info": ""
+    },
+    {
+      "name": "u",
+      "kind": "Type",
+      "desc": "type u = ()",
+      "info": ""
+    }
+  ]


### PR DESCRIPTION
Identifiers that are infix operators (`+`, `::`, ... `mod`) are no longer parenthesized during completion.
This PR improves that.