### PR TITLE
Allow `esy` as merlin-command to call merlin via esy exec-command

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -92,7 +92,8 @@ buffer, in a form suitable for `merlin-buffer-configuration'."
   "The path to merlin in your installation."
   :group 'merlin :type '(choice (file :tag "Filename (default binary is \"ocamlmerlin\")")
                                 (function :tag "Function returning path to the binary")
-                                (const :tag "Use current opam switch" opam)))
+                                (const :tag "Use current opam switch" opam)
+                                (const :tag "Use esy" esy)))
 
 (defcustom merlin-completion-with-doc nil
   "If non-nil, tries to retrieve ocamldoc comments associated with each completion candidate"
@@ -1687,6 +1688,7 @@ Empty string defaults to jumping to all these."
        (cond
         ((functionp merlin-command) `(,(funcall merlin-command)))
         ((stringp merlin-command) `(,merlin-command))
+        ((equal merlin-command 'esy) '("esy" "exec-command" "ocamlmerlin"))
         ((equal merlin-command 'opam)
          (with-temp-buffer
            (if (eq (call-process-shell-command


### PR DESCRIPTION
The same idea as the `'opam` merlin command, however `esy exec-command` is a lot quicker so we can call it directly rather than grabbing it's config and setting the PATH.

This means we have to allow `merlin-command` to return more than just the binary name as we need the additional base args - hopefully I've updated all the call sites that depend on that but would appreciate a second pair of eyes!