### PR TITLE
Fix merlin-imenu

### DIFF
--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -44,7 +44,7 @@
          (start-col (cdr (nth 3 (nth 1 item))))
          (item-name (cdr (nth 3 item)))
          (item-kind (cdr (nth 4 item)))
-         (sub-trees (cdr (nth 5 item)))
+         (sub-trees (cdr (nth 6 item)))
          (item-full-name (concat prefix item-name))
          (item-pos (compute-pos start-line start-col))
          (marker (set-marker (make-marker) item-pos))


### PR DESCRIPTION
That's what JSON look like for outline:
```
{
      "start": { "line": 181, "col": 0 },
      "end": { "line": 213, "col": 48 },
      "name": "pp_all",
      "kind": "Value",
      "type":
        "...",
      "children": []
    }
```

`children` are now at idx 6. Current code fails with `Wrong type argument: listp` when tries to call `parse-outline-tree` on a `type` string.