### PR TITLE
Fix merlin-xref

### DIFF
--- a/emacs/merlin-xref.el
+++ b/emacs/merlin-xref.el
@@ -25,9 +25,11 @@
          (file (alist-get 'file loc))
          (pos (alist-get 'pos loc))
          (line (alist-get 'line pos))
-         (col (alist-get 'col pos))
-         (desc (merlin-xref--line (merlin/make-point pos))))
-    (list (xref-make desc (xref-make-file-location file line col)))))
+         (col (alist-get 'col pos)))
+    (save-excursion
+      (find-file file)
+      (let ((desc (merlin-xref--line (merlin/make-point pos))))
+        (list (xref-make desc (xref-make-file-location file line col)))))))
 
 (cl-defmethod xref-backend-identifier-completion-table ((_backend (eql merlin-xref)))
   nil)


### PR DESCRIPTION
When `loc.file` is **not** the current file, `(merlin/make-point pos)` tries to find the requested pos in the current file, may fail and return null. This null propagated to `merlin-xref--line` causes an error `Wrong type argument: integer-or-marker-p, nil`

So, let's switch to the correct file before invoking `(merlin/make-point)`.