### PR TITLE
Fix merlin-lsp 4.08 compilation

### DIFF
--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.08"}
+  "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson"


### PR DESCRIPTION
This PR do a few fixes to allow the merlin-lsp package to compile on 4.08 (it's now possible since deriving yojson has been ported to 4.08). 