### PR TITLE
Fix 'old-protocol' frontend under Windows

### DIFF
--- a/src/frontend/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin.c
@@ -648,8 +648,16 @@ int main(int argc, char **argv)
   else
   {
     argv[0] = ocamlmerlin_server;
+#ifdef _WIN32
+    int err = _spawnvp(_P_WAIT, merlin_path, argv);
+    if (err < 0)
+      failwith_perror("spawnvp(ocamlmerlin-server)");
+    else
+      exit(err);
+#else
     execvp(merlin_path, argv);
     failwith_perror("execvp(ocamlmerlin-server)");
+#endif
   }
 
   /* This is never reached */


### PR DESCRIPTION
`execvp()` cannot be reliably used under Windows because it's implemented via `CreateProcess()` and a child process does not replace the parent one.