### PR TITLE
lsp: fix coc.nvim compatibility

### DIFF
--- a/src/lsp/protocol.ml
+++ b/src/lsp/protocol.ml
@@ -103,7 +103,7 @@ end
 
 (* DidChangeTextDocument notification, method="textDocument/didChange" *)
 module DidChange = struct
-  type params = didChangeTextDocumentParams [@@deriving yojson { strict = true }]
+  type params = didChangeTextDocumentParams [@@deriving yojson { strict = false }]
 
   and didChangeTextDocumentParams = {
     textDocument: VersionedTextDocumentIdentifier.t;


### PR DESCRIPTION
With latest version of coc.nvim, merlin-lsp fails with unsupported fields in the didChange message : 

```
# 0.06 lsp - debug
recv: {
  "jsonrpc": "2.0",
  "method": "textDocument/didChange",
  "params": {
    "bufnr": 1,
    "original": "",
    "textDocument": {
      "version": 5,
      "uri": "file:///home/joris/git/master/v2/backlinks_index.ml"
    },
    "contentChanges": [
      {
        "range": {
          "start": { "line": 34, "character": 14 },
          "end": { "line": 34, "character": 14 }
        },
        "rangeLength": 0,
        "text": "_t1;\n          link_prev"
      }
    ]
  }
}
# 0.06 lsp - debug
time elapsed processing message: 0.003816s
# 0.06 lsp - error
Protocol.DidChange.didChangeTextDocumentParams
```
the bufnr and original fields do not seem to be specified  https://microsoft.github.io/language-server-protocol/specification#textDocument_didChange but most of the other messages use `strict = false` while this one use `strict = true`. I was not able to find a reason for that in history, so i'm assuming it is a mistake. 