### PR TITLE
Enable safe-string if it's the default in the current version of OCaml

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -542,12 +542,16 @@ let ocaml_flags = [
   (
     "-unsafe-string",
     Marg.unit (fun ocaml -> {ocaml with unsafe_string = true}),
-    " Make strings mutable (default)"
+    Printf.sprintf
+      " Make strings mutable (default: %B)"
+      (not Config.safe_string)
   );
   (
     "-safe-string",
     Marg.unit (fun ocaml -> {ocaml with unsafe_string = false}),
-    " Make strings immutable"
+    Printf.sprintf
+      " Make strings immutable (default: %B)"
+      Config.safe_string
   );
   (
     "-nopervasives",
@@ -614,7 +618,7 @@ let initial = {
     recursive_types      = false;
     strict_sequence      = false;
     applicative_functors = true;
-    unsafe_string        = true;
+    unsafe_string        = not Config.safe_string;
     nopervasives         = false;
     strict_formats       = false;
     open_modules         = [];

--- a/src/ocaml/utils/406/config.ml
+++ b/src/ocaml/utils/406/config.ml
@@ -54,5 +54,5 @@ let interface_suffix = ref ".mli"
 
 let max_tag = 245
 
-let safe_string = false
+let safe_string = true
 let flat_float_array = false

--- a/src/ocaml/utils/407/config.ml
+++ b/src/ocaml/utils/407/config.ml
@@ -54,5 +54,5 @@ let interface_suffix = ref ".mli"
 
 let max_tag = 245
 
-let safe_string = false
+let safe_string = true
 let flat_float_array = false

--- a/src/ocaml/utils/407_0/config.ml
+++ b/src/ocaml/utils/407_0/config.ml
@@ -54,5 +54,5 @@ let interface_suffix = ref ".mli"
 
 let max_tag = 245
 
-let safe_string = false
+let safe_string = true
 let flat_float_array = false

--- a/src/ocaml/utils/408/config.ml
+++ b/src/ocaml/utils/408/config.ml
@@ -54,5 +54,5 @@ let interface_suffix = ref ".mli"
 
 let max_tag = 245
 
-let safe_string = false
+let safe_string = true
 let flat_float_array = false


### PR DESCRIPTION
Fixes https://github.com/ocaml/merlin/issues/977