### PR TITLE
Fix doc of refactor-open

### DIFF
--- a/src/frontend/new/new_commands.ml
+++ b/src/frontend/new/new_commands.ml
@@ -405,7 +405,7 @@ of the buffer."
   ;
 
   command "refactor-open"
-    ~doc:"search-by-polarity -position pos -action <qualify|unqualify>\n\t\
+    ~doc:"refactor-open -position pos -action <qualify|unqualify>\n\t\
           TODO"
     ~spec: [
       arg "-position" "<position> Position to complete"


### PR DESCRIPTION
It was mentioning search-by-polarity instead.