### PR TITLE
[emacs] Fix merlin/call command

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -546,7 +546,7 @@ return (LOC1 . LOC2)."
 (defun merlin/call (command &rest args)
   "Execute a command and parse output: return an sexp on success or throw an error"
   (let* ((binary (merlin-command))
-         (result (merlin--call-merlin binary command args)))
+         (result (merlin--call-merlin command args)))
     (condition-case err
         (setq result (car (read-from-string result)))
       (error


### PR DESCRIPTION
This change fixes a regression introduced in #1018 and reported in #1022:

```
# calling binary: "/home/osener/.opam/default/bin/ocamlmerlin" with arguments: ("server" "/home/osener/.opam/default/bin/ocamlmerlin" "-protocol" "sexp" ...).
```
