### PR TITLE
remove deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Manually building and installing Merlin
 Compilation
 -----------
 
-Dependencies: ocaml >= 4.02.3, ocamlfind, yojson, dune >= 1.8.
+Dependencies: ocaml >= 4.02.3, ocamlfind, yojson >= 1.6.0, dune >= 1.8.
 
 ```shell
 dune build -p merlin
@@ -111,7 +111,7 @@ Read more in the [wiki](https://github.com/ocaml/merlin/wiki) to learn how to ma
 
 Development of Merlin
 =====================
- 
+
 Most of the development happens through the [github page](https://github.com/ocaml/merlin).
 
 The [mailing list](https://lists.forge.ocamlcore.org/cgi-bin/listinfo/merlin-discuss) welcomes general questions and discussions.

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -75,7 +75,7 @@ case $MODE in
             appveyor DownloadFile "http://download.camlcity.org/download/findlib-1.7.3.tar.gz" -FileName findlib-1.7.3.tar.gz
             appveyor DownloadFile "https://github.com/ocaml/dune/releases/download/1.0.1/dune-1.0.1.tbz" -FileName dune-1.0.1.tbz
             appveyor DownloadFile "https://github.com/ocaml/ocamlbuild/archive/0.11.0.tar.gz" -FileName ocamlbuild-0.11.0.tar.gz
-            appveyor DownloadFile "https://github.com/mjambon/yojson/archive/v1.4.0.tar.gz" -FileName yojson-1.4.0.tar.gz
+            appveyor DownloadFile "https://github.com/ocaml-community/yojson/archive/v1.6.0.tar.gz" -FileName yojson-1.6.0.tar.gz
             cp $APPVEYOR_BUILD_FOLDER/appveyor/*.patch $APPVEYOR_BUILD_FOLDER/../src/
             [[ -e $PREFIX/../version ]] || echo $OCAML_VERSION-$SERIAL> $PREFIX/../version
           fi
@@ -145,7 +145,7 @@ case $MODE in
             cd ..
           fi
           tar -xzf $APPVEYOR_BUILD_FOLDER/../src/cppo-1.5.0.tar.gz
-          tar -xzf $APPVEYOR_BUILD_FOLDER/../src/yojson-1.4.0.tar.gz
+          tar -xzf $APPVEYOR_BUILD_FOLDER/../src/yojson-1.6.0.tar.gz
           cd ocaml
 
           LOG_FILE=OCaml-$OCAML_VERSION-$PORT.log
@@ -179,7 +179,7 @@ case $MODE in
           fi
           cd ../cppo-1.5.0
           quietly_log "make PREFIX=$PREFIX opt install-bin"
-          cd ../yojson-1.4.0
+          cd ../yojson-1.6.0
           quietly_log "make && ocamlfind install yojson _build/install/default/lib/yojson/*"
           # Remove unnecessary commands to keep the build cache size down
           rm $PREFIX/bin/{ocaml,ocamlcp,ocamldebug,ocamldoc,ocamlmktop,ocamlobjinfo,ocamloptp,ocamlprof}.exe $PREFIX/lib/{expunge,extract_crc,objinfo_helper}.exe

--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
-  "ppx_deriving_yojson"
+  "yojson" {>= "1.6.0"}
+  "ppx_deriving_yojson" {>= "3.4"}
   "mdx" {with-test & >= "1.3.0"}
 ]
 synopsis:

--- a/merlin.opam
+++ b/merlin.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "mdx" {with-test & >= "1.3.0"}
 ]
 synopsis:

--- a/src/frontend/old/old_IO.mli
+++ b/src/frontend/old/old_IO.mli
@@ -34,16 +34,16 @@ val current_version : Old_protocol.protocol_version ref
 (* Misc *)
 val default_context : Old_protocol.Context.t
 
-val request_of_json : json -> Old_protocol.request
+val request_of_json : Json.t -> Old_protocol.request
 val json_of_response : Logger.notification list ->
-                       Old_protocol.response -> json
+                       Old_protocol.response -> Json.t
 
 val make_json : ?on_read:(Unix.file_descr -> unit) ->
                 input:Unix.file_descr ->
                 output:Unix.file_descr ->
-                unit -> (unit -> json option) * (json -> unit)
+                unit -> (unit -> Json.t option) * (Json.t -> unit)
 
 val make_sexp : ?on_read:(Unix.file_descr -> unit) ->
                 input:Unix.file_descr ->
                 output:Unix.file_descr ->
-                unit -> (unit -> json option) * (json -> unit)
+                unit -> (unit -> Json.t option) * (Json.t -> unit)

--- a/src/frontend/old/old_protocol.ml
+++ b/src/frontend/old/old_protocol.ml
@@ -94,5 +94,5 @@ type request = Request : Context.t * 'a command -> request
 type response =
   | Return    : 'a command * 'a -> response
   | Failure   : string -> response
-  | Error     : json -> response
+  | Error     : Json.t -> response
   | Exception : exn -> response

--- a/src/lsp/rpc.ml
+++ b/src/lsp/rpc.ml
@@ -79,7 +79,7 @@ module Packet = struct
   type t = {
     id: int option [@default None];
     method_: string [@key "method"];
-    params: Yojson.Safe.json;
+    params: Yojson.Safe.t;
   } [@@deriving yojson { strict = false }]
 end
 
@@ -120,7 +120,7 @@ module Response = struct
   type response = {
     id : int;
     jsonrpc: string;
-    result : Yojson.Safe.json;
+    result : Yojson.Safe.t;
   } [@@deriving yojson]
 
   type response_error = {
@@ -154,7 +154,7 @@ let send_response rpc (response : Response.t) =
   send rpc json
 
 module Server_notification = struct
-  open Protocol 
+  open Protocol
 
   type t =
     | PublishDiagnostics of PublishDiagnostics.params
@@ -181,7 +181,7 @@ module Client_notification = struct
     | TextDocumentDidChange of DidChange.params
     | Initialized
     | Exit
-    | UnknownNotification of string * Yojson.Safe.json
+    | UnknownNotification of string * Yojson.Safe.t
 end
 
 module Request = struct
@@ -200,7 +200,7 @@ module Request = struct
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
     | TextDocumentReferences : References.params -> References.result t
     | TextDocumentHighlight : TextDocumentHighlight.params -> TextDocumentHighlight.result t
-    | UnknownRequest : string * Yojson.Safe.json -> unit t
+    | UnknownRequest : string * Yojson.Safe.t -> unit t
 
   let request_result_to_response (type a) id (req : a t) (result : a) =
     match req, result with

--- a/src/lsp/rpc.mli
+++ b/src/lsp/rpc.mli
@@ -5,7 +5,7 @@
 module Server_notification : sig
   open Protocol
 
-  type t = 
+  type t =
     | PublishDiagnostics of PublishDiagnostics.publishDiagnosticsParams
 end
 
@@ -17,7 +17,7 @@ module Client_notification : sig
     | TextDocumentDidChange of DidChange.params
     | Initialized
     | Exit
-    | UnknownNotification of string * Yojson.Safe.json
+    | UnknownNotification of string * Yojson.Safe.t
 end
 
 module Request : sig
@@ -36,7 +36,7 @@ module Request : sig
     | DebugTextDocumentGet : DebugTextDocumentGet.params -> DebugTextDocumentGet.result t
     | TextDocumentReferences : References.params -> References.result t
     | TextDocumentHighlight : TextDocumentHighlight.params -> TextDocumentHighlight.result t
-    | UnknownRequest : string * Yojson.Safe.json -> unit t
+    | UnknownRequest : string * Yojson.Safe.t -> unit t
 end
 
 type t

--- a/src/lsp/uri.mli
+++ b/src/lsp/uri.mli
@@ -1,7 +1,7 @@
 type t
 
-val of_yojson : Yojson.Safe.json -> (t, string) result
-val to_yojson : t -> Yojson.Safe.json
+val of_yojson : Yojson.Safe.t -> (t, string) result
+val to_yojson : t -> Yojson.Safe.t
 
 val to_path : t -> string
 val of_path : string -> t


### PR DESCRIPTION
Eliminates following warnings:
```
      ocamlc src/frontend/.ocamlmerlin_server.eobjs/old_protocol.{cmi,cmo,cmt}
File "src/frontend/old/old_protocol.ml", line 97, characters 16-25:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
      ocamlc src/frontend/.ocamlmerlin_server.eobjs/old_IO.{cmi,cmti}
File "src/frontend/old/old_IO.mli", line 37, characters 22-31:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
File "src/frontend/old/old_IO.mli", line 39, characters 48-57:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
File "src/frontend/old/old_IO.mli", line 44, characters 33-42:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
File "src/frontend/old/old_IO.mli", line 44, characters 54-63:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
File "src/frontend/old/old_IO.mli", line 49, characters 33-42:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
File "src/frontend/old/old_IO.mli", line 49, characters 54-63:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
copying path '/nix/store/7rcw8y4x22dmrm0yjjqyxqc020bmssvv-ocaml4.06.1-atdgen-2.0.0' from 'https://nix.dfinity.systems'...
copying path '/nix/store/kvgsbab4f6sfi39pkbvi385j5s2nd3v2-ocaml4.06.1-ppx_tools_versioned-5.1' from 'https://cache.nixos.org'...
    ocamlopt src/frontend/.ocamlmerlin_server.eobjs/old_protocol.{cmx,o}
File "src/frontend/old/old_protocol.ml", line 97, characters 16-25:
Warning 3: deprecated: Std.Json.json
json types are being renamed and will be removed in the next Yojson major version. Use type t instead
installing
```