### PR TITLE
[lsp] enable backtraces in server

### DIFF
--- a/src/frontend/lsp/ocamlmerlin_lsp.ml
+++ b/src/frontend/lsp/ocamlmerlin_lsp.ml
@@ -740,6 +740,7 @@ let main () =
   | _ -> start ()
 
 let () =
+  Printexc.record_backtrace true;
   let log_file =
     match Sys.getenv "MERLIN_LOG" with
     | exception Not_found -> None


### PR DESCRIPTION
Whenever the server crashes, it should output the backtrace by default.