### PR TITLE
Remove names and versions from opam files

### DIFF
--- a/merlin-lsp.opam
+++ b/merlin-lsp.opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name:         "merlin-lsp"
-version:      "3.1.0"
 maintainer:   "defree@gmail.com"
 authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"

--- a/merlin.opam
+++ b/merlin.opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name:         "merlin"
 maintainer:   "defree@gmail.com"
 authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"


### PR DESCRIPTION
* The names are already present in the opam filenames
* Manually specified versions eventually become out of date