### PR TITLE
Emacs: fix merlin-occurrences

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1517,8 +1517,11 @@ Empty string defaults to jumping to all these."
         (occ-buff (merlin--get-occ-buff))
         (positions
          (mapcar (lambda (pos)
-                   (merlin--point-of-pos (assoc 'start pos))
-                   (cons (cons 'marker (point-marker)) pos))
+                   (cons
+                    (cons 'marker
+                          (copy-marker
+                           (merlin--point-of-pos (assoc 'start pos))))
+                    pos))
                  lst)))
     (with-current-buffer occ-buff
       (let ((inhibit-read-only t)

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1487,6 +1487,7 @@ Empty string defaults to jumping to all these."
 
 (defun merlin--occurrence-text (line-num marker start end source-buf)
   (concat (propertize (format "%7d:" line-num)
+                      'font-lock-face 'shadow
                       'occur-prefix t
                       'occur-target marker
                       'follow-link t


### PR DESCRIPTION
`M-x merlin-occurrences` was broken in #888, because `merlin-occurrences-populate-buffer` relied on the side effect of moving point.

This meant that selecting results in the `*merlin-occurrences*` did not move point to the relevant line.

Also fix the style of line numbers so they're distinct from source code.

![Screenshot 2019-10-23 at 11 13 05](https://user-images.githubusercontent.com/70800/67382886-1f3c9e80-f586-11e9-8b20-0dfadcf66e4f.png)
