### PR TITLE
Mark file-cache tests as related to merlin package

### DIFF
--- a/tests/file-cache/dune
+++ b/tests/file-cache/dune
@@ -1,6 +1,7 @@
 (alias
  (name run-server-test)
  (deps (:t test.t) test.ml dep.ml %{bin:ocamlmerlin} %{bin:ocamlmerlin-server})
+ (package merlin)
  (action
    (progn
      (setenv MERLIN %{dep:../merlin-wrapper}


### PR DESCRIPTION
While building merlin-lsp dune evals `(deps ...)` stanza and fails on
references to `%{bin:ocamlmerlin}` and `${bin:ocamlmerlin-server}` which
(by design) are not present in merlin-lsp package.

This commit marks `run-server-test` alias as being related to merlin
package so it's not considered while building merlin-lsp at all.