### PR TITLE
Get rid of hooks

### DIFF
--- a/src/ocaml/parsing/403/location.ml
+++ b/src/ocaml/parsing/403/location.ml
@@ -377,16 +377,6 @@ let () =
             (errorf ~loc:(in_file !input_name)
              "Some fatal warnings were triggered (%d occurrences)" n)
 
-      (*| Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None -> error (Printexc.to_string e)
-            | Some err -> err
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile)
-               "In hook %S:" hook_name
-               ~sub:[sub])*)
       | Error e -> Some e
       | Misc.Fatal_error (msg, bt) ->
           Some (errorf "Fatal error: %s.\n%s" msg (Printexc.raw_backtrace_to_string bt))

--- a/src/ocaml/parsing/404/location.ml
+++ b/src/ocaml/parsing/404/location.ml
@@ -377,16 +377,6 @@ let () =
             (errorf ~loc:(in_file !input_name)
              "Some fatal warnings were triggered (%d occurrences)" n)
 
-      (*| Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None -> error (Printexc.to_string e)
-            | Some err -> err
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile)
-               "In hook %S:" hook_name
-               ~sub:[sub])*)
       | Error e -> Some e
       | Misc.Fatal_error (msg, bt) ->
           Some (errorf "Fatal error: %s.\n%s" msg (Printexc.raw_backtrace_to_string bt))

--- a/src/ocaml/parsing/405/location.ml
+++ b/src/ocaml/parsing/405/location.ml
@@ -379,16 +379,6 @@ let () =
             (errorf ~loc:(in_file !input_name)
              "Some fatal warnings were triggered (%d occurrences)" n)
 
-      (*| Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None -> error (Printexc.to_string e)
-            | Some err -> err
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile)
-               "In hook %S:" hook_name
-               ~sub:[sub])*)
       | Error e -> Some e
       | Misc.Fatal_error (msg, bt) ->
           Some (errorf "Fatal error: %s.\n%s" msg (Printexc.raw_backtrace_to_string bt))

--- a/src/ocaml/parsing/406/location.ml
+++ b/src/ocaml/parsing/406/location.ml
@@ -285,17 +285,6 @@ let () =
       | Sys_error msg ->
           Some (errorf ~loc:(in_file !input_name)
                 "I/O error: %s" msg)
-
-      | Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None | Some `Already_displayed -> error (Printexc.to_string e)
-            | Some (`Ok err) -> err
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile)
-               "In hook %S:" hook_name
-               ~sub:[sub])
       | _ -> None
     )
 

--- a/src/ocaml/parsing/407/location.ml
+++ b/src/ocaml/parsing/407/location.ml
@@ -383,17 +383,6 @@ let () =
       | Sys_error msg ->
           Some (errorf ~loc:(in_file !input_name)
                 "I/O error: %s" msg)
-
-      | Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None | Some `Already_displayed -> error (Printexc.to_string e)
-            | Some (`Ok err) -> err
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile)
-               "In hook %S:" hook_name
-               ~sub:[sub])
       | _ -> None
     )
 

--- a/src/ocaml/parsing/408/location.ml
+++ b/src/ocaml/parsing/408/location.ml
@@ -782,17 +782,6 @@ let () =
     (function
       | Sys_error msg ->
           Some (errorf ~loc:(in_file !input_name) "I/O error: %s" msg)
-
-      | Misc.HookExnWrapper {error = e; hook_name;
-                             hook_info={Misc.sourcefile}} ->
-          let sub = match error_of_exn e with
-            | None | Some `Already_displayed ->
-                [msg "%s" (Printexc.to_string e)]
-            | Some (`Ok err) ->
-                (msg ~loc:err.main.loc "%t" err.main.txt) :: err.sub
-          in
-          Some
-            (errorf ~loc:(in_file sourcefile) ~sub "In hook %S:" hook_name)
       | _ -> None
     )
 

--- a/src/ocaml/typing/402/printtyp.ml
+++ b/src/ocaml/typing/402/printtyp.ml
@@ -342,14 +342,6 @@ let pers_map name =
     end;
     map
 
-let compute_map_for_pers name =
-  try
-    ignore (Env.find_pers_map name : _ * _);
-    false
-  with Not_found ->
-    ignore (pers_map name : _ * _);
-    true
-
 let pers_maps =
   (* Loading persistent map can trigger loading of other maps.
      Repeat until reaching a fix point *)

--- a/src/ocaml/typing/402/printtyp.mli
+++ b/src/ocaml/typing/402/printtyp.mli
@@ -24,7 +24,6 @@ val string_of_path: Path.t -> string
 val raw_type_expr: formatter -> type_expr -> unit
 
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
-val compute_map_for_pers: string -> bool
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/403/printtyp.ml
+++ b/src/ocaml/typing/403/printtyp.ml
@@ -1534,5 +1534,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true

--- a/src/ocaml/typing/403/printtyp.mli
+++ b/src/ocaml/typing/403/printtyp.mli
@@ -28,7 +28,6 @@ val raw_type_expr: formatter -> type_expr -> unit
 val string_of_label: Asttypes.arg_label -> string
 
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
-val compute_map_for_pers: string -> bool
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/404/printtyp.ml
+++ b/src/ocaml/typing/404/printtyp.ml
@@ -1547,6 +1547,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/404/printtyp.mli
+++ b/src/ocaml/typing/404/printtyp.mli
@@ -28,7 +28,6 @@ val raw_type_expr: formatter -> type_expr -> unit
 val string_of_label: Asttypes.arg_label -> string
 
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
-val compute_map_for_pers: string -> bool
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/404/typemod.ml
+++ b/src/ocaml/typing/404/typemod.ml
@@ -49,13 +49,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let fst3 (x,_,_) = x
@@ -1593,9 +1586,6 @@ let type_toplevel_phrase env s =
   end;
   let (str, sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -1778,20 +1768,16 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       (Some sourcefile) initial_env None;
     raise e
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
+let type_interface _sourcefile env ast =
   begin
     let iter = Builtin_attributes.emit_external_warnings in
     iter.Ast_iterator.signature iter ast
   end;
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/404/typemod.mli
+++ b/src/ocaml/typing/404/typemod.mli
@@ -82,12 +82,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/typing/405/printtyp.ml
+++ b/src/ocaml/typing/405/printtyp.ml
@@ -1534,6 +1534,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/405/printtyp.mli
+++ b/src/ocaml/typing/405/printtyp.mli
@@ -30,9 +30,6 @@ val string_of_label: Asttypes.arg_label -> string
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
-val compute_map_for_pers: string -> bool
-    (* Call the function using the environment for type path shortening *)
-    (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/405/typemod.ml
+++ b/src/ocaml/typing/405/typemod.ml
@@ -49,13 +49,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let fst3 (x,_,_) = x
@@ -1595,9 +1588,6 @@ let type_toplevel_phrase env s =
   end;
   let (str, sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -1780,20 +1770,16 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       (Some sourcefile) initial_env None;
     raise e
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
+let type_interface _sourcefile env ast =
   begin
     let iter = Builtin_attributes.emit_external_warnings in
     iter.Ast_iterator.signature iter ast
   end;
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/405/typemod.mli
+++ b/src/ocaml/typing/405/typemod.mli
@@ -82,12 +82,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/typing/406/printtyp.ml
+++ b/src/ocaml/typing/406/printtyp.ml
@@ -1534,6 +1534,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/406/printtyp.mli
+++ b/src/ocaml/typing/406/printtyp.mli
@@ -30,9 +30,6 @@ val string_of_label: Asttypes.arg_label -> string
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
-val compute_map_for_pers: string -> bool
-    (* Call the function using the environment for type path shortening *)
-    (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/406/typemod.ml
+++ b/src/ocaml/typing/406/typemod.ml
@@ -52,13 +52,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let fst3 (x,_,_) = x
@@ -1777,9 +1770,6 @@ let type_toplevel_phrase env s =
   Env.reset_required_globals ();
   let (str, sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -1960,16 +1950,12 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       (Some sourcefile) initial_env None;
     raise e
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+let type_interface _sourcefile env ast =
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/406/typemod.mli
+++ b/src/ocaml/typing/406/typemod.mli
@@ -85,12 +85,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/typing/407/printtyp.ml
+++ b/src/ocaml/typing/407/printtyp.ml
@@ -1643,6 +1643,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/407/printtyp.mli
+++ b/src/ocaml/typing/407/printtyp.mli
@@ -30,9 +30,6 @@ val string_of_label: Asttypes.arg_label -> string
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
-val compute_map_for_pers: string -> bool
-    (* Call the function using the environment for type path shortening *)
-    (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/407/typemod.ml
+++ b/src/ocaml/typing/407/typemod.ml
@@ -52,13 +52,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let fst3 (x,_,_) = x
@@ -1830,9 +1823,6 @@ let type_toplevel_phrase env s =
   Env.reset_required_globals ();
   let (str, sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -2017,16 +2007,12 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       (Some sourcefile) initial_env None;
     raise e
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+let type_interface _sourcefile env ast =
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/407/typemod.mli
+++ b/src/ocaml/typing/407/typemod.mli
@@ -92,12 +92,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/typing/407_0/printtyp.ml
+++ b/src/ocaml/typing/407_0/printtyp.ml
@@ -1644,6 +1644,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/407_0/printtyp.mli
+++ b/src/ocaml/typing/407_0/printtyp.mli
@@ -30,9 +30,6 @@ val string_of_label: Asttypes.arg_label -> string
 val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
-val compute_map_for_pers: string -> bool
-    (* Call the function using the environment for type path shortening *)
-    (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/407_0/typemod.ml
+++ b/src/ocaml/typing/407_0/typemod.ml
@@ -52,13 +52,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let fst3 (x,_,_) = x
@@ -1827,9 +1820,6 @@ let type_toplevel_phrase env s =
   Env.reset_required_globals ();
   let (str, sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -2014,16 +2004,12 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       (Some sourcefile) initial_env None;
     raise e
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+let type_interface _sourcefile env ast =
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/407_0/typemod.mli
+++ b/src/ocaml/typing/407_0/typemod.mli
@@ -92,12 +92,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/typing/408/printtyp.ml
+++ b/src/ocaml/typing/408/printtyp.ml
@@ -1959,6 +1959,3 @@ let shorten_class_type_path env p =
 
 let () =
   Env.shorten_module_path := shorten_module_path
-
-let compute_map_for_pers _name = true
-

--- a/src/ocaml/typing/408/printtyp.mli
+++ b/src/ocaml/typing/408/printtyp.mli
@@ -49,9 +49,6 @@ val wrap_printing_env: ?error:bool -> Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
     (* Also, if [~error:true], then disable the loading of cmis *)
-val compute_map_for_pers: string -> bool
-    (* Call the function using the environment for type path shortening *)
-    (* This affects all the printing functions below *)
 val shorten_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_type_path: Env.t -> Path.t -> Path.t
 val shorten_module_path: Env.t -> Path.t -> Path.t

--- a/src/ocaml/typing/408/typemod.ml
+++ b/src/ocaml/typing/408/typemod.ml
@@ -110,13 +110,6 @@ let update_location loc = function
   | err -> err
 let () = Typetexp.typemod_update_location := update_location
 
-module ImplementationHooks = Misc.MakeHooks(struct
-    type t = Typedtree.structure * Typedtree.module_coercion
-  end)
-module InterfaceHooks = Misc.MakeHooks(struct
-    type t = Typedtree.signature
-  end)
-
 open Typedtree
 
 let rec path_concat head p =
@@ -2445,9 +2438,6 @@ let type_toplevel_phrase env s =
   Env.reset_required_globals ();
   let (str, sg, _to_remove_from_sg, env) =
     type_structure ~toplevel:true false None env s Location.none in
-  let (str, _coerce) = ImplementationHooks.apply_hooks
-      { Misc.sourcefile = "//toplevel//" } (str, Tcoerce_none)
-  in
   (str, sg, (* to_remove_from_sg,*) env)
 
 let type_module_alias = type_module ~alias:true true false None
@@ -2647,16 +2637,12 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
              (Array.of_list (Cmt_format.get_saved_types ())))
           (Some sourcefile) initial_env None)
 
-let type_implementation sourcefile outputprefix modulename initial_env ast =
-  ImplementationHooks.apply_hooks { Misc.sourcefile }
-    (type_implementation sourcefile outputprefix modulename initial_env ast)
-
 let save_signature modname tsg outputprefix source_file initial_env cmi =
   Cmt_format.save_cmt  (outputprefix ^ ".cmti") modname
     (Cmt_format.Interface tsg) (Some source_file) initial_env (Some cmi)
 
-let type_interface sourcefile env ast =
-  InterfaceHooks.apply_hooks { Misc.sourcefile } (transl_signature env ast)
+let type_interface _sourcefile env ast =
+  transl_signature env ast
 
 (* "Packaging" of several compilation units into one unit
    having them as sub-modules.  *)

--- a/src/ocaml/typing/408/typemod.mli
+++ b/src/ocaml/typing/408/typemod.mli
@@ -136,12 +136,6 @@ exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
 
-
-module ImplementationHooks : Misc.HookSig
-  with type t = Typedtree.structure * Typedtree.module_coercion
-module InterfaceHooks : Misc.HookSig
-  with type t = Typedtree.signature
-
 (* merlin *)
 
 val normalize_signature : Env.t -> Types.signature -> unit

--- a/src/ocaml/utils/misc.ml
+++ b/src/ocaml/utils/misc.ml
@@ -620,56 +620,6 @@ let modules_in_path ~ext path =
       with Sys_error _ -> results
     end
 
-
-type hook_info = {
-  sourcefile : string;
-}
-
-type hook_exn_wrapper = {
-  error: exn;
-  hook_name: string;
-  hook_info: hook_info;
-}
-
-exception HookExnWrapper of hook_exn_wrapper
-
-
-exception HookExn of exn
-
-let raise_direct_hook_exn e = raise (HookExn e)
-
-let fold_hooks list hook_info ast =
-  List.fold_left ~f:(fun ast (hook_name,f) ->
-    try
-      f hook_info ast
-    with
-    | HookExn e -> raise e
-    | error -> raise (HookExnWrapper {error; hook_name; hook_info})
-       (* when explicit reraise with backtrace will be available,
-          it should be used here *)
-
-  ) ~init:ast (List.sort ~cmp:compare list)
-
-module type HookSig = sig
-  type t
-
-  val add_hook : string -> (hook_info -> t -> t) -> unit
-  val apply_hooks : hook_info -> t -> t
-end
-
-module MakeHooks(M: sig
-    type t
-  end) : HookSig with type t = M.t
-= struct
-
-  type t = M.t
-
-  let hooks = ref []
-  let add_hook name f = hooks := (name, f) :: !hooks
-  let apply_hooks sourcefile intf =
-    fold_hooks !hooks sourcefile intf
-end
-
 module String = struct
   include CamlString
   module Set = Set.Make(struct type t = string let compare = compare end)

--- a/src/ocaml/utils/misc.mli
+++ b/src/ocaml/utils/misc.mli
@@ -266,39 +266,3 @@ val unitname: string -> string
 (** Return the name of the OCaml module matching a basename
     (filename without directory).
     Remove the extension and capitalize *)
-
-(** {1 Hook machinery}
-
-    Hooks machinery:
-   [add_hook name f] will register a function that will be called on the
-   argument of a later call to [apply_hooks]. Hooks are applied in the
-   lexicographical order of their names.
-*)
-
-type hook_info = {
-  sourcefile : string;
-}
-
-type hook_exn_wrapper = {
-  error: exn;
-  hook_name: string;
-  hook_info: hook_info;
-}
-
-exception HookExnWrapper of hook_exn_wrapper
-
-(** An exception raised by a hook will be wrapped into a
-    [HookExnWrapper] constructor by the hook machinery.  *)
-
-
-val raise_direct_hook_exn: exn -> 'a
-(** A hook can use [raise_unwrapped_hook_exn] to raise an exception that will
-    not be wrapped into a [HookExnWrapper]. *)
-
-module type HookSig = sig
-  type t
-  val add_hook : string -> (hook_info -> t -> t) -> unit
-  val apply_hooks : hook_info -> t -> t
-end
-
-module MakeHooks : functor (M : sig type t end) -> HookSig with type t = M.t


### PR DESCRIPTION
This simple PR remove hooks from all OCaml versions.
Hooks are not used by Merlin and were removed from OCaml 4.09. This simplification is not necessary but prepare the 4.09 support.