### PR TITLE
Simplify management of dynamically-scope global state (Local_store)

### DIFF
--- a/src/kernel/mocaml.ml
+++ b/src/kernel/mocaml.ml
@@ -27,7 +27,7 @@ let setup_config config = (
 type typer_state = Local_store.scope
 
 let new_state ~unit_name =
-  let scope = Local_store.(merge (fresh Btype.state) (fresh Env.state)) in
+  let scope = Local_store.fresh Local_store.typechecker_state in
   Local_store.with_scope scope
     (fun () -> Env.set_unit_name unit_name);
   scope

--- a/src/ocaml/typing/402/btype.ml
+++ b/src/ocaml/typing/402/btype.ml
@@ -600,8 +600,7 @@ type changes =
 
 type snapshot = changes ref * int
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 let last_snapshot = sref (fun () -> 0)

--- a/src/ocaml/typing/402/btype.mli
+++ b/src/ocaml/typing/402/btype.mli
@@ -210,10 +210,6 @@ val log_type: type_expr -> unit
 (**** Forward declarations ****)
 val print_raw: (Format.formatter -> type_expr -> unit) ref
 
-(** merlin: manage all internal state *)
-
-val state : Local_store.bindings
-
 (* merlin: Number of unification variables that have been linked so far.
    Used to estimate the "cost" of unification. *)
 val linked_variables: unit -> int

--- a/src/ocaml/typing/402/env.ml
+++ b/src/ocaml/typing/402/env.ml
@@ -23,9 +23,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/402/env.mli
+++ b/src/ocaml/typing/402/env.mli
@@ -288,7 +288,6 @@ val check_value_name: string -> Location.t -> unit
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/403/btype.ml
+++ b/src/ocaml/typing/403/btype.ml
@@ -86,9 +86,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/403/btype.mli
+++ b/src/ocaml/typing/403/btype.mli
@@ -225,10 +225,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: manage all internal state *)
-
-val state : Local_store.bindings
-
 (* merlin: Number of unification variables that have been linked so far.
    Used to estimate the "cost" of unification. *)
 val linked_variables: unit -> int

--- a/src/ocaml/typing/403/env.ml
+++ b/src/ocaml/typing/403/env.ml
@@ -26,9 +26,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/403/env.mli
+++ b/src/ocaml/typing/403/env.mli
@@ -304,8 +304,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/404/btype.ml
+++ b/src/ocaml/typing/404/btype.ml
@@ -86,9 +86,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/404/btype.mli
+++ b/src/ocaml/typing/404/btype.mli
@@ -218,9 +218,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -24,9 +24,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/404/env.mli
+++ b/src/ocaml/typing/404/env.mli
@@ -335,8 +335,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/405/btype.ml
+++ b/src/ocaml/typing/405/btype.ml
@@ -87,9 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 
@@ -215,7 +213,7 @@ let proxy ty =
 
 (**** Utilities for fixed row private types ****)
 
-let row_of_type t = 
+let row_of_type t =
   match (repr t).desc with
     Tobject(t,_) ->
       let rec get_row t =

--- a/src/ocaml/typing/405/btype.mli
+++ b/src/ocaml/typing/405/btype.mli
@@ -220,9 +220,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -24,9 +24,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/405/env.mli
+++ b/src/ocaml/typing/405/env.mli
@@ -335,8 +335,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/406/btype.ml
+++ b/src/ocaml/typing/406/btype.ml
@@ -87,9 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 
@@ -215,7 +213,7 @@ let proxy ty =
 
 (**** Utilities for fixed row private types ****)
 
-let row_of_type t = 
+let row_of_type t =
   match (repr t).desc with
     Tobject(t,_) ->
       let rec get_row t =

--- a/src/ocaml/typing/406/btype.mli
+++ b/src/ocaml/typing/406/btype.mli
@@ -220,9 +220,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -24,9 +24,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/406/env.mli
+++ b/src/ocaml/typing/406/env.mli
@@ -335,8 +335,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/407/btype.ml
+++ b/src/ocaml/typing/407/btype.ml
@@ -88,9 +88,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 
@@ -216,7 +214,7 @@ let proxy ty =
 
 (**** Utilities for fixed row private types ****)
 
-let row_of_type t = 
+let row_of_type t =
   match (repr t).desc with
     Tobject(t,_) ->
       let rec get_row t =

--- a/src/ocaml/typing/407/btype.mli
+++ b/src/ocaml/typing/407/btype.mli
@@ -221,9 +221,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -24,9 +24,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/407/env.mli
+++ b/src/ocaml/typing/407/env.mli
@@ -354,8 +354,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/407_0/btype.ml
+++ b/src/ocaml/typing/407_0/btype.ml
@@ -88,9 +88,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 
@@ -216,7 +214,7 @@ let proxy ty =
 
 (**** Utilities for fixed row private types ****)
 
-let row_of_type t = 
+let row_of_type t =
   match (repr t).desc with
     Tobject(t,_) ->
       let rec get_row t =

--- a/src/ocaml/typing/407_0/btype.mli
+++ b/src/ocaml/typing/407_0/btype.mli
@@ -221,9 +221,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -24,9 +24,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/407_0/env.mli
+++ b/src/ocaml/typing/407_0/env.mli
@@ -354,8 +354,6 @@ val unbound_class: Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val with_cmis : (unit -> 'a) -> 'a

--- a/src/ocaml/typing/408/btype.ml
+++ b/src/ocaml/typing/408/btype.ml
@@ -87,9 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/408/btype.mli
+++ b/src/ocaml/typing/408/btype.mli
@@ -236,9 +236,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/408/env.ml
+++ b/src/ocaml/typing/408/env.ml
@@ -23,9 +23,7 @@ open Path
 open Types
 open Btype
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Typechecker
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/408/env.mli
+++ b/src/ocaml/typing/408/env.mli
@@ -394,8 +394,6 @@ val unbound_class : Path.t
 
 (** merlin: manage internal state *)
 
-val state : Local_store.bindings
-
 val check_state_consistency: unit -> bool
 
 val without_cmis : ('a -> 'b) -> 'a -> 'b

--- a/src/utils/local_store.ml
+++ b/src/utils/local_store.ml
@@ -35,3 +35,10 @@ let with_scope scope f =
     List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) scope;
     restore backup;
     reraise exn
+
+let typechecker_state = new_bindings ()
+
+module Typechecker = struct
+  let sref f = ref typechecker_state f
+  let srefk k = ref typechecker_state (fun () -> k)
+end

--- a/src/utils/local_store.mli
+++ b/src/utils/local_store.mli
@@ -1,3 +1,5 @@
+(* Dynamic-scoping for global piece of state *)
+
 type bindings
 val new_bindings : unit -> bindings
 
@@ -7,3 +9,13 @@ type scope
 val fresh : bindings -> scope
 val merge : scope -> scope -> scope
 val with_scope : scope -> (unit -> 'a) -> 'a
+
+(* Typechecker state *)
+
+val typechecker_state : bindings
+
+module Typechecker : sig
+  (* Scopped-references *)
+  val sref : (unit -> 'a) -> 'a ref
+  val srefk : 'a -> 'a ref
+end


### PR DESCRIPTION
`Local_store` is our abstraction to manage different instances of global state.
In practice, there is only a single kind of state to manage in this way: the typechecker one.

This PR acknowledges that and simplifies `Local_store` accordingly. That should help #1052.