### PR TITLE
Rework global state

### DIFF
--- a/dune-workspace.test
+++ b/dune-workspace.test
@@ -4,4 +4,4 @@
 (context (opam (switch 4.05.0)))
 (context (opam (switch 4.06.1)))
 (context (opam (switch 4.07.1)))
-(context (opam (switch 4.08.0)))
+(context (opam (switch 4.08.1)))

--- a/src/frontend/lsp/document.ml
+++ b/src/frontend/lsp/document.ml
@@ -13,7 +13,8 @@ let normalize_line_endings text =
 
 let uri doc = Lsp.Text_document.documentUri doc.tdoc
 let source doc = doc.source
-let pipeline doc = doc.pipeline
+let with_pipeline doc f =
+  Mpipeline.with_pipeline doc.pipeline (fun () -> f doc.pipeline)
 let version doc = Lsp.Text_document.version doc.tdoc
 
 let make_config uri =

--- a/src/frontend/lsp/document.mli
+++ b/src/frontend/lsp/document.mli
@@ -9,7 +9,7 @@ val make :
 
 val uri : t -> Lsp.Protocol.documentUri
 val source : t -> Msource.t
-val pipeline : t -> Mpipeline.t
+val with_pipeline : t -> (Mpipeline.t -> 'a) -> 'a
 val version : t -> int
 
 val update_text : ?version:int -> Lsp.Protocol.DidChange.textDocumentContentChangeEvent -> t -> t

--- a/src/frontend/ocamlmerlin/new/new_commands.ml
+++ b/src/frontend/ocamlmerlin/new/new_commands.ml
@@ -61,7 +61,6 @@ let rec find_command name = function
 let run pipeline query =
   Logger.log ~section:"New_commands" ~title:"run(query)"
     "%a" Logger.json (fun () -> Query_json.dump query);
-  Mpipeline.with_reader pipeline @@ fun () ->
   let result = Query_commands.dispatch pipeline query in
   let json = Query_json.json_of_response query result in
   json

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -96,7 +96,10 @@ let run = function
         let json =
           let class_, message =
             Printexc.record_backtrace true;
-            match command_action pipeline command_args with
+            match
+              Mpipeline.with_pipeline pipeline @@ fun () ->
+              command_action pipeline command_args
+            with
             | result ->
               ("return", result)
             | exception (Failure str) ->

--- a/src/frontend/ocamlmerlin/old/old_command.ml
+++ b/src/frontend/ocamlmerlin/old/old_command.ml
@@ -240,7 +240,7 @@ let dispatch (type a) (context : Context.t) (cmd : a command) =
   match cmd with
   | Query q ->
     let pipeline = make_pipeline config state.buffer in
-    Mpipeline.with_reader pipeline @@ fun () ->
+    Mpipeline.with_pipeline pipeline @@ fun () ->
     Query_commands.dispatch pipeline q
   | Sync (Checkout context) when state == Lazy.force default_state ->
     let buffer = checkout_buffer context in

--- a/src/kernel/mocaml.ml
+++ b/src/kernel/mocaml.ml
@@ -1,13 +1,37 @@
 open Std
+open Local_store.Compiler
 
+(* Instance of environment cache & btype unification log  *)
+
+type typer_state = Local_store.scope
+
+let bound = srefk None
+
+let new_state () =
+  let scope = Local_store.fresh compiler_state in
+  Local_store.with_scope scope (fun () -> bound := Some scope);
+  scope
+
+let with_state state f =
+  if Local_store.is_bound compiler_state then
+    failwith "Mocaml.with_state: another instance is already in use";
+  match Local_store.with_scope state f with
+  | r -> Cmt_format.clear (); r
+  | exception exn -> Cmt_format.clear (); reraise exn
+
+let is_current_state state = match !bound with
+  | Some state' -> state == state'
+  | None -> false
 
 (* Build settings *)
 
 let setup_config config = (
+  assert Local_store.(is_bound compiler_state);
   let open Mconfig in
   let open Clflags in
   let ocaml = config.ocaml in
   Load_path.init (Mconfig.build_path config);
+  Env.set_unit_name (Mconfig.unitname config);
   Location.input_name  := config.query.filename;
   fast                 := ocaml.unsafe ;
   classic              := ocaml.classic ;
@@ -21,35 +45,6 @@ let setup_config config = (
   strict_formats       := ocaml.strict_formats ;
   open_modules         := ocaml.open_modules ;
 )
-
-(* Instance of environment cache & btype unification log  *)
-
-type typer_state = Local_store.scope
-
-let new_state ~unit_name =
-  let scope = Local_store.fresh Local_store.typechecker_state in
-  Local_store.with_scope scope
-    (fun () -> Env.set_unit_name unit_name);
-  scope
-
-let current_state = ref None
-
-let with_state state f =
-  let state' = !current_state in
-  current_state := Some state;
-  match Local_store.with_scope state f with
-  | r ->
-    current_state := state';
-    Cmt_format.clear ();
-    r
-  | exception exn ->
-    current_state := state';
-    Cmt_format.clear ();
-    reraise exn
-
-let is_current_state state = match !current_state with
-  | Some state' -> state == state'
-  | None -> false
 
 (** Switchable implementation of Oprint *)
 

--- a/src/kernel/mocaml.ml
+++ b/src/kernel/mocaml.ml
@@ -5,11 +5,11 @@ open Local_store.Compiler
 
 type typer_state = Local_store.scope
 
-let bound = srefk None
+let current_state = srefk None
 
 let new_state () =
   let scope = Local_store.fresh compiler_state in
-  Local_store.with_scope scope (fun () -> bound := Some scope);
+  Local_store.with_scope scope (fun () -> current_state := Some scope);
   scope
 
 let with_state state f =
@@ -19,7 +19,7 @@ let with_state state f =
   | r -> Cmt_format.clear (); r
   | exception exn -> Cmt_format.clear (); reraise exn
 
-let is_current_state state = match !bound with
+let is_current_state state = match !current_state with
   | Some state' -> state == state'
   | None -> false
 

--- a/src/kernel/mocaml.mli
+++ b/src/kernel/mocaml.mli
@@ -1,12 +1,12 @@
-(* Build settings *)
-val setup_config : Mconfig.t -> unit
-
-(* Instance of environment cache & btype unification log  *)
+(* An instance of load path, environment cache & btype unification log  *)
 type typer_state
 
-val new_state : unit_name:string -> typer_state
+val new_state : unit -> typer_state
 val with_state : typer_state -> (unit -> 'a) -> 'a
 val is_current_state : typer_state -> bool
+
+(* Build settings *)
+val setup_config : Mconfig.t -> unit
 
 (* Replace Outcome printer *)
 val default_printer :

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -29,7 +29,7 @@ module Cache = struct
     in
     match List.assoc key !cache with
     | state ->
-      cache := List.remove_assoc key !cache;
+      cache := (key, state) :: List.remove_assoc key !cache;
       log ~title "found entry for this configuration";
       state
     | exception Not_found ->

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -1,3 +1,7 @@
+open Std
+
+let {Logger. log} = Logger.for_section "Pipeline"
+
 let time_shift = ref 0.0
 
 let timed_lazy r x =
@@ -14,6 +18,26 @@ let timed_lazy r x =
     | x -> update (); x
     | exception exn -> update (); Std.reraise exn
   )
+
+module Cache = struct
+  let cache = ref []
+
+  let get config =
+    let title = "pop_cache" in
+    let key =
+      Mconfig.(config.query.directory, config.query.filename, config.ocaml)
+    in
+    match List.assoc key !cache with
+    | state ->
+      cache := List.remove_assoc key !cache;
+      log ~title "found entry for this configuration";
+      state
+    | exception Not_found ->
+      log ~title "nothing cached for this configuration";
+      let state = Mocaml.new_state () in
+      cache := (key, state) :: List.take_n 5 !cache;
+      state
+end
 
 module Typer = struct
   type t = {
@@ -32,6 +56,7 @@ end
 
 type t = {
   config : Mconfig.t;
+  state  : Mocaml.typer_state;
   raw_source : Msource.t;
   source : Msource.t lazy_t;
   reader : (Mreader.result * Mconfig.t) lazy_t;
@@ -50,12 +75,13 @@ let raw_source t = t.raw_source
 let input_config t = t.config
 let input_source t = Lazy.force t.source
 
+let with_pipeline t f =
+  Mocaml.with_state t.state @@ fun () ->
+  Mreader.with_ambient_reader t.config (input_source t) f
+
 let get_lexing_pos t pos =
   Msource.get_lexing_pos
     (input_source t) ~filename:(Mconfig.filename t.config) pos
-
-let with_reader t f =
-  Mreader.with_ambient_reader t.config (input_source t) f
 
 let reader t = Lazy.force t.reader
 
@@ -79,6 +105,7 @@ let typer_result t = (typer t).Typer.result
 let typer_errors t = Lazy.force (typer t).Typer.errors
 
 let process
+    ?state
     ?(pp_time=ref 0.0)
     ?(reader_time=ref 0.0)
     ?(ppx_time=ref 0.0)
@@ -86,6 +113,10 @@ let process
     ?(error_time=ref 0.0)
     ?for_completion
     config raw_source =
+  let state = match state with
+    | None -> Cache.get config
+    | Some state -> state
+  in
   let source = timed_lazy pp_time (lazy (
       match Mconfig.(config.ocaml.pp) with
       | None -> raw_source
@@ -119,17 +150,17 @@ let process
       let errors = timed_lazy error_time (lazy (Mtyper.get_errors result)) in
       { Typer. errors; result }
     )) in
-  { config; raw_source; source; reader; ppx; typer;
+  { config; state; raw_source; source; reader; ppx; typer;
     pp_time; reader_time; ppx_time; typer_time; error_time }
 
 let make config source =
   process (Mconfig.normalize config) source
 
 let for_completion position
-    {config; raw_source;
+    {config; state; raw_source;
      pp_time; reader_time; ppx_time; typer_time; error_time; _} =
   process config raw_source ~for_completion:position
-    ~pp_time ~reader_time ~ppx_time ~typer_time ~error_time
+    ~state ~pp_time ~reader_time ~ppx_time ~typer_time ~error_time
 
 let timing_information t = [
   "pp"     , !(t.pp_time);

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -1,6 +1,6 @@
 type t
-
 val make : Mconfig.t -> Msource.t -> t
+val with_pipeline : t -> (unit -> 'a) -> 'a
 val for_completion : Msource.position -> t -> t
 
 val raw_source : t -> Msource.t
@@ -9,7 +9,6 @@ val input_config : t -> Mconfig.t
 val input_source : t -> Msource.t
 val get_lexing_pos : t -> [< Msource.position] -> Lexing.position
 
-val with_reader : t -> (unit -> 'a) -> 'a
 val reader_config : t -> Mconfig.t
 val reader_comments : t -> (string * Location.t) list
 val reader_parsetree : t -> Mreader.parsetree

--- a/src/kernel/mtyper.mli
+++ b/src/kernel/mtyper.mli
@@ -16,8 +16,6 @@ type typedtree = [
 
 val run : Mconfig.t -> Mreader.parsetree -> result
 
-val with_typer : result -> (unit -> 'a) -> 'a
-
 val get_env : ?pos:Msource.position -> result -> Env.t
 
 val get_typedtree : result -> typedtree

--- a/src/ocaml/typing/402/btype.ml
+++ b/src/ocaml/typing/402/btype.ml
@@ -600,7 +600,7 @@ type changes =
 
 type snapshot = changes ref * int
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 let last_snapshot = sref (fun () -> 0)

--- a/src/ocaml/typing/402/env.ml
+++ b/src/ocaml/typing/402/env.ml
@@ -23,7 +23,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/403/btype.ml
+++ b/src/ocaml/typing/403/btype.ml
@@ -86,7 +86,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/403/env.ml
+++ b/src/ocaml/typing/403/env.ml
@@ -26,7 +26,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/404/btype.ml
+++ b/src/ocaml/typing/404/btype.ml
@@ -86,7 +86,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -24,7 +24,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/405/btype.ml
+++ b/src/ocaml/typing/405/btype.ml
@@ -87,7 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -24,7 +24,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/406/btype.ml
+++ b/src/ocaml/typing/406/btype.ml
@@ -87,7 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -24,7 +24,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/407/btype.ml
+++ b/src/ocaml/typing/407/btype.ml
@@ -88,7 +88,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -24,7 +24,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/407_0/btype.ml
+++ b/src/ocaml/typing/407_0/btype.ml
@@ -88,7 +88,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -24,7 +24,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/typing/408/btype.ml
+++ b/src/ocaml/typing/408/btype.ml
@@ -87,7 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/408/env.ml
+++ b/src/ocaml/typing/408/env.ml
@@ -23,7 +23,7 @@ open Path
 open Types
 open Btype
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let add_delayed_check_forward = ref (fun _ -> assert false)
 

--- a/src/ocaml/utils/402/config.ml
+++ b/src/ocaml/utils/402/config.ml
@@ -19,6 +19,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -34,7 +36,7 @@ and ast_intf_magic_number = "Caml1999N015"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T004"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/403/config.ml
+++ b/src/ocaml/utils/403/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I020"
 and cmo_magic_number = "Caml1999O011"
@@ -41,7 +43,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T007"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/404/config.ml
+++ b/src/ocaml/utils/404/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -45,7 +47,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T008"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/405/config.ml
+++ b/src/ocaml/utils/405/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -45,7 +47,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T009"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/406/config.ml
+++ b/src/ocaml/utils/406/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -48,7 +50,7 @@ and cmxs_magic_number = "Caml1999D022"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T022"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/407/config.ml
+++ b/src/ocaml/utils/407/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -48,7 +50,7 @@ and cmxs_magic_number = "Caml1999D023"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T024"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/407_0/config.ml
+++ b/src/ocaml/utils/407_0/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -48,7 +50,7 @@ and cmxs_magic_number = "Caml1999D023"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T023"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/408/config.ml
+++ b/src/ocaml/utils/408/config.ml
@@ -22,6 +22,8 @@
 (**                                                                   **)
 (***********************************************************************)
 
+open Local_store.Compiler
+
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
@@ -48,7 +50,7 @@ and cmxs_magic_number = "Caml1999D025"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T025"
 
-let load_path = ref ([] : string list)
+let load_path = srefk ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/408/load_path.ml
+++ b/src/ocaml/utils/408/load_path.ml
@@ -17,7 +17,7 @@ module SMap = Misc.String.Map
 (* Mapping from basenames to full filenames *)
 type registry = string SMap.t ref
 
-open Local_store.Typechecker
+open Local_store.Compiler
 
 let files : registry = srefk SMap.empty
 let files_uncap : registry = srefk SMap.empty
@@ -38,6 +38,7 @@ end
 let dirs = srefk []
 
 let reset () =
+  assert (Local_store.is_bound compiler_state);
   files := SMap.empty;
   files_uncap := SMap.empty;
   dirs := []
@@ -46,6 +47,7 @@ let get () = !dirs
 let get_paths () = List.map Dir.path !dirs
 
 let add dir =
+  assert (Local_store.is_bound compiler_state);
   let add_file base =
     let fn = Filename.concat dir.Dir.path base in
     files := SMap.add base fn !files;
@@ -55,6 +57,7 @@ let add dir =
   dirs := dir :: !dirs
 
 let remove_dir dir =
+  assert (Local_store.is_bound compiler_state);
   let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
   if new_dirs <> !dirs then begin
     reset ();
@@ -70,12 +73,14 @@ let init l =
 let is_basename fn = Filename.basename fn = fn
 
 let find fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find fn !files
   else
     Misc.find_in_path (get_paths ()) fn
 
 let find_uncap fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find (String.uncapitalize_ascii fn) !files_uncap
   else

--- a/src/utils/local_store.ml
+++ b/src/utils/local_store.ml
@@ -1,11 +1,14 @@
 open Std
 
 type ref_and_reset = F : 'a ref * (unit -> 'a) -> ref_and_reset
-type bindings = { mutable refs: ref_and_reset list; is_bound: bool ref }
+type bindings = {
+  mutable refs: ref_and_reset list;
+  mutable frozen : bool;
+  is_bound: bool ref
+}
 
 let new_bindings () =
-  let is_bound = ref false in
-  { refs = [F (is_bound, (fun () -> true))]; is_bound }
+  { refs = []; is_bound = ref false; frozen = false }
 
 let is_bound t = !(t.is_bound)
 
@@ -15,29 +18,36 @@ let reset t =
 
 let ref t f =
   let result = ref (f ()) in
+  assert (not t.frozen);
   t.refs <- (F (result, f)) :: t.refs;
   result
 
 type 'a slot = { ref : 'a ref; mutable value : 'a }
 type a_slot = Slot : 'a slot -> a_slot
-type scope = a_slot list
+type scope = { slots: a_slot list; scope_bound : bool ref }
 
 let fresh t =
-  List.map ~f:(fun (F(ref,f)) -> Slot {ref; value = f ()}) t.refs
+  t.frozen <- true;
+  { slots = List.map ~f:(fun (F(ref,f)) -> Slot {ref; value = f ()}) t.refs;
+    scope_bound = t.is_bound }
 
 type ref_and_value = V : 'a ref * 'a -> ref_and_value
 let restore l = List.iter ~f:(fun (V(r,v)) -> r := v) l
 
-let with_scope scope f =
-  let backup = List.rev_map ~f:(fun (Slot {ref;_}) -> V (ref,!ref)) scope in
-  List.iter ~f:(fun (Slot {ref;value}) -> ref := value) scope;
+let with_scope { slots; scope_bound } f =
+  assert (not !scope_bound);
+  scope_bound := true;
+  let backup = List.rev_map ~f:(fun (Slot {ref;_}) -> V (ref,!ref)) slots in
+  List.iter ~f:(fun (Slot {ref;value}) -> ref := value) slots;
   match f () with
   | x ->
-    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) scope;
+    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) slots;
+    scope_bound := false;
     restore backup;
     x
   | exception exn ->
-    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) scope;
+    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) slots;
+    scope_bound := false;
     restore backup;
     reraise exn
 

--- a/src/utils/local_store.mli
+++ b/src/utils/local_store.mli
@@ -2,20 +2,19 @@
 
 type bindings
 val new_bindings : unit -> bindings
+val is_bound : bindings -> bool
+val reset : bindings -> unit
 
 val ref : bindings -> (unit -> 'a) -> 'a ref
 
 type scope
 val fresh : bindings -> scope
-val merge : scope -> scope -> scope
 val with_scope : scope -> (unit -> 'a) -> 'a
 
-(* Typechecker state *)
+(* ... Unique instance for compiler-libs state *)
 
-val typechecker_state : bindings
-
-module Typechecker : sig
-  (* Scopped-references *)
+module Compiler : sig
+  val compiler_state : bindings
   val sref : (unit -> 'a) -> 'a ref
   val srefk : 'a -> 'a ref
 end


### PR DESCRIPTION
This changes the way state from the compiler is managed.
It now mimics a much simpler form of dynamic-scoping were bindings cannot be nested and there is a unique "binding point" that snapshots the whole compiler state.

If this doesn't break the cache (in correctness nor performance), it will help further changes (path management that @trefis worked on) and can be the basis of a hypothetical upstreaming of state management.