### PR TITLE
Disable implicit_transitive_deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,5 @@
 (lang dune 1.8)
 (name merlin)
 (using menhir 2.0)
+
+(implicit_transitive_deps false)

--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -1,4 +1,14 @@
 (library
  (name merlin_analysis)
  (wrapped false)
- (libraries config merlin_kernel merlin_utils parsing preprocess query_protocol typing utils))
+ (libraries
+  config
+  merlin_specific
+  merlin_extend
+  merlin_kernel
+  merlin_utils
+  parsing
+  preprocess
+  query_protocol
+  typing
+  utils))

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -6,4 +6,13 @@
 (library
  (name      query_commands)
  (modules   query_commands)
- (libraries merlin_analysis query_protocol))
+ (libraries
+  merlin_utils
+  merlin_kernel
+  utils
+  parsing
+  typing
+  merlin_specific
+  config
+  merlin_analysis
+  query_protocol))

--- a/src/frontend/lsp/dune
+++ b/src/frontend/lsp/dune
@@ -3,5 +3,18 @@
  (package merlin-lsp)
  (public_name ocamlmerlin-lsp)
  (flags (:standard "-open" "Result"))
- (libraries config merlin_analysis merlin_kernel merlin_utils os_ipc
-            parsing query_protocol lsp typing utils query_commands result))
+ (libraries
+  merlin_specific
+  config
+  merlin_analysis
+  merlin_kernel
+  merlin_utils os_ipc
+  parsing
+  query_protocol
+  lsp
+  typing
+  utils
+  query_commands
+  result
+  yojson
+  ppx_yojson_conv_lib))

--- a/src/frontend/lsp/dune
+++ b/src/frontend/lsp/dune
@@ -5,10 +5,9 @@
  (flags (:standard "-open" "Result"))
  (libraries
   merlin_specific
-  config
   merlin_analysis
   merlin_kernel
-  merlin_utils os_ipc
+  merlin_utils
   parsing
   query_protocol
   lsp

--- a/src/frontend/ocamlmerlin/dune
+++ b/src/frontend/ocamlmerlin/dune
@@ -5,8 +5,9 @@
  (package merlin)
  (public_name ocamlmerlin-server)
  (modules (:standard \ gen_ccflags))
- (libraries config merlin_analysis merlin_kernel merlin_utils os_ipc
-            parsing query_protocol query_commands typing utils))
+ (libraries config findlib yojson merlin_analysis merlin_kernel
+            merlin_utils os_ipc parsing query_protocol query_commands
+            typing utils))
 
 (executable
  (name      gen_ccflags)

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -5,4 +5,4 @@
  (name merlin_kernel)
  (wrapped false)
  (libraries config merlin_extend merlin_specific merlin_utils parsing
-            preprocess typing utils))
+            preprocess typing utils findlib))

--- a/src/lsp/dune
+++ b/src/lsp/dune
@@ -1,7 +1,7 @@
 (library
   (name lsp)
-  (libraries merlin_utils yojson threads result ppx_yojson_conv_lib)
-  (flags (:standard "-open" "Result" "-open" "Ppx_yojson_conv_lib" "-open" "Yojson_conv"))
+  (libraries merlin_utils yojson threads.posix result ppx_yojson_conv_lib)
+  (flags :standard "-open" "Result" "-open" "Ppx_yojson_conv_lib" "-open" "Yojson_conv")
   (lint (pps ppx_yojson_conv)))
 
 (ocamllex (modules text_document_text))

--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -37,7 +37,7 @@ Printf.ksprintf J.send {|
 (library
   (name preprocess)
   (wrapped false)
-  (libraries parsing))
+  (libraries parsing utils merlin_utils))
 
 (menhir
  (modules parser_raw)


### PR DESCRIPTION
Dependencies should be specified explicitly without relying on
transitive deps.