### PR TITLE
Move go-to typedef to merlin

### DIFF
--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -705,7 +705,7 @@ let from_longident ~config ~env ~lazy_trie ~pos nss ml_or_mli ident =
     else
       locate ~config ~ml_or_mli ~path:tagged_path ~lazy_trie ~pos ~str_ident loc
 
-let from_path ~config ~local_defs ~pos ~namespace ~loc ml_or_mli path =
+let from_path ~config ~local_defs ~pos ~namespace ml_or_mli path =
   if Utils.is_builtin_path path then
     `Builtin
   else
@@ -716,6 +716,7 @@ let from_path ~config ~local_defs ~pos ~namespace ~loc ml_or_mli path =
               [Browse_tree.of_browse browse])
     in
     let nss_path = Namespaced_path.of_path ~namespace path in
+    let loc = Location.none in
     match
       locate ~config ~ml_or_mli ~path:nss_path ~lazy_trie ~pos ~str_ident loc
     with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -705,7 +705,7 @@ let from_longident ~config ~env ~lazy_trie ~pos nss ml_or_mli ident =
     else
       locate ~config ~ml_or_mli ~path:tagged_path ~lazy_trie ~pos ~str_ident loc
 
-let from_path ~config ~local_defs ~pos ~namespace ml_or_mli path =
+let from_path ~config ~local_defs ~pos ~namespace ~loc ml_or_mli path =
   if Utils.is_builtin_path path then
     `Builtin
   else
@@ -716,7 +716,6 @@ let from_path ~config ~local_defs ~pos ~namespace ml_or_mli path =
               [Browse_tree.of_browse browse])
     in
     let nss_path = Namespaced_path.of_path ~namespace path in
-    let loc = Location.none in
     match
       locate ~config ~ml_or_mli ~path:nss_path ~lazy_trie ~pos ~str_ident loc
     with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -706,31 +706,34 @@ let from_longident ~config ~env ~lazy_trie ~pos nss ml_or_mli ident =
       locate ~config ~ml_or_mli ~path:tagged_path ~lazy_trie ~pos ~str_ident loc
 
 let from_path ~config ~local_defs ~pos ~namespace ml_or_mli path =
-  let str_ident = Path.name path in
-  let browse = Mbrowse.of_typedtree local_defs in
-  let lazy_trie =
-    lazy (Typedtrie.of_browses ~local_buffer:true
-            [Browse_tree.of_browse browse])
-  in
-  let nss_path = Namespaced_path.of_path ~namespace path in
-  let loc = Location.none in
-  match
-    locate ~config ~ml_or_mli ~path:nss_path ~lazy_trie ~pos ~str_ident loc
-  with
-  | `Not_found _
-  | `File_not_found _ as err -> err
-  | `Found (loc, _) ->
-    match find_source ~config loc with
-    | Found src -> `Found (Some src, loc.Location.loc_start)
-    | Not_found f ->
-      let path = Path.name path in
-      File.explain_not_found path f
-    | Multiple_matches lst ->
-      let matches = String.concat lst ~sep:", " in
-      `File_not_found (
-        sprintf "Several source files in your path have the same name, and \
-                 merlin doesn't know which is the right one: %s"
-          matches)
+  if Utils.is_builtin_path path then
+    `Builtin
+  else
+    let str_ident = Path.name path in
+    let browse = Mbrowse.of_typedtree local_defs in
+    let lazy_trie =
+      lazy (Typedtrie.of_browses ~local_buffer:true
+              [Browse_tree.of_browse browse])
+    in
+    let nss_path = Namespaced_path.of_path ~namespace path in
+    let loc = Location.none in
+    match
+      locate ~config ~ml_or_mli ~path:nss_path ~lazy_trie ~pos ~str_ident loc
+    with
+    | `Not_found _
+    | `File_not_found _ as err -> err
+    | `Found (loc, _) ->
+      match find_source ~config loc with
+      | Found src -> `Found (Some src, loc.Location.loc_start)
+      | Not_found f ->
+        let path = Path.name path in
+        File.explain_not_found path f
+      | Multiple_matches lst ->
+        let matches = String.concat lst ~sep:", " in
+        `File_not_found (
+          sprintf "Several source files in your path have the same name, and \
+                   merlin doesn't know which is the right one: %s"
+            matches)
 
 let from_string ~config ~env ~local_defs ~pos ?namespaces switch path =
   let browse = Mbrowse.of_typedtree local_defs in

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -37,6 +37,7 @@ val from_path
   -> local_defs:Mtyper.typedtree
   -> pos:Lexing.position
   -> namespace:Namespaced_path.Namespace.t
+  -> loc:Location.t
   -> [ `ML | `MLI ]
   -> Path.t
   -> [> `File_not_found of string

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -34,6 +34,7 @@ end
 
 val from_path
   : config:Mconfig.t
+  -> env:Env.t
   -> local_defs:Mtyper.typedtree
   -> pos:Lexing.position
   -> namespace:Namespaced_path.Namespace.t

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -37,7 +37,6 @@ val from_path
   -> local_defs:Mtyper.typedtree
   -> pos:Lexing.position
   -> namespace:Namespaced_path.Namespace.t
-  -> loc:Location.t
   -> [ `ML | `MLI ]
   -> Path.t
   -> [> `File_not_found of string

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -32,6 +32,17 @@ module Namespace : sig
   type t = [ `Type | `Mod | `Modtype | `Vals | `Constr | `Labels ]
 end
 
+val from_path
+  : config:Mconfig.t
+  -> local_defs:Mtyper.typedtree
+  -> pos:Lexing.position
+  -> namespace:Namespaced_path.Namespace.t
+  -> [ `ML | `MLI ]
+  -> Path.t
+  -> [> `File_not_found of string
+     | `Found of string option * Lexing.position
+     | `Not_found of string * string option ]
+
 val from_string
   :  config:Mconfig.t
   -> env:Env.t

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -41,6 +41,7 @@ val from_path
   -> Path.t
   -> [> `File_not_found of string
      | `Found of string option * Lexing.position
+     | `Builtin
      | `Not_found of string * string option ]
 
 val from_string

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -43,6 +43,7 @@ val from_path
   -> [> `File_not_found of string
      | `Found of string option * Lexing.position
      | `Builtin
+     | `Not_in_env of string
      | `Not_found of string * string option ]
 
 val from_string

--- a/src/frontend/ocamlmerlin/new/new_commands.ml
+++ b/src/frontend/ocamlmerlin/new/new_commands.ml
@@ -363,6 +363,21 @@ different file."
     end
   ;
 
+  command "locate-type"
+    ~spec: [
+      arg "-position" "<position> Position to complete"
+        (marg_position (fun pos _ -> pos));
+    ]
+    ~doc: "Locate the declaration of the type of the expression"
+    ~default:`None
+    begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Locate_type pos)
+    end
+  ;
+
   command "occurrences"
     ~spec: [
       arg "-identifier-at" "<position> Position to complete"

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -77,8 +77,10 @@ let dump (type a) : a t -> json =
       "position", mk_position pos;
     ]
 
-  | Locate_type _ ->
-    failwith "This isn't supported via the frontend"
+  | Locate_type pos ->
+    mk "locate-type" [
+      "position", mk_position pos
+    ]
 
   | Enclosing pos ->
     mk "enclosing" [
@@ -389,6 +391,11 @@ let json_of_response (type a) (query : a t) (response : a) : json =
              ~f:(fun loc -> with_location loc []))
   | Version, version ->
     `String version
-  | Locate_type _, _ ->
-    (* Impossible to reach as queries reach here only via LSP *)
-    assert false
+  | Locate_type _, locs ->
+    `List (
+      List.map locs ~f:(fun (t, pos) ->
+          match t with
+          | None ->
+            `Assoc ["pos", Lexing.json_of_position pos]
+          | Some file ->
+            `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]))

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -77,6 +77,9 @@ let dump (type a) : a t -> json =
       "position", mk_position pos;
     ]
 
+  | Type_definition _ ->
+    failwith "This isn't supported via the frontend"
+
   | Enclosing pos ->
     mk "enclosing" [
       "position", mk_position pos;
@@ -386,3 +389,6 @@ let json_of_response (type a) (query : a t) (response : a) : json =
              ~f:(fun loc -> with_location loc []))
   | Version, version ->
     `String version
+  | Type_definition _, _ ->
+    (* Impossible to reach as queries reach here only via LSP *)
+    assert false

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -77,7 +77,7 @@ let dump (type a) : a t -> json =
       "position", mk_position pos;
     ]
 
-  | Type_definition _ ->
+  | Locate_type _ ->
     failwith "This isn't supported via the frontend"
 
   | Enclosing pos ->
@@ -389,6 +389,6 @@ let json_of_response (type a) (query : a t) (response : a) : json =
              ~f:(fun loc -> with_location loc []))
   | Version, version ->
     `String version
-  | Type_definition _, _ ->
+  | Locate_type _, _ ->
     (* Impossible to reach as queries reach here only via LSP *)
     assert false

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -304,6 +304,26 @@ let rec json_of_shape { shape_loc; shape_sub } =
     "children", `List (List.map ~f:json_of_shape shape_sub);
   ]
 
+let json_of_locate resp =
+  match resp with
+  | `At_origin -> `String "Already at definition point"
+  | `Builtin s ->
+    `String (sprintf "%S is a builtin, and it is therefore impossible \
+                      to jump to its definition" s)
+  | `Invalid_context -> `String "Not a valid identifier"
+  | `Not_found (id, None) -> `String ("didn't manage to find " ^ id)
+  | `Not_found (i, Some f) ->
+    `String
+      (sprintf "%s was supposed to be in %s but could not be found" i f)
+  | `Not_in_env str ->
+    `String (Printf.sprintf "Not in environment '%s'" str)
+  | `File_not_found msg ->
+    `String msg
+  | `Found (None,pos) ->
+    `Assoc ["pos", Lexing.json_of_position pos]
+  | `Found (Some file,pos) ->
+    `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]
+
 let json_of_response (type a) (query : a t) (response : a) : json =
   match query, response with
   | Type_expr _, str -> `String str
@@ -337,46 +357,8 @@ let json_of_response (type a) (query : a t) (response : a) : json =
       | `Found doc ->
         `String doc
     end
-  | Locate_type _, resp ->
-    begin match resp with
-      | `At_origin -> `String "Already at definition point"
-      | `Builtin s ->
-        `String (sprintf "%S is a builtin, and it is therefore impossible \
-                          to jump to its definition" s)
-      | `Invalid_context -> `String "Not a valid identifier"
-      | `Not_found (id, None) -> `String ("didn't manage to find " ^ id)
-      | `Not_found (i, Some f) ->
-        `String
-          (sprintf "%s was supposed to be in %s but could not be found" i f)
-      | `Not_in_env str ->
-        `String (Printf.sprintf "Not in environment '%s'" str)
-      | `File_not_found msg ->
-        `String msg
-      | `Found (None,pos) ->
-        `Assoc ["pos", Lexing.json_of_position pos]
-      | `Found (Some file,pos) ->
-        `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]
-    end
-  | Locate _, resp ->
-    begin match resp with
-      | `At_origin -> `String "Already at definition point"
-      | `Builtin s ->
-        `String (sprintf "%S is a builtin, and it is therefore impossible \
-                          to jump to its definition" s)
-      | `Invalid_context -> `String "Not a valid identifier"
-      | `Not_found (id, None) -> `String ("didn't manage to find " ^ id)
-      | `Not_found (i, Some f) ->
-        `String
-          (sprintf "%s was supposed to be in %s but could not be found" i f)
-      | `Not_in_env str ->
-        `String (Printf.sprintf "Not in environment '%s'" str)
-      | `File_not_found msg ->
-        `String msg
-      | `Found (None,pos) ->
-        `Assoc ["pos", Lexing.json_of_position pos]
-      | `Found (Some file,pos) ->
-        `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]
-    end
+  | Locate_type _, resp -> json_of_locate resp
+  | Locate _, resp -> json_of_locate resp
   | Jump _, resp ->
     begin match resp with
       | `Error str ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -326,7 +326,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     in
     List.map ~f:Mbrowse.node_loc path
 
-  | Type_definition pos ->
+  | Locate_type pos ->
     let typer = Mpipeline.typer_result pipeline in
     let structures = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
     let pos = Mpipeline.get_lexing_pos pipeline pos in

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -333,7 +333,8 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     let path = Mbrowse.enclosing pos [structures] in
     let path =
       Std.List.filter_map path ~f:(fun (env, node) ->
-        Locate.log ~title:"debug" "inspecting node: %s" (Browse_raw.string_of_node node);
+        Locate.log ~title:"query_commands Locate_type"
+          "inspecting node: %s" (Browse_raw.string_of_node node);
         match node with
         | Browse_raw.Expression {exp_type = ty; _}
         | Pattern {pat_type = ty; _}

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -362,6 +362,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
       | `Invalid_context
       | `Missing_labels_namespace
       | `Not_found _
+      | `Builtin
       | `Not_in_env _ -> None)
 
   | Complete_prefix (prefix, pos, kinds, with_doc, with_types) ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -347,11 +347,12 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         | _ -> None
       )
     in
-    Std.List.filter_map path ~f:(fun (_env, path) ->
+    Std.List.filter_map path ~f:(fun (env, path) ->
       Locate.log ~title:"debug" "found type: %s" (Path.name path);
       let local_defs = Mtyper.get_typedtree typer in
       match
         Locate.from_path
+          ~env
           ~config:(Mpipeline.final_config pipeline)
           ~local_defs ~pos ~namespace:`Type `MLI
           path

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -336,24 +336,24 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         Locate.log ~title:"query_commands Locate_type"
           "inspecting node: %s" (Browse_raw.string_of_node node);
         match node with
-        | Browse_raw.Expression {exp_type = ty; exp_loc = loc; _}
-        | Pattern {pat_type = ty; pat_loc = loc; _}
-        | Core_type {ctyp_type = ty; ctyp_loc = loc; _}
-        | Value_description { val_desc = { ctyp_type = ty; _ }; val_loc = loc; _ } ->
+        | Browse_raw.Expression {exp_type = ty; _}
+        | Pattern {pat_type = ty; _}
+        | Core_type {ctyp_type = ty; _}
+        | Value_description { val_desc = { ctyp_type = ty; _ }; _ } ->
           begin match (Ctype.repr ty).desc with
-            | Tconstr (path, _, _) -> Some (env, loc, path)
+            | Tconstr (path, _, _) -> Some (env, path)
             | _ -> None
           end
         | _ -> None
       )
     in
-    Std.List.filter_map path ~f:(fun (_env, loc, path) ->
+    Std.List.filter_map path ~f:(fun (_env, path) ->
       Locate.log ~title:"debug" "found type: %s" (Path.name path);
       let local_defs = Mtyper.get_typedtree typer in
       match
         Locate.from_path
           ~config:(Mpipeline.final_config pipeline)
-          ~local_defs ~pos ~namespace:`Type ~loc `MLI
+          ~local_defs ~pos ~namespace:`Type `MLI
           path
       with
       | exception Env.Error _ -> None

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -336,24 +336,24 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         Locate.log ~title:"query_commands Locate_type"
           "inspecting node: %s" (Browse_raw.string_of_node node);
         match node with
-        | Browse_raw.Expression {exp_type = ty; _}
-        | Pattern {pat_type = ty; _}
-        | Core_type {ctyp_type = ty; _}
-        | Value_description { val_desc = { ctyp_type = ty; _ }; _ } ->
+        | Browse_raw.Expression {exp_type = ty; exp_loc = loc; _}
+        | Pattern {pat_type = ty; pat_loc = loc; _}
+        | Core_type {ctyp_type = ty; ctyp_loc = loc; _}
+        | Value_description { val_desc = { ctyp_type = ty; _ }; val_loc = loc; _ } ->
           begin match (Ctype.repr ty).desc with
-            | Tconstr (path, _, _) -> Some (env, path)
+            | Tconstr (path, _, _) -> Some (env, loc, path)
             | _ -> None
           end
         | _ -> None
       )
     in
-    Std.List.filter_map path ~f:(fun (_env, path) ->
+    Std.List.filter_map path ~f:(fun (_env, loc, path) ->
       Locate.log ~title:"debug" "found type: %s" (Path.name path);
       let local_defs = Mtyper.get_typedtree typer in
       match
         Locate.from_path
           ~config:(Mpipeline.final_config pipeline)
-          ~local_defs ~pos ~namespace:`Type `MLI
+          ~local_defs ~pos ~namespace:`Type ~loc `MLI
           path
       with
       | exception Env.Error _ -> None

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -361,6 +361,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
                 ~local_defs ~pos ~namespace:`Type `MLI
                 path with
         | `Builtin -> `Builtin (Path.name path)
+        | `Not_in_env _ as s -> s
         | `Not_found _ as s -> s
         | `Found _ as s -> s
         | `File_not_found _ as s -> s

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -349,20 +349,17 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         | _ -> None
       )
     in
-    Std.List.filter_map path ~f:(fun (env, path) ->
+    Std.List.filter_map path ~f:(fun (_env, path) ->
       Locate.log ~title:"debug" "found type: %s" (Path.name path);
       let local_defs = Mtyper.get_typedtree typer in
       match
-        Locate.from_string
+        Locate.from_path
           ~config:(Mpipeline.final_config pipeline)
-          ~env ~local_defs ~pos ~namespaces:[`Type] `MLI
-          (* FIXME: instead of converting to a string, pass it directly. *)
-          (Path.name path)
+          ~local_defs ~pos ~namespace:`Type `MLI
+          path
       with
       | exception Env.Error _ -> None
       | `Found (path, lex_position) -> Some (path, lex_position)
-      | `At_origin
-      | `Builtin _
       | `File_not_found _
       | `Invalid_context
       | `Missing_labels_namespace

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -131,7 +131,7 @@ type _ t =
        | `Not_found of string * string option
        | `No_documentation
        ] t
-  | Type_definition : Msource.position -> (string option * Lexing.position) list t
+  | Locate_type : Msource.position -> (string option * Lexing.position) list t
   | Locate(* *)
     : string option * [ `ML | `MLI ] * Msource.position
     -> [ `Found of string option * Lexing.position

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -131,6 +131,7 @@ type _ t =
        | `Not_found of string * string option
        | `No_documentation
        ] t
+  | Type_definition : Msource.position -> (string option * Lexing.position) list t
   | Locate(* *)
     : string option * [ `ML | `MLI ] * Msource.position
     -> [ `Found of string option * Lexing.position

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -131,7 +131,16 @@ type _ t =
        | `Not_found of string * string option
        | `No_documentation
        ] t
-  | Locate_type : Msource.position -> (string option * Lexing.position) list t
+  | Locate_type
+    : Msource.position
+      -> [ `Found of string option * Lexing.position
+         | `Invalid_context
+         | `Builtin of string
+         | `Not_in_env of string
+         | `File_not_found of string
+         | `Not_found of string * string option
+         | `At_origin
+         ] t
   | Locate(* *)
     : string option * [ `ML | `MLI ] * Msource.position
     -> [ `Found of string option * Lexing.position

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -645,6 +645,21 @@
 (alias (name runtest) (deps (alias locate-sig-substs-basic)))
 
 (alias
+ (name locate-type-run)
+ (deps (:t ./test-dirs/locate-type/run.t)
+       (source_tree ./test-dirs/locate-type)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/locate-type
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias locate-type-run)))
+
+(alias
  (name misc-external-arity)
  (deps (:t ./test-dirs/misc/external-arity.t)
        (source_tree ./test-dirs/misc)

--- a/tests/test-dirs/locate-type/a.ml
+++ b/tests/test-dirs/locate-type/a.ml
@@ -1,0 +1,7 @@
+module T = struct
+  type t = X of int
+end
+
+module Y = struct
+  let y = T.X 1
+end

--- a/tests/test-dirs/locate-type/run.t
+++ b/tests/test-dirs/locate-type/run.t
@@ -1,0 +1,15 @@
+
+  $ $MERLIN single locate-type -position 6:6 -filename ./a.ml < ./a.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "tests/test-dirs/locate-type/a.ml",
+        "pos": {
+          "line": 2,
+          "col": 2
+        }
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/locate-type/run.t
+++ b/tests/test-dirs/locate-type/run.t
@@ -2,14 +2,12 @@
   $ $MERLIN single locate-type -position 6:6 -filename ./a.ml < ./a.ml
   {
     "class": "return",
-    "value": [
-      {
-        "file": "tests/test-dirs/locate-type/a.ml",
-        "pos": {
-          "line": 2,
-          "col": 2
-        }
+    "value": {
+      "file": "tests/test-dirs/locate-type/a.ml",
+      "pos": {
+        "line": 2,
+        "col": 2
       }
-    ],
+    },
     "notifications": []
   }


### PR DESCRIPTION
The lsp frontend implements the ability to go to the type definition of
an expression. This requires some low level machinery, so it's moved to
merlin itself.