### PR TITLE
Print argument parsing errors

### DIFF
--- a/tests/test-dirs/locate/includes/test.t
+++ b/tests/test-dirs/locate/includes/test.t
@@ -6,7 +6,7 @@ in the environment to fallback to:
 Test when the include is a name, this should directly redirect us to the right
 thing.
 
-  $ $MERLIN single locate -look-for-mli -position 4:17 -filename test.ml < test.ml
+  $ $MERLIN single locate -look-for mli -position 4:17 -filename test.ml < test.ml
   {
     "class": "return",
     "value": {
@@ -22,7 +22,7 @@ thing.
 Test including a structure: there we will want to look up the ident again inside
 the structure, but the stamp will have changed:
 
-  $ $MERLIN single locate -look-for-mli -position 10:17 -filename test.ml < test.ml
+  $ $MERLIN single locate -look-for mli -position 10:17 -filename test.ml < test.ml
   {
     "class": "return",
     "value": {

--- a/tests/test-dirs/locate/issue845/test.t
+++ b/tests/test-dirs/locate/issue845/test.t
@@ -13,13 +13,13 @@ Test jumping to impl:
 
 FIXME: this jumps to the .mli...
 
-  $ $MERLIN single locate -look-for-ml -position 1:24 -filename test.ml <<EOF \
+  $ $MERLIN single locate -look-for ml -position 1:24 -filename test.ml <<EOF \
   > module SM = Local_map.Make(String) \
   > EOF
   {
     "class": "return",
     "value": {
-      "file": "tests/test-dirs/locate/issue845/local_map.mli",
+      "file": "tests/test-dirs/locate/issue845/local_map.ml",
       "pos": {
         "line": 1,
         "col": 0
@@ -30,7 +30,7 @@ FIXME: this jumps to the .mli...
 
 Test jumping to intf:
 
-  $ $MERLIN single locate -look-for-mli -position 1:24 -filename test.ml <<EOF \
+  $ $MERLIN single locate -look-for mli -position 1:24 -filename test.ml <<EOF \
   > module SM = Local_map.Make(String) \
   > EOF
   {

--- a/tests/test-dirs/motion/phrase.t
+++ b/tests/test-dirs/motion/phrase.t
@@ -1,4 +1,4 @@
-  $ $MERLIN single phrase next -position 1:0 -filename test.ml <<EOF \
+  $ $MERLIN single phrase -target next -position 1:0 -filename test.ml <<EOF \
   > let x = 5 \
   > let y = 2 \
   > EOF
@@ -15,7 +15,7 @@
 
 FIXME: ??
 
-  $ $MERLIN single phrase prev -position 2:0 -filename test.ml <<EOF \
+  $ $MERLIN single phrase -target prev -position 2:0 -filename test.ml <<EOF \
   > let x = 5 \
   > let y = 2 \
   > EOF
@@ -23,7 +23,7 @@ FIXME: ??
     "class": "return",
     "value": {
       "pos": {
-        "line": 3,
+        "line": 1,
         "col": 0
       }
     },


### PR DESCRIPTION
This should save people time debugging. It also caught some silent errors
in some tests. The commit history describes includes the details