### PR TITLE
Detect deprecation from attributes

### DIFF
--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -234,7 +234,7 @@ let make_candidate ~get_doc ~attrs ~exact ~prefix_path name ?loc ?path ty =
         end
       | _, _ -> `None
   in
-  let deprecated = false in
+  let deprecated = Type_utils.is_deprecated attrs in
   {name; kind; desc; info; deprecated}
 
 let item_for_global_module name =

--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -234,9 +234,11 @@ let make_candidate ~get_doc ~attrs ~exact ~prefix_path name ?loc ?path ty =
         end
       | _, _ -> `None
   in
-  {name; kind; desc; info}
+  let deprecated = false in
+  {name; kind; desc; info; deprecated}
 
-let item_for_global_module name = {name; kind = `Module; desc = `None; info = `None}
+let item_for_global_module name =
+  {name; kind = `Module; desc = `None; info = `None; deprecated = false}
 
 let fold_types f id env acc =
   Env.fold_types (fun s p (decl,_) acc -> f s p decl acc) id env acc
@@ -467,7 +469,7 @@ let complete_methods ~env ~prefix obj =
   let methods = List.filter ~f:has_prefix (methods_of_type env t) in
   List.map methods ~f:(fun (name,ty) ->
     let info = `None (* TODO: get documentation. *) in
-    { name; kind = `MethodCall; desc = `Type_scheme ty; info }
+    { name; kind = `MethodCall; desc = `Type_scheme ty; info; deprecated = false }
   )
 
 type is_label =
@@ -549,7 +551,8 @@ let complete_prefix ?get_doc ?target_type ?(kinds=[]) ~prefix ~is_label
       List.fold_left (Mconfig.global_modules config) ~init:compl ~f:(
         fun candidates name ->
           if not (String.no_double_underscore name) then candidates else
-          let default = { name; kind = `Module; desc = `None; info = `None } in
+          let default =
+            { name; kind = `Module; desc = `None; info = `None; deprecated = false } in
           if name = prefix && uniq (`Mod, name) then
             try
               let path, md, attrs = Type_utils.lookup_module (Longident.Lident name) env in

--- a/src/analysis/type_utils.ml
+++ b/src/analysis/type_utils.ml
@@ -311,3 +311,11 @@ let read_doc_attributes attrs =
     | [] -> None
   in
   loop (List.map ~f:Ast_helper.Attr.as_tuple attrs)
+
+let is_deprecated =
+  List.exists ~f:(fun (attr : Parsetree.attribute) ->
+      match Ast_helper.Attr.as_tuple attr with
+      | {Location.txt =
+           ("deprecated" | "ocaml.deprecated"); loc = _}, _ ->
+        true
+      | _ -> false)

--- a/src/analysis/type_utils.mli
+++ b/src/analysis/type_utils.mli
@@ -67,3 +67,5 @@ val lookup_module : Longident.t ->
 
 val read_doc_attributes : Parsetree.attributes -> (string * Location.t) option
 (** [read_doc_attributes] looks for a docstring in an attribute list. *)
+
+val is_deprecated : Parsetree.attributes -> bool

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -261,11 +261,12 @@ let json_of_error (error : Location.error) =
   ] in
   with_location ~skip_none:true loc content
 
-let json_of_completion {Compl. name; kind; desc; info} =
+let json_of_completion {Compl. name; kind; desc; info; deprecated} =
   `Assoc ["name", `String name;
           "kind", `String (string_of_completion_kind kind);
           "desc", `String desc;
-          "info", `String info]
+          "info", `String info;
+          "deprecated", `Bool deprecated]
 
 let json_of_completions {Compl. entries; context } =
   `Assoc [

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -430,7 +430,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
           let name = Format.flush_str_formatter () in
           Printtyp.type_scheme env Format.str_formatter v.Types.val_type;
           let desc = Format.flush_str_formatter () in
-          {Compl. name; kind = `Value; desc; info = "" }
+          {Compl. name; kind = `Value; desc; info = ""; deprecated = false }
         )
     in
     { Compl. entries ; context = `Unknown }

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -34,6 +34,7 @@ struct
            `Module|`Modtype|`Type|`MethodCall];
     desc: 'desc;
     info: 'desc;
+    deprecated: bool;
   }
 
   type entry = string raw_entry

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -1,20 +1,5 @@
 
 (alias
- (name completion-expansion)
- (deps (:t ./test-dirs/completion/expansion.t)
-       (source_tree ./test-dirs/completion)
-       %{bin:ocamlmerlin}
-       %{bin:ocamlmerlin-server})
- (action
-   (chdir ./test-dirs/completion
-     (setenv MERLIN %{exe:merlin-wrapper}
-     (setenv OCAMLC %{ocamlc}
-       (progn
-         (run %{bin:mdx} test --syntax=cram %{t})
-         (diff? %{t} %{t}.corrected)))))))
-(alias (name runtest) (deps (alias completion-expansion)))
-
-(alias
  (name completion-parenthesize)
  (deps (:t ./test-dirs/completion/parenthesize.t)
        (source_tree ./test-dirs/completion)

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -1,5 +1,20 @@
 
 (alias
+ (name completion-expansion)
+ (deps (:t ./test-dirs/completion/expansion.t)
+       (source_tree ./test-dirs/completion)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/completion
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias completion-expansion)))
+
+(alias
  (name completion-parenthesize)
  (deps (:t ./test-dirs/completion/parenthesize.t)
        (source_tree ./test-dirs/completion)
@@ -73,6 +88,21 @@
          (run %{bin:mdx} test --syntax=cram %{t})
          (diff? %{t} %{t}.corrected)))))))
 (alias (name runtest) (deps (alias config-path-expansion)))
+
+(alias
+ (name deprecation-run)
+ (deps (:t ./test-dirs/deprecation/run.t)
+       (source_tree ./test-dirs/deprecation)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/deprecation
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias deprecation-run)))
 
 (alias
  (name destruct-basic)

--- a/tests/test-dirs/completion/expansion.t
+++ b/tests/test-dirs/completion/expansion.t
@@ -5,97 +5,113 @@
       "name": "List.map",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.map2",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mapi",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem_assoc",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem_assq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.memq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.merge",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.map",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.map2",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mapi",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem_assoc",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem_assq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.memq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.merge",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     }
   ]
 
@@ -106,97 +122,113 @@
       "name": "List.map",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.map2",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mapi",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem_assoc",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.mem_assq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.memq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "List.merge",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.map",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.map2",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mapi",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem_assoc",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.mem_assq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.memq",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "ListLabels.merge",
       "kind": "Value",
       "desc": "",
-      "info": ""
+      "info": "",
+      "deprecated": false
     }
   ]
 

--- a/tests/test-dirs/completion/parenthesize.t
+++ b/tests/test-dirs/completion/parenthesize.t
@@ -5,42 +5,49 @@
       "name": "()",
       "kind": "Constructor",
       "desc": "MyList.u",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "(::)",
       "kind": "Constructor",
       "desc": "'a * 'a MyList.t -> 'a MyList.t",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "(mod)",
       "kind": "Value",
       "desc": "MyList.u",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "[]",
       "kind": "Constructor",
       "desc": "'a MyList.t",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "random",
       "kind": "Value",
       "desc": "int",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "t",
       "kind": "Type",
       "desc": "type 'a t = (::) of 'a * 'a MyList.t | []",
-      "info": ""
+      "info": "",
+      "deprecated": false
     },
     {
       "name": "u",
       "kind": "Type",
       "desc": "type u = ()",
-      "info": ""
+      "info": "",
+      "deprecated": false
     }
   ]

--- a/tests/test-dirs/deprecation/foo.mli
+++ b/tests/test-dirs/deprecation/foo.mli
@@ -1,0 +1,5 @@
+
+val bar : unit -> int
+[@@ocaml.deprecated "deprecation message"]
+
+val baz : unit -> unit

--- a/tests/test-dirs/deprecation/run.t
+++ b/tests/test-dirs/deprecation/run.t
@@ -1,0 +1,26 @@
+  $ echo "S .\nB .\nFLG -nopervasives" > .merlin
+  $ $OCAMLC -nopervasives -c -bin-annot foo.mli
+  $ $MERLIN single complete-prefix -position 2:14 -prefix Foo.ba -kind val -filename x.ml < x.ml
+  {
+    "class": "return",
+    "value": {
+      "entries": [
+        {
+          "name": "bar",
+          "kind": "Value",
+          "desc": "unit -> int",
+          "info": "",
+          "deprecated": false
+        },
+        {
+          "name": "baz",
+          "kind": "Value",
+          "desc": "unit -> unit",
+          "info": "",
+          "deprecated": false
+        }
+      ],
+      "context": null
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/deprecation/run.t
+++ b/tests/test-dirs/deprecation/run.t
@@ -10,7 +10,7 @@
           "kind": "Value",
           "desc": "unit -> int",
           "info": "",
-          "deprecated": false
+          "deprecated": true
         },
         {
           "name": "baz",

--- a/tests/test-dirs/deprecation/x.ml
+++ b/tests/test-dirs/deprecation/x.ml
@@ -1,0 +1,1 @@
+let x = Foo.ba

--- a/tests/test-dirs/polarity-search/older.t
+++ b/tests/test-dirs/polarity-search/older.t
@@ -20,29 +20,30 @@ We should probably rely on our own.
 There is less duplication than on versions >= 4.07, but there still is some.
 
   $ echo "" | $MERLIN single search-by-polarity -safe-string \
-  > -query "-int +string" -position 1:0 -filename test.ml | \
-  > head -n16
+  > -query "-int +string" -position 1:0 -filename test.ml | tr '\n' ' ' | \
+  > jq '.value.entries |= (map(del(.info) | del(.kind) | del (.deprecated)) | .[0:2])'
   {
     "class": "return",
     "value": {
       "entries": [
         {
           "name": "string_of_int",
-          "kind": "Value",
-          "desc": "int -> string",
-          "info": ""
+          "desc": "int -> string"
         },
         {
           "name": "string_of_int",
-          "kind": "Value",
-          "desc": "int -> string",
-          "info": ""
-        },
+          "desc": "int -> string"
+        }
+      ],
+      "context": null
+    },
+    "notifications": []
+  }
 
 - Lower bound on function arity
 
   $ echo "" | $MERLIN single search-by-polarity \
-  > -query "-float +fun +fun +float" -position 1:0 -filename test.ml | \
+  > -query "-float +fun +fun +float" -position 1:0 -filename test.ml | tr '\n' ' ' | \
   > jq '.value.entries[] | del(.info) | del(.kind) | del (.deprecated)'
   {
     "name": "**",

--- a/tests/test-dirs/polarity-search/older.t
+++ b/tests/test-dirs/polarity-search/older.t
@@ -7,7 +7,7 @@ We should probably rely on our own.
 
   $ echo "" | $MERLIN single search-by-polarity -query "-float +int64" \
   > -position 1:0 -filename test.ml | \
-  > jq '.value.entries[] | del(.info) | del(.kind)'
+  > jq '.value.entries[] | del(.info) | del(.kind) | del (.deprecated)'
   {
     "name": "Int64.bits_of_float",
     "desc": "float -> int64"
@@ -43,7 +43,7 @@ There is less duplication than on versions >= 4.07, but there still is some.
 
   $ echo "" | $MERLIN single search-by-polarity \
   > -query "-float +fun +fun +float" -position 1:0 -filename test.ml | \
-  > jq '.value.entries[] | del(.info) | del(.kind)'
+  > jq '.value.entries[] | del(.info) | del(.kind) | del (.deprecated)'
   {
     "name": "**",
     "desc": "float -> float -> float"

--- a/tests/test-dirs/polarity-search/recent.t
+++ b/tests/test-dirs/polarity-search/recent.t
@@ -8,22 +8,21 @@ A few simple tests that show all the things we want to preserve or improve:
 
   $ echo "" | $MERLIN single search-by-polarity -query "-float +int64" \
   > -position 1:0 -filename test.ml | \
-  > jq '.value.entries[] | del(.info) | del(.kind)'
+  > jq '.value.entries[] | del(.info) | del(.kind) | del(.deprecated)'
   {
     "name": "Stdlib__int64.bits_of_float",
-    "desc": "float -> int64",
-    "deprecated": false
+    "desc": "float -> int64"
   }
   {
     "name": "Stdlib__int64.of_float",
-    "desc": "float -> int64",
-    "deprecated": false
+    "desc": "float -> int64"
   }
 
 - Duplicated elements
 
   $ echo "" | $MERLIN single search-by-polarity -safe-string \
   > -query "-int +string" -position 1:0 -filename test.ml | \
+  > tr '\n' ' ' | jq '.value.entries[] |= del (.deprecated)' | \
   > head -n16
   {
     "class": "return",
@@ -33,14 +32,14 @@ A few simple tests that show all the things we want to preserve or improve:
           "name": "string_of_int",
           "kind": "Value",
           "desc": "int -> string",
-          "info": "",
-          "deprecated": false
+          "info": ""
         },
         {
           "name": "string_of_int",
           "kind": "Value",
           "desc": "int -> string",
-          "info": "",
+          "info": ""
+        },
 
 # To keep
 
@@ -48,52 +47,52 @@ A few simple tests that show all the things we want to preserve or improve:
 
   $ echo "" | $MERLIN single search-by-polarity \
   > -query "-float +fun +fun +float" -position 1:0 -filename test.ml | \
-  > tr '\n' ' ' | jq '.value.entries[] | del(.info) | del(.kind)' | head -n48
+  > tr '\n' ' ' | jq '.value.entries[] | del(.info) | del(.kind) | del (.deprecated)' | head -n48
   {
     "name": "**",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "**",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "*.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "*.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "+.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "+.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "-.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "-.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "/.",
-    "desc": "float -> float -> float",
-    "deprecated": false
+    "desc": "float -> float -> float"
   }
   {
     "name": "/.",
-    "desc": "float -> float -> float",
+    "desc": "float -> float -> float"
+  }
+  {
+    "name": "atan2",
+    "desc": "float -> float -> float"
+  }
+  {
+    "name": "atan2",
+    "desc": "float -> float -> float"
+  }

--- a/tests/test-dirs/polarity-search/recent.t
+++ b/tests/test-dirs/polarity-search/recent.t
@@ -22,8 +22,7 @@ A few simple tests that show all the things we want to preserve or improve:
 
   $ echo "" | $MERLIN single search-by-polarity -safe-string \
   > -query "-int +string" -position 1:0 -filename test.ml | \
-  > tr '\n' ' ' | jq '.value.entries[] |= del (.deprecated)' | \
-  > head -n16
+  > tr '\n' ' ' | jq '.value.entries |= (map(del(.deprecated)) | .[:2])'
   {
     "class": "return",
     "value": {
@@ -39,7 +38,12 @@ A few simple tests that show all the things we want to preserve or improve:
           "kind": "Value",
           "desc": "int -> string",
           "info": ""
-        },
+        }
+      ],
+      "context": null
+    },
+    "notifications": []
+  }
 
 # To keep
 
@@ -47,52 +51,57 @@ A few simple tests that show all the things we want to preserve or improve:
 
   $ echo "" | $MERLIN single search-by-polarity \
   > -query "-float +fun +fun +float" -position 1:0 -filename test.ml | \
-  > tr '\n' ' ' | jq '.value.entries[] | del(.info) | del(.kind) | del (.deprecated)' | head -n48
+  > tr '\n' ' ' | jq '.value.entries |= (map(del(.info) | del(.kind) | del (.deprecated)) | .[0:11])'
   {
-    "name": "**",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "**",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "*.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "*.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "+.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "+.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "-.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "-.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "/.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "/.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "atan2",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "atan2",
-    "desc": "float -> float -> float"
+    "class": "return",
+    "value": {
+      "entries": [
+        {
+          "name": "**",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "**",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "*.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "*.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "+.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "+.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "-.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "-.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "/.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "/.",
+          "desc": "float -> float -> float"
+        },
+        {
+          "name": "atan2",
+          "desc": "float -> float -> float"
+        }
+      ],
+      "context": null
+    },
+    "notifications": []
   }

--- a/tests/test-dirs/polarity-search/recent.t
+++ b/tests/test-dirs/polarity-search/recent.t
@@ -11,11 +11,13 @@ A few simple tests that show all the things we want to preserve or improve:
   > jq '.value.entries[] | del(.info) | del(.kind)'
   {
     "name": "Stdlib__int64.bits_of_float",
-    "desc": "float -> int64"
+    "desc": "float -> int64",
+    "deprecated": false
   }
   {
     "name": "Stdlib__int64.of_float",
-    "desc": "float -> int64"
+    "desc": "float -> int64",
+    "deprecated": false
   }
 
 - Duplicated elements
@@ -31,14 +33,14 @@ A few simple tests that show all the things we want to preserve or improve:
           "name": "string_of_int",
           "kind": "Value",
           "desc": "int -> string",
-          "info": ""
+          "info": "",
+          "deprecated": false
         },
         {
           "name": "string_of_int",
           "kind": "Value",
           "desc": "int -> string",
-          "info": ""
-        },
+          "info": "",
 
 # To keep
 
@@ -49,49 +51,49 @@ A few simple tests that show all the things we want to preserve or improve:
   > tr '\n' ' ' | jq '.value.entries[] | del(.info) | del(.kind)' | head -n48
   {
     "name": "**",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "**",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "*.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "*.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "+.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "+.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "-.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "-.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "/.",
-    "desc": "float -> float -> float"
+    "desc": "float -> float -> float",
+    "deprecated": false
   }
   {
     "name": "/.",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "atan2",
-    "desc": "float -> float -> float"
-  }
-  {
-    "name": "atan2",
-    "desc": "float -> float -> float"
-  }
+    "desc": "float -> float -> float",


### PR DESCRIPTION
LSP clients are able to display deprecated completion suggestions as ~~strike
through~~. Hence it's useful to pass this information through.

The current implementation is a bit too simplistic. We need to make sure that it
works for various completion suggestions.