### PR TITLE
Add reproduction case for punned field lookup

### DIFF
--- a/tests/test-dirs/locate/context-detection/field.ml
+++ b/tests/test-dirs/locate/context-detection/field.ml
@@ -5,3 +5,11 @@ let f t = t.foo
 let foo () = 3
 
 let f t = t.foo
+
+module X = struct
+  type t = { bar : int; baz : bool }
+end
+
+let bar = 123
+let baz = true
+let y = { X.bar ; baz }

--- a/tests/test-dirs/locate/context-detection/field.t
+++ b/tests/test-dirs/locate/context-detection/field.t
@@ -25,3 +25,31 @@
     "notifications": []
   }
 
+Merlin is confused by punned fields prefixed by the module. { X.bar } goes to
+the field bar rather than the identifier.
+  $ $MERLIN single locate -look-for ml -position 15:14 -filename ./field.ml < ./field.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/test-dirs/locate/context-detection/field.ml",
+      "pos": {
+        "line": 10,
+        "col": 2
+      }
+    },
+    "notifications": []
+  }
+
+Normal punning works as expected:
+  $ $MERLIN single locate -look-for ml -position 15:19 -filename ./field.ml < ./field.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "tests/test-dirs/locate/context-detection/field.ml",
+      "pos": {
+        "line": 14,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }


### PR DESCRIPTION
When looking up an identifier that is being punned to a field, this
confuses merlin.