### PR TITLE
Reproduce #949

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -435,6 +435,21 @@
 (alias (name runtest) (deps (alias locate-issue845-test)))
 
 (alias
+ (name locate-issue949-run)
+ (deps (:t ./test-dirs/locate/issue949/run.t)
+       (source_tree ./test-dirs/locate/issue949)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/locate/issue949
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias locate-issue949-run)))
+
+(alias
  (name locate-local-definitions-issue798)
  (deps (:t ./test-dirs/locate/local-definitions/issue798.t)
        (source_tree ./test-dirs/locate/local-definitions)

--- a/tests/test-dirs/locate/issue949/issue949.ml
+++ b/tests/test-dirs/locate/issue949/issue949.ml
@@ -1,0 +1,2 @@
+module A = struct let (+.) a b = a +. b end
+let f x = A.(x +. 1.)

--- a/tests/test-dirs/locate/issue949/run.t
+++ b/tests/test-dirs/locate/issue949/run.t
@@ -1,0 +1,8 @@
+This test is for testing the behavior of identifiers with a . in them:
+
+  $ $MERLIN single locate -look-for ml -position 2:16 ./issue949.ml < ./issue949.ml
+  {
+    "class": "return",
+    "value": "Not in environment ''",
+    "notifications": []
+  }


### PR DESCRIPTION
Looking up the definition of `+.` fails. This is because `Longident.parse` fails
to parse this identifier correctly.