### PR TITLE
Properly report syntax errors on 408 and 409

### DIFF
--- a/src/ocaml/parsing/408/pprintast.ml
+++ b/src/ocaml/parsing/408/pprintast.ml
@@ -1614,3 +1614,43 @@ let pattern = pattern reset_ctxt
 let signature = signature reset_ctxt
 let structure = structure reset_ctxt
 let case_list = case_list reset_ctxt
+
+let prepare_error err =
+  let open Syntaxerr in
+  match err with
+  | Unclosed(opening_loc, opening, closing_loc, closing) ->
+      Location.errorf
+        ~loc:closing_loc
+        ~sub:[
+          Location.msg ~loc:opening_loc
+            "This '%s' might be unmatched" opening
+        ]
+        "Syntax error: '%s' expected" closing
+
+  | Expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s expected." nonterm
+  | Not_expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s not expected." nonterm
+  | Applicative_path loc ->
+      Location.errorf ~loc
+        "Syntax error: applicative paths of the form F(X).t \
+         are not supported when the option -no-app-func is set."
+  | Variable_in_scope (loc, var) ->
+      Location.errorf ~loc
+        "In this scoped type, variable %a \
+         is reserved for the local type %s."
+        tyvar var var
+  | Other loc ->
+      Location.errorf ~loc "Syntax error"
+  | Ill_formed_ast (loc, s) ->
+      Location.errorf ~loc
+        "broken invariant in parsetree: %s" s
+  | Invalid_package_type (loc, s) ->
+      Location.errorf ~loc "invalid package type: %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Syntaxerr.Error err -> Some (prepare_error err)
+      | _ -> None
+    )

--- a/src/ocaml/parsing/409/pprintast.ml
+++ b/src/ocaml/parsing/409/pprintast.ml
@@ -1616,3 +1616,43 @@ let pattern = pattern reset_ctxt
 let signature = signature reset_ctxt
 let structure = structure reset_ctxt
 let case_list = case_list reset_ctxt
+
+let prepare_error err =
+  let open Syntaxerr in
+  match err with
+  | Unclosed(opening_loc, opening, closing_loc, closing) ->
+      Location.errorf
+        ~loc:closing_loc
+        ~sub:[
+          Location.msg ~loc:opening_loc
+            "This '%s' might be unmatched" opening
+        ]
+        "Syntax error: '%s' expected" closing
+
+  | Expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s expected." nonterm
+  | Not_expecting (loc, nonterm) ->
+      Location.errorf ~loc "Syntax error: %s not expected." nonterm
+  | Applicative_path loc ->
+      Location.errorf ~loc
+        "Syntax error: applicative paths of the form F(X).t \
+         are not supported when the option -no-app-func is set."
+  | Variable_in_scope (loc, var) ->
+      Location.errorf ~loc
+        "In this scoped type, variable %a \
+         is reserved for the local type %s."
+        tyvar var var
+  | Other loc ->
+      Location.errorf ~loc "Syntax error"
+  | Ill_formed_ast (loc, s) ->
+      Location.errorf ~loc
+        "broken invariant in parsetree: %s" s
+  | Invalid_package_type (loc, s) ->
+      Location.errorf ~loc "invalid package type: %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Syntaxerr.Error err -> Some (prepare_error err)
+      | _ -> None
+    )

--- a/src/ocaml/preprocess/409/parser_raw.mly
+++ b/src/ocaml/preprocess/409/parser_raw.mly
@@ -495,7 +495,7 @@ let class_of_let_bindings ~loc lbs body =
    the assertions below should be turned into explicit checks. *)
 let package_type_of_module_type pmty =
   let err loc s =
-    raise (Syntaxerr.Error (Syntaxerr.Invalid_package_type (loc, s)))
+    raise_error (Syntaxerr.Error (Syntaxerr.Invalid_package_type (loc, s)))
   in
   let map_cstr = function
     | Pwith_type (lid, ptyp) ->
@@ -508,24 +508,24 @@ let package_type_of_module_type pmty =
           err loc "private types are not supported";
 
         (* restrictions below are checked by the 'with_constraint' rule *)
-        assert (ptyp.ptype_kind = Ptype_abstract);
-        assert (ptyp.ptype_attributes = []);
-        let ty =
-          match ptyp.ptype_manifest with
-          | Some ty -> ty
-          | None -> assert false
-        in
-        (lid, ty)
+        (* assert (ptyp.ptype_kind = Ptype_abstract); *)
+        (* assert (ptyp.ptype_attributes = []); *)
+        begin match ptyp.ptype_manifest with
+        | Some ty -> Some (lid, ty)
+        | None -> None
+        end
     | _ ->
-        err pmty.pmty_loc "only 'with type t =' constraints are supported"
+        err pmty.pmty_loc "only 'with type t =' constraints are supported";
+        None
   in
   match pmty with
   | {pmty_desc = Pmty_ident lid} -> (lid, [])
   | {pmty_desc = Pmty_with({pmty_desc = Pmty_ident lid}, cstrs)} ->
-      (lid, List.map map_cstr cstrs)
+      (lid, List.filter_map map_cstr cstrs)
   | _ ->
       err pmty.pmty_loc
-        "only module type identifier and 'with type' constraints are supported"
+        "only module type identifier and 'with type' constraints are supported";
+      (Location.mkloc (Lident "_") pmty.pmty_loc, [])
 
 let mk_directive_arg ~loc k =
   { pdira_desc = k;

--- a/tests/test-dirs/no-escape/test.t
+++ b/tests/test-dirs/no-escape/test.t
@@ -211,3 +211,57 @@ unused case after
     "notifications": []
   }
 
+Syntax errors also shouldn't escape:
+
+  $ echo "let f (_ : (module S with type 'a t = int)) = ()" | \
+  > $MERLIN single errors -filename "invalid_package_type.ml"
+  {
+    "class": "exception",
+    "value": "Syntaxerr.Error(_)
+  Raised at file \"src/ocaml/preprocess/parser_raw.mly\", line 498, characters 4-69
+  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 504, characters 10-56
+  Called from file \"list.ml\", line 92, characters 20-23
+  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 525, characters 12-35
+  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 3325, characters 21-53
+  Called from file \"src/utils/menhirLib.ml\", line 1885, characters 18-44
+  Called from file \"src/utils/std.ml\", line 93, characters 17-25
+  Called from file \"src/kernel/mreader_recover.ml\", line 210, characters 10-57
+  Called from file \"src/kernel/mreader_recover.ml\", line 248, characters 28-38
+  Called from file \"src/kernel/mreader_parser.ml\", line 130, characters 21-35
+  Called from file \"src/kernel/mreader_parser.ml\", line 175, characters 20-48
+  Called from file \"src/kernel/mreader_parser.ml\", line 190, characters 6-42
+  Called from file \"src/ocaml/utils/misc.ml\", line 62, characters 8-15
+  Re-raised at file \"src/ocaml/utils/misc.ml\", line 79, characters 10-24
+  Called from file \"src/kernel/mreader_parser.ml\", line 204, characters 20-56
+  Called from file \"src/kernel/mreader.ml\", line 49, characters 15-77
+  Called from file \"src/kernel/mpipeline.ml\", line 134, characters 19-62
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
+  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
+  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
+  Called from file \"src/kernel/mpipeline.ml\", line 104, characters 21-30
+  Called from file \"src/frontend/query_commands.ml\", line 587, characters 16-47
+  Called from file \"src/frontend/ocamlmerlin/new/new_commands.ml\", line 64, characters 15-53
+  Called from file \"src/utils/std.ml\", line 679, characters 8-12
+  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
+  Called from file \"src/ocaml/utils/misc.ml\", line 62, characters 8-15
+  Re-raised at file \"src/ocaml/utils/misc.ml\", line 79, characters 10-24
+  Called from file \"src/utils/local_store.ml\", line 42, characters 8-12
+  Re-raised at file \"src/utils/local_store.ml\", line 52, characters 4-15
+  Called from file \"src/kernel/mocaml.ml\", line 18, characters 8-38
+  Re-raised at file \"src/kernel/mocaml.ml\", line 20, characters 42-53
+  Called from file \"src/frontend/ocamlmerlin/new/new_merlin.ml\", line 100, characters 14-110
+  ",
+    "notifications": []
+  }

--- a/tests/test-dirs/no-escape/test.t
+++ b/tests/test-dirs/no-escape/test.t
@@ -216,52 +216,36 @@ Syntax errors also shouldn't escape:
   $ echo "let f (_ : (module S with type 'a t = int)) = ()" | \
   > $MERLIN single errors -filename "invalid_package_type.ml"
   {
-    "class": "exception",
-    "value": "Syntaxerr.Error(_)
-  Raised at file \"src/ocaml/preprocess/parser_raw.mly\", line 498, characters 4-69
-  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 504, characters 10-56
-  Called from file \"list.ml\", line 92, characters 20-23
-  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 525, characters 12-35
-  Called from file \"src/ocaml/preprocess/parser_raw.mly\", line 3325, characters 21-53
-  Called from file \"src/utils/menhirLib.ml\", line 1885, characters 18-44
-  Called from file \"src/utils/std.ml\", line 93, characters 17-25
-  Called from file \"src/kernel/mreader_recover.ml\", line 210, characters 10-57
-  Called from file \"src/kernel/mreader_recover.ml\", line 248, characters 28-38
-  Called from file \"src/kernel/mreader_parser.ml\", line 130, characters 21-35
-  Called from file \"src/kernel/mreader_parser.ml\", line 175, characters 20-48
-  Called from file \"src/kernel/mreader_parser.ml\", line 190, characters 6-42
-  Called from file \"src/ocaml/utils/misc.ml\", line 62, characters 8-15
-  Re-raised at file \"src/ocaml/utils/misc.ml\", line 79, characters 10-24
-  Called from file \"src/kernel/mreader_parser.ml\", line 204, characters 20-56
-  Called from file \"src/kernel/mreader.ml\", line 49, characters 15-77
-  Called from file \"src/kernel/mpipeline.ml\", line 134, characters 19-62
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Re-raised at file \"src/kernel/mpipeline.ml\", line 19, characters 34-49
-  Called from file \"camlinternalLazy.ml\", line 31, characters 17-27
-  Re-raised at file \"camlinternalLazy.ml\", line 36, characters 4-11
-  Called from file \"src/kernel/mpipeline.ml\", line 104, characters 21-30
-  Called from file \"src/frontend/query_commands.ml\", line 587, characters 16-47
-  Called from file \"src/frontend/ocamlmerlin/new/new_commands.ml\", line 64, characters 15-53
-  Called from file \"src/utils/std.ml\", line 679, characters 8-12
-  Re-raised at file \"src/utils/std.ml\", line 681, characters 30-39
-  Called from file \"src/ocaml/utils/misc.ml\", line 62, characters 8-15
-  Re-raised at file \"src/ocaml/utils/misc.ml\", line 79, characters 10-24
-  Called from file \"src/utils/local_store.ml\", line 42, characters 8-12
-  Re-raised at file \"src/utils/local_store.ml\", line 52, characters 4-15
-  Called from file \"src/kernel/mocaml.ml\", line 18, characters 8-38
-  Re-raised at file \"src/kernel/mocaml.ml\", line 20, characters 42-53
-  Called from file \"src/frontend/ocamlmerlin/new/new_merlin.ml\", line 100, characters 14-110
-  ",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 11
+        },
+        "end": {
+          "line": 1,
+          "col": 42
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module type S"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 26
+        },
+        "end": {
+          "line": 1,
+          "col": 41
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "invalid package type: parametrized types are not supported"
+      }
+    ],
     "notifications": []
   }


### PR DESCRIPTION
Before this PR:
- one error was never caught on 409 (i.e. the exception & backtrace reached the user).
- some errors were caught and never reported on both 408 and 409.