### PR TITLE
Fix short-paths for 409

### DIFF
--- a/src/ocaml/typing/409/env.ml
+++ b/src/ocaml/typing/409/env.ml
@@ -631,44 +631,11 @@ type persistent_module = {
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
-
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
-(* FIXME
-let register_pers_for_short_paths ps =
-  let deps, alias_deps =
-    List.fold_left
-      (fun (deps, alias_deps) (name, digest) ->
-         Short_paths.Basis.add !short_paths_basis name;
-         match digest with
-         | None -> deps, name :: alias_deps
-         | Some _ -> name :: deps, alias_deps)
-      ([], []) ps.ps_crcs
-  in
-  let path = Pident (Ident.create_persistent ps.ps_name) in
-  let components =
-    lazy (!short_paths_module_components_desc' empty path ps.ps_comps)
-  in
-  let desc =
-    Short_paths.Desc.Module.(Fresh (Signature components))
-  in
-  let is_deprecated =
-    List.exists
-      (function
-        | Alerts alerts ->
-          String.Map.mem "deprecated" alerts ||
-          String.Map.mem "ocaml.deprecated" alerts
-        | _ -> false)
-      ps.ps_flags
-  in
-  let deprecated =
-    if is_deprecated then Short_paths.Desc.Deprecated
-    else Short_paths.Desc.Not_deprecated
-  in
-  Short_paths.Basis.load !short_paths_basis ps.ps_name
-    deps alias_deps desc deprecated
-*)
+let short_paths_components name pm =
+  let path = Pident (Ident.create_persistent name) in
+  lazy (!short_paths_module_components_desc' empty path pm.pm_components)
 
 exception Cmi_cache_store of signature lazy_t
 
@@ -732,16 +699,20 @@ let import_crcs ~source crcs =
   Persistent_env.import_crcs !persistent_env ~source crcs
 
 let read_pers_mod modname filename =
-  Persistent_env.read !persistent_env read_sign_of_cmi modname filename
+  Persistent_env.read !persistent_env
+    read_sign_of_cmi short_paths_components modname filename
 
 let find_pers_mod name =
-  Persistent_env.find !persistent_env read_sign_of_cmi name
+  Persistent_env.find !persistent_env
+    read_sign_of_cmi short_paths_components name
 
 let check_pers_mod ~loc name =
-  Persistent_env.check !persistent_env read_sign_of_cmi ~loc name
+  Persistent_env.check !persistent_env
+    read_sign_of_cmi short_paths_components ~loc name
 
 let crc_of_unit name =
-  Persistent_env.crc_of_unit !persistent_env read_sign_of_cmi name
+  Persistent_env.crc_of_unit !persistent_env
+    read_sign_of_cmi short_paths_components name
 
 let is_imported_opaque modname =
   Persistent_env.is_imported_opaque !persistent_env modname
@@ -2816,7 +2787,8 @@ let update_short_paths env =
   let env, short_paths =
     match env.short_paths with
     | None ->
-      let short_paths = Short_paths.initial !short_paths_basis in
+      let basis = Persistent_env.short_paths_basis !persistent_env in
+      let short_paths = Short_paths.initial basis in
       let env = { env with short_paths = Some short_paths } in
       env, short_paths
     | Some short_paths -> env, short_paths
@@ -2833,7 +2805,9 @@ let update_short_paths env =
 
 let short_paths env =
   match env.short_paths with
-  | None -> Short_paths.initial !short_paths_basis
+  | None ->
+    let basis = Persistent_env.short_paths_basis !persistent_env in
+    Short_paths.initial basis
   | Some short_paths -> short_paths
 
 (* Make the initial environment *)

--- a/src/ocaml/typing/409/persistent_env.ml
+++ b/src/ocaml/typing/409/persistent_env.ml
@@ -71,6 +71,7 @@ type 'a t = {
   imported_opaque_units: String.Set.t ref;
   crc_units: Consistbl.t;
   can_load_cmis: can_load_cmis ref;
+  short_paths_basis: Short_paths.Basis.t ref;
 }
 
 let empty () = {
@@ -79,6 +80,7 @@ let empty () = {
   imported_opaque_units = ref String.Set.empty;
   crc_units = Consistbl.create ();
   can_load_cmis = ref Can_load_cmis;
+  short_paths_basis = ref (Short_paths.Basis.create ());
 }
 
 let clear penv =
@@ -88,12 +90,14 @@ let clear penv =
     imported_opaque_units;
     crc_units;
     can_load_cmis;
+    short_paths_basis;
   } = penv in
   Hashtbl.clear persistent_structures;
   imported_units := String.Set.empty;
   imported_opaque_units := String.Set.empty;
   Consistbl.clear crc_units;
   can_load_cmis := Can_load_cmis;
+  short_paths_basis := Short_paths.Basis.create ();
   ()
 
 let clear_missing {persistent_structures; _} =
@@ -135,6 +139,8 @@ let can_load_cmis penv =
   !(penv.can_load_cmis)
 let set_can_load_cmis penv setting =
   penv.can_load_cmis := setting
+let short_paths_basis penv =
+  !(penv.short_paths_basis)
 
 let without_cmis penv f x =
   let log = EnvLazy.log () in
@@ -152,6 +158,36 @@ let fold {persistent_structures; _} f x =
       | Found (_, pm) -> f modname pm x)
     persistent_structures x
 
+let register_pers_for_short_paths penv ps components =
+  let deps, alias_deps =
+    List.fold_left
+      (fun (deps, alias_deps) (name, digest) ->
+         Short_paths.Basis.add (short_paths_basis penv) name;
+         match digest with
+         | None -> deps, name :: alias_deps
+         | Some _ -> name :: deps, alias_deps)
+      ([], []) ps.ps_crcs
+  in
+  let desc =
+    Short_paths.Desc.Module.(Fresh (Signature components))
+  in
+  let is_deprecated =
+    List.exists
+      (function
+        | Alerts alerts ->
+          String.Map.mem "deprecated" alerts ||
+          String.Map.mem "ocaml.deprecated" alerts
+        | _ -> false)
+      ps.ps_flags
+  in
+  let deprecated =
+    if is_deprecated then Short_paths.Desc.Deprecated
+    else Short_paths.Desc.Not_deprecated
+  in
+  Short_paths.Basis.load (short_paths_basis penv) ps.ps_name
+    deps alias_deps desc deprecated
+
+
 (* Reading persistent structures from .cmi files *)
 
 let save_pers_struct penv crc ps pm =
@@ -168,7 +204,7 @@ let save_pers_struct penv crc ps pm =
   Consistbl.set crc_units modname crc ps.ps_filename;
   add_import penv modname
 
-let acknowledge_pers_struct penv check modname pers_sig pm =
+let acknowledge_pers_struct penv short_path_comps check modname pers_sig pm =
   let { Persistent_signature.filename; cmi } = pers_sig in
   let name = cmi.cmi_name in
   let crcs = cmi.cmi_crcs in
@@ -194,17 +230,21 @@ let acknowledge_pers_struct penv check modname pers_sig pm =
   if check then check_consistency penv ps;
   let {persistent_structures; _} = penv in
   Hashtbl.add persistent_structures modname (Found (ps, pm));
+  register_pers_for_short_paths penv ps (short_path_comps ps.ps_name pm);
   ps
 
-let read_pers_struct penv val_of_pers_sig check modname filename =
+let read_pers_struct
+      penv val_of_pers_sig short_path_comps check modname filename =
   add_import penv modname;
   let {Cmi_cache. cmi; cmi_cache} = Cmi_cache.read filename in
   let pers_sig = { Persistent_signature.filename; cmi; cmi_cache } in
   let pm = val_of_pers_sig pers_sig in
-  let ps = acknowledge_pers_struct penv check modname pers_sig pm in
+  let ps =
+    acknowledge_pers_struct penv short_path_comps check modname pers_sig pm
+  in
   (ps, pm)
 
-let find_pers_struct penv val_of_pers_sig check name =
+let find_pers_struct penv val_of_pers_sig short_path_comps check name =
   let {persistent_structures; _} = penv in
   if name = "*predef*" then raise Not_found;
   match Hashtbl.find persistent_structures name with
@@ -223,13 +263,13 @@ let find_pers_struct penv val_of_pers_sig check name =
         in
         add_import penv name;
         let pm = val_of_pers_sig psig in
-        let ps = acknowledge_pers_struct penv check name psig pm in
+        let ps = acknowledge_pers_struct penv short_path_comps check name psig pm in
         (ps, pm)
 
 (* Emits a warning if there is no valid cmi for name *)
-let check_pers_struct penv f ~loc name =
+let check_pers_struct penv f1 f2 ~loc name =
   try
-    ignore (find_pers_struct penv f false name)
+    ignore (find_pers_struct penv f1 f2 false name)
   with
   | Not_found ->
       let warn = Warnings.No_cmi_file(name, None) in
@@ -258,13 +298,13 @@ let check_pers_struct penv f ~loc name =
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning loc warn
 
-let read penv f modname filename =
-  snd (read_pers_struct penv f true modname filename)
+let read penv f1 f2 modname filename =
+  snd (read_pers_struct penv f1 f2 true modname filename)
 
-let find penv f name =
-  snd (find_pers_struct penv f true name)
+let find penv f1 f2 name =
+  snd (find_pers_struct penv f1 f2 true name)
 
-let check penv f ~loc name =
+let check penv f1 f2 ~loc name =
   let {persistent_structures; _} = penv in
   if not (Hashtbl.mem persistent_structures name) then begin
     (* PR#6843: record the weak dependency ([add_import]) regardless of
@@ -273,11 +313,11 @@ let check penv f ~loc name =
     add_import penv name;
     if (Warnings.is_active (Warnings.No_cmi_file("", None))) then
       !add_delayed_check_forward
-        (fun () -> check_pers_struct penv f ~loc name)
+        (fun () -> check_pers_struct penv f1 f2 ~loc name)
   end
 
-let crc_of_unit penv f name =
-  let (ps, _pm) = find_pers_struct penv f true name in
+let crc_of_unit penv f1 f2 name =
+  let (ps, _pm) = find_pers_struct penv f1 f2 true name in
   let crco =
     try
       List.assoc name ps.ps_crcs

--- a/src/ocaml/typing/409/persistent_env.mli
+++ b/src/ocaml/typing/409/persistent_env.mli
@@ -50,19 +50,24 @@ type 'a t
 
 val empty : unit -> 'a t
 
+val short_paths_basis : 'a t -> Short_paths.Basis.t
+
 val clear : 'a t -> unit
 val clear_missing : 'a t -> unit
 
 val fold : 'a t -> (modname -> 'a -> 'b -> 'b) -> 'b -> 'b
 
 val read : 'a t -> (Persistent_signature.t -> 'a)
+  -> (string -> 'a -> Short_paths.Desc.Module.components Lazy.t)
   -> modname -> filepath -> 'a
 val find : 'a t -> (Persistent_signature.t -> 'a)
+  -> (string -> 'a -> Short_paths.Desc.Module.components Lazy.t)
   -> modname -> 'a
 
 val find_in_cache : 'a t -> modname -> 'a option
 
 val check : 'a t -> (Persistent_signature.t -> 'a)
+  -> (string -> 'a -> Short_paths.Desc.Module.components Lazy.t)
   -> loc:Location.t -> modname -> unit
 
 (* [looked_up penv md] checks if one has already tried
@@ -96,7 +101,9 @@ val import_crcs : 'a t -> source:filepath -> crcs -> unit
 val imports : 'a t -> crcs
 
 (* Return the CRC of the interface of the given compilation unit *)
-val crc_of_unit: 'a t -> (Persistent_signature.t -> 'a) -> modname -> Digest.t
+val crc_of_unit: 'a t -> (Persistent_signature.t -> 'a)
+  -> (string -> 'a -> Short_paths.Desc.Module.components Lazy.t)
+  -> modname -> Digest.t
 
 (* Forward declaration to break mutual recursion with Typecore. *)
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref

--- a/tests/test-dirs/short-paths/dep.mli
+++ b/tests/test-dirs/short-paths/dep.mli
@@ -1,0 +1,4 @@
+
+module M : sig type t end
+
+type t = M.t

--- a/tests/test-dirs/short-paths/test.ml
+++ b/tests/test-dirs/short-paths/test.ml
@@ -84,3 +84,7 @@ module Bar = Functor (struct
 
     let foo _i = "haha"
   end)
+
+(* #1082 *)
+
+let x : Dep.M.t = 5

--- a/tests/test-dirs/short-paths/test.t
+++ b/tests/test-dirs/short-paths/test.t
@@ -1,3 +1,5 @@
+  $ $OCAMLC -c dep.mli
+
   $ $MERLIN single errors -filename test.ml < test.ml
   {
     "class": "return",
@@ -172,6 +174,20 @@
     val foo : int -> t
   File \"test.ml\", line 72, characters 2-20: Expected declaration
   File \"test.ml\", line 85, characters 8-11: Actual declaration"
+      },
+      {
+        "start": {
+          "line": 90,
+          "col": 18
+        },
+        "end": {
+          "line": 90,
+          "col": 19
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This expression has type int but an expression was expected of type Dep.M.t"
       }
     ],
     "notifications": []
@@ -351,6 +367,20 @@
     val foo : t -> t
   File \"test.ml\", line 72, characters 2-20: Expected declaration
   File \"test.ml\", line 85, characters 8-11: Actual declaration"
+      },
+      {
+        "start": {
+          "line": 90,
+          "col": 18
+        },
+        "end": {
+          "line": 90,
+          "col": 19
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This expression has type int but an expression was expected of type Dep.M.t"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/short-paths/test.t
+++ b/tests/test-dirs/short-paths/test.t
@@ -380,7 +380,7 @@
         "type": "typer",
         "sub": [],
         "valid": true,
-        "message": "This expression has type int but an expression was expected of type Dep.M.t"
+        "message": "This expression has type int but an expression was expected of type Dep.t"
       }
     ],
     "notifications": []


### PR DESCRIPTION
The 4.09 short-paths code had a FIXME. This PR fixes it.

Without this PR, `-short-paths` does not have access to any information from .cmi files -- so it doesn't work very well.