### PR TITLE
Include the stdlib in the source path

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -751,11 +751,13 @@ let document_arguments oc =
   print_doc findlib_flags;
   output_string oc "Flags accepted by ocamlc and ocamlopt but not affecting merlin will be ignored.\n"
 
-let source_path config = (
-  config.query.directory ::
-  config.merlin.source_path @
-  config.merlin.packages_path
-)
+let source_path config =
+  let stdlib = if config.ocaml.no_std_include then [] else [stdlib config] in
+  List.concat
+    [[config.query.directory];
+     stdlib;
+     config.merlin.source_path;
+     config.merlin.packages_path]
 
 let build_path config = (
   let dirs =


### PR DESCRIPTION
Currently locate won't jump to locations in the standard library because it is not part of the source path.

Arguably the stdlib directory is a build directory not a source directory, but since it includes the `.mli` files alongside the `.cmti` files it makes sense to treat it as if it were a source directory.