### PR TITLE
Fix wrong type information for constructors under type coercions

### DIFF
--- a/src/ocaml/merlin_specific/402/browse_raw.ml
+++ b/src/ocaml/merlin_specific/402/browse_raw.ml
@@ -232,10 +232,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_open _ | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
 let of_module_expr me = app (Module_expr me)
@@ -327,16 +337,6 @@ let of_expression_desc loc = function
     app (Class_structure cs)
   | Texp_pack me ->
     of_module_expr me
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_open _ | Texp_newtype _ ->
-    id_fold
 
 and of_class_expr_desc = function
   | Tcl_ident (_,_,cts) ->
@@ -496,9 +496,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/src/ocaml/merlin_specific/403/browse_raw.ml
+++ b/src/ocaml/merlin_specific/403/browse_raw.ml
@@ -232,10 +232,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_open _ | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_label_declaration ct = app (Label_declaration ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
@@ -332,16 +342,6 @@ let of_expression_desc loc = function
   | Texp_pack me ->
     of_module_expr me
   | Texp_unreachable | Texp_extension_constructor _ ->
-    id_fold
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_open _ | Texp_newtype _ ->
     id_fold
 
 and of_class_expr_desc = function
@@ -502,9 +502,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/src/ocaml/merlin_specific/404/browse_raw.ml
+++ b/src/ocaml/merlin_specific/404/browse_raw.ml
@@ -239,10 +239,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_open _ | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_label_declaration ct = app (Label_declaration ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
@@ -345,16 +355,6 @@ let of_expression_desc loc = function
   | Texp_pack me ->
     of_module_expr me
   | Texp_unreachable | Texp_extension_constructor _ ->
-    id_fold
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_open _ | Texp_newtype _ ->
     id_fold
 
 and of_class_expr_desc = function
@@ -515,9 +515,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/src/ocaml/merlin_specific/405/browse_raw.ml
+++ b/src/ocaml/merlin_specific/405/browse_raw.ml
@@ -239,10 +239,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_open _ | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_label_declaration ct = app (Label_declaration ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
@@ -345,16 +355,6 @@ let of_expression_desc loc = function
   | Texp_pack me ->
     of_module_expr me
   | Texp_unreachable | Texp_extension_constructor _ ->
-    id_fold
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_open _ | Texp_newtype _ ->
     id_fold
 
 and of_class_expr_desc = function
@@ -515,9 +515,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/src/ocaml/merlin_specific/408/browse_raw.ml
+++ b/src/ocaml/merlin_specific/408/browse_raw.ml
@@ -240,10 +240,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_label_declaration ct = app (Label_declaration ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
@@ -357,16 +367,6 @@ let of_expression_desc loc = function
     of_case body
   | Texp_open (od, e) ->
     app (Module_expr od.open_expr) ** of_expression e
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_newtype _ ->
-    id_fold
 
 and of_class_expr_desc = function
   | Tcl_ident (_,_,cts) ->
@@ -540,9 +540,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/src/ocaml/merlin_specific/409/browse_raw.ml
+++ b/src/ocaml/merlin_specific/409/browse_raw.ml
@@ -240,10 +240,20 @@ let option_fold f' o env (f : _ f0) acc = match o with
   | None -> acc
   | Some x -> f' x env f acc
 
-let of_expression e = app (Expression e)
+let of_core_type ct = app (Core_type ct)
+let of_exp_extra (exp,_,_) = match exp with
+  | Texp_constraint ct ->
+    of_core_type ct
+  | Texp_coerce (cto,ct) ->
+    of_core_type ct ** option_fold of_core_type cto
+  | Texp_poly cto ->
+    option_fold of_core_type cto
+  | Texp_newtype _ ->
+    id_fold
+let of_expression e = app (Expression e) **
+    list_fold of_exp_extra e.exp_extra
 let of_case c = app (Case c)
 let of_pattern p = app (Pattern p)
-let of_core_type ct = app (Core_type ct)
 let of_label_declaration ct = app (Label_declaration ct)
 let of_value_binding vb = app (Value_binding vb)
 let of_module_type mt = app (Module_type mt)
@@ -357,16 +367,6 @@ let of_expression_desc loc = function
     of_case body
   | Texp_open (od, e) ->
     app (Module_expr od.open_expr) ** of_expression e
-
-and of_exp_extra (exp,_,_) = match exp with
-  | Texp_constraint ct ->
-    of_core_type ct
-  | Texp_coerce (cto,ct) ->
-    of_core_type ct ** option_fold of_core_type cto
-  | Texp_poly cto ->
-    option_fold of_core_type cto
-  | Texp_newtype _ ->
-    id_fold
 
 and of_class_expr_desc = function
   | Tcl_ident (_,_,cts) ->
@@ -540,9 +540,8 @@ let of_node = function
   | Pattern { pat_desc; pat_extra } ->
     of_pattern_desc pat_desc **
     list_fold of_pat_extra pat_extra
-  | Expression { exp_desc; exp_extra; exp_loc } ->
-    of_expression_desc exp_loc exp_desc **
-    list_fold of_exp_extra exp_extra
+  | Expression { exp_desc; exp_extra=_; exp_loc } ->
+    of_expression_desc exp_loc exp_desc
   | Case { c_lhs; c_guard; c_rhs } ->
     of_pattern c_lhs ** of_expression c_rhs **
     option_fold of_expression c_guard

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -810,6 +810,21 @@
 (alias (name runtest) (deps (alias short-paths-test)))
 
 (alias
+ (name type-enclosing-cons)
+ (deps (:t ./test-dirs/type-enclosing/cons.t)
+       (source_tree ./test-dirs/type-enclosing)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/type-enclosing
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias type-enclosing-cons)))
+
+(alias
  (name type-enclosing-letop)(enabled_if (>= %{ocaml_version} 4.08.0))
  (deps (:t ./test-dirs/type-enclosing/letop.t)
        (source_tree ./test-dirs/type-enclosing)

--- a/tests/test-dirs/type-enclosing/cons.ml
+++ b/tests/test-dirs/type-enclosing/cons.ml
@@ -1,0 +1,15 @@
+type t = U
+type t' = U
+
+let f : t  = U
+
+let g (x : t) =
+  match x with
+  | U -> ()
+
+module M = struct
+  type t = A
+  type u = A | B
+end
+
+let f () = (M.A : M.t);

--- a/tests/test-dirs/type-enclosing/cons.t
+++ b/tests/test-dirs/type-enclosing/cons.t
@@ -1,0 +1,126 @@
+Various parts of the cons.ml:
+
+- The expression:
+  $ $MERLIN single type-enclosing -position 4:14 -verbosity 0 \
+  > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 4,
+        "col": 13
+      },
+      "end": {
+        "line": 4,
+        "col": 14
+      },
+      "type": "t",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 4,
+        "col": 13
+      },
+      "end": {
+        "line": 4,
+        "col": 14
+      },
+      "type": "t",
+      "tail": "no"
+    }
+  ]
+
+Note: the output is duplicated because it is the result of the concatenation
+of both the ast-based and the small_enclosings (source based) heuristics.
+We aim to fix that in the future.
+
+- The pattern:
+
+  $ $MERLIN single type-enclosing -position 8:6 -verbosity 0 \
+  > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 7,
+        "col": 2
+      },
+      "end": {
+        "line": 8,
+        "col": 11
+      },
+      "type": "unit",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 6
+      },
+      "end": {
+        "line": 8,
+        "col": 11
+      },
+      "type": "t -> unit",
+      "tail": "no"
+    }
+  ]
+
+- Non-regression test:
+
+  $ $MERLIN single type-enclosing -position 15:13 -verbosity 0 \
+  > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 15,
+        "col": 12
+      },
+      "end": {
+        "line": 15,
+        "col": 13
+      },
+      "type": "sig type t = A type u = A | B end",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 12
+      },
+      "end": {
+        "line": 15,
+        "col": 15
+      },
+      "type": "M.t",
+      "tail": "no"
+    }
+  ]
+
+  $ $MERLIN single type-enclosing -position 15:15 -verbosity 0 \
+  > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 15,
+        "col": 12
+      },
+      "end": {
+        "line": 15,
+        "col": 15
+      },
+      "type": "M.t",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 15,
+        "col": 12
+      },
+      "end": {
+        "line": 15,
+        "col": 15
+      },
+      "type": "M.t",
+      "tail": "no"
+    }
+  ]


### PR DESCRIPTION
## Bug description:

Given the following file:

```ocaml
type t = U
type t' = U

let f : t  = U
```

The type hint given by Merlin for the `U` occuring in `f` is `t'` instead of `t`.
The same problem happens in patterns.

## Solution:

- Refactor the `Browse_raw.fold_node` so that `exp_extra` nodes are considered children of their corresponding expression and not parents.
- Short the heuristic for type enclosings when the type can be directly extracted from the node.