### PR TITLE
Error in constrained env

### DIFF
--- a/src/ocaml/typing/402/ctype.ml
+++ b/src/ocaml/typing/402/ctype.ml
@@ -118,6 +118,20 @@ let nongen_level = ref 0
 let global_level = ref 1
 let saved_level = ref []
 
+type levels =
+    { current_level: int; nongen_level: int; global_level: int;
+      saved_level: (int * int) list; }
+let save_levels () =
+  { current_level = !current_level;
+    nongen_level = !nongen_level;
+    global_level = !global_level;
+    saved_level = !saved_level }
+let set_levels l =
+  current_level := l.current_level;
+  nongen_level := l.nongen_level;
+  global_level := l.global_level;
+  saved_level := l.saved_level
+
 let get_current_level () = !current_level
 let init_def level = current_level := level; nongen_level := level
 let begin_def () =
@@ -2280,7 +2294,7 @@ let complete_type_list ?(allow_absent=false) env nl1 lv2 mty2 nl2 tl2 =
         nt2 :: complete (if n = n2 then nl else nl1) ntl'
     | n :: nl, _ ->
         try
-          let path = 
+          let path =
             Env.lookup_type (concat_longident (Longident.Lident "Pkg") n) env'
           in
           match Env.find_type path env' with

--- a/src/ocaml/typing/402/ctype.mli
+++ b/src/ocaml/typing/402/ctype.mli
@@ -37,6 +37,11 @@ val reset_global_level: unit -> unit
 val increase_global_level: unit -> int
 val restore_global_level: int -> unit
         (* This pair of functions is only used in Typetexp *)
+type levels =
+    { current_level: int; nongen_level: int; global_level: int;
+      saved_level: (int * int) list; }
+val save_levels: unit -> levels
+val set_levels: levels -> unit
 
 val newty: type_desc -> type_expr
 val newvar: ?name:string -> unit -> type_expr

--- a/src/ocaml/typing/402/typecore.ml
+++ b/src/ocaml/typing/402/typecore.ml
@@ -1842,11 +1842,13 @@ and type_expect ?in_function env sexp ty_expected =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function env sexp ty_expected
       with exn ->
         Msupport.erroneous_type_register ty_expected;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/403/typecore.ml
+++ b/src/ocaml/typing/403/typecore.ml
@@ -2016,11 +2016,13 @@ and type_expect ?in_function ?(recarg=Rejected) env sexp ty_expected =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function ~recarg env sexp ty_expected
       with exn ->
         Msupport.erroneous_type_register ty_expected;
         Msupport.raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/404/typecore.ml
+++ b/src/ocaml/typing/404/typecore.ml
@@ -2039,11 +2039,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function ?recarg env sexp ty_expected
       with exn ->
         Msupport.erroneous_type_register ty_expected;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/405/typecore.ml
+++ b/src/ocaml/typing/405/typecore.ml
@@ -2050,11 +2050,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function ?recarg env sexp ty_expected
       with exn ->
         Msupport.erroneous_type_register ty_expected;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/406/typecore.ml
+++ b/src/ocaml/typing/406/typecore.ml
@@ -1894,7 +1894,7 @@ struct
         x y
 
     let single id access = M.add id access M.empty
-  
+
     let empty = M.empty
 
     let list_matching p t =
@@ -2717,11 +2717,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function ?recarg env sexp ty_expected
       with exn ->
         Msupport.erroneous_type_register ty_expected;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/407/typecore.ml
+++ b/src/ocaml/typing/407/typecore.ml
@@ -2038,7 +2038,7 @@ struct
      Typedtree.Texp_apply *)
   let is_abstracted_arg : arg_label * expression option -> bool = function
     | (_, None) -> true
-    | (_, Some _) -> false    
+    | (_, Some _) -> false
 
   type sd = Static | Dynamic
 
@@ -2844,11 +2844,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected_explained =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+      let saved = save_levels () in
       try
         type_expect_ ?in_function ?recarg env sexp ty_expected_explained
       with exn ->
         Msupport.erroneous_type_register ty_expected_explained.ty;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/src/ocaml/typing/408/typecore.ml
+++ b/src/ocaml/typing/408/typecore.ml
@@ -2359,11 +2359,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected_explained =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+       let saved = save_levels () in
        try
          type_expect_ ?in_function ?recarg env sexp ty_expected_explained
        with exn ->
         Msupport.erroneous_type_register ty_expected_explained.ty;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident
@@ -2377,7 +2379,7 @@ and type_expect ?in_function ?recarg env sexp ty_expected_explained =
                         });
           exp_loc = loc;
           exp_extra = [];
-          exp_type = ty_expected_explained.ty;
+          exp_type = instance ty_expected_explained.ty;
           exp_env = env;
           exp_attributes = merlin_recovery_attributes [];
 	})

--- a/src/ocaml/typing/409/typecore.ml
+++ b/src/ocaml/typing/409/typecore.ml
@@ -2380,11 +2380,13 @@ and type_expect ?in_function ?recarg env sexp ty_expected_explained =
   Msupport.with_saved_types
     ~warning_attribute:sexp.pexp_attributes ?save_part:None
     (fun () ->
+       let saved = save_levels () in
        try
          type_expect_ ?in_function ?recarg env sexp ty_expected_explained
        with exn ->
         Msupport.erroneous_type_register ty_expected_explained.ty;
         raise_error exn;
+        set_levels saved;
         let loc = sexp.pexp_loc in
         {
           exp_desc = Texp_ident

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -120,6 +120,21 @@
 (alias (name runtest) (deps (alias destruct-basic)))
 
 (alias
+ (name errors-error-in-constrained-env-test)
+ (deps (:t ./test-dirs/errors/error-in-constrained-env/test.t)
+       (source_tree ./test-dirs/errors/error-in-constrained-env)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/errors/error-in-constrained-env
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias errors-error-in-constrained-env-test)))
+
+(alias
  (name errors-inconsistent-assumptions-test)(enabled_if (< %{ocaml_version} 4.08.0))
  (deps (:t ./test-dirs/errors/inconsistent-assumptions/test.t)
        (source_tree ./test-dirs/errors/inconsistent-assumptions)

--- a/tests/test-dirs/errors/error-in-constrained-env/test.ml
+++ b/tests/test-dirs/errors/error-in-constrained-env/test.ml
@@ -1,0 +1,7 @@
+type _ gadt =
+  | I : int gadt
+  | S : string gadt
+
+let show : type a. a gadt -> a -> string = function
+  | I -> string_of_int
+  | S -> None

--- a/tests/test-dirs/errors/error-in-constrained-env/test.t
+++ b/tests/test-dirs/errors/error-in-constrained-env/test.t
@@ -1,0 +1,43 @@
+In the example, typing "None" will fail. 
+Because the environment has constraints, the failure will happen between a
+begin_def and an end_def.
+Thus the error recovery will happen at the wrong level.
+The fix is to save and restore levels when attempting a recoverable typing.
+
+  $ $MERLIN single errors -filename test.ml < test.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 5,
+          "col": 4
+        },
+        "end": {
+          "line": 7,
+          "col": 13
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This definition has type 'a gadt -> 'a -> string which is less general than
+    'a0. 'a0 gadt -> 'a0 -> string"
+      },
+      {
+        "start": {
+          "line": 7,
+          "col": 9
+        },
+        "end": {
+          "line": 7,
+          "col": 13
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "This expression has type 'a option but an expression was expected of type
+    a -> string"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/errors/error-in-constrained-env/test.t
+++ b/tests/test-dirs/errors/error-in-constrained-env/test.t
@@ -10,21 +10,6 @@ The fix is to save and restore levels when attempting a recoverable typing.
     "value": [
       {
         "start": {
-          "line": 5,
-          "col": 4
-        },
-        "end": {
-          "line": 7,
-          "col": 13
-        },
-        "type": "typer",
-        "sub": [],
-        "valid": true,
-        "message": "This definition has type 'a gadt -> 'a -> string which is less general than
-    'a0. 'a0 gadt -> 'a0 -> string"
-      },
-      {
-        "start": {
           "line": 7,
           "col": 9
         },


### PR DESCRIPTION
When a type error occurs, recovery can sometime be done at an incorrect level. This happens because after the exception, calls to begin_def/end_def are not well bracketed.

This can lead to erroneous error messages, for instance in this example:
```
type _ gadt =
  | I : int gadt
  | S : string gadt

let show : type a. a gadt -> a -> string = function
  | I -> string_of_int
  | S -> None
```
We get:
`This definition has type 'a gadt -> 'a -> string which is less general than
    'a0. 'a0 gadt -> 'a0 -> string`

In this PR, we propose to fix this problem by always saving and restoring levels when recovering from a type error.