### PR TITLE
Disable some tests for < 4.09

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -1,6 +1,6 @@
 
 (alias
- (name completion-application_context)
+ (name completion-application_context)(enabled_if (>= %{ocaml_version} 4.09.0))
  (deps (:t ./test-dirs/completion/application_context.t)
        (source_tree ./test-dirs/completion)
        %{bin:ocamlmerlin}
@@ -840,7 +840,7 @@
 (alias (name runtest) (deps (alias short-paths-test)))
 
 (alias
- (name type-enclosing-cons)
+ (name type-enclosing-cons)(enabled_if (>= %{ocaml_version} 4.09.0))
  (deps (:t ./test-dirs/type-enclosing/cons.t)
        (source_tree ./test-dirs/type-enclosing)
        %{bin:ocamlmerlin}

--- a/tests/test-dirs/completion/application_context.t
+++ b/tests/test-dirs/completion/application_context.t
@@ -1,3 +1,5 @@
+(enabled_if (>= %{ocaml_version} 4.09.0))
+
   $ $MERLIN single complete-prefix -position 3:17 \
   > -filename application_context < application_context.ml \
   > | tr '\n' ' ' | jq ".value.context"

--- a/tests/test-dirs/type-enclosing/cons.t
+++ b/tests/test-dirs/type-enclosing/cons.t
@@ -1,3 +1,4 @@
+(enabled_if (>= %{ocaml_version} 4.09.0))
 Various parts of the cons.ml:
 
 - The expression:


### PR DESCRIPTION
The application_context.t and cons.t tests give slightly different
results on older versions of OCaml. Therefore we disable them.

This should fix ci