### PR TITLE
Fix windows popup 

### DIFF
--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -51,7 +51,7 @@ end
 module WinCmd : PpxCmd = struct
   type command_input = string * string list
   let normalize_first_segment_as_windows_path s =
-    let separated = String.split_on_char ' ' s in
+    let separated = String.split_on_char_ ' ' s in
     let rec first_path cur_str rest =
       match (cur_str, rest) with
       | ("", []) -> ("", [])

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -72,8 +72,7 @@ module UnixCmd : PpxCmd = struct
   let prepare_ppx_commandline _fn_in _fn_out = ()
 
   let run_ppx_command workdir cmd =
-    Sys.command cmd;
-    0
+    Sys.command cmd
 
   let ppx_commandline cmd fn_in fn_out =
     Printf.sprintf "%s %s %s 1>&2"


### PR DESCRIPTION
I pieced together many of the different suggestions discussed in [this issue](https://github.com/ocaml/merlin/issues/714).

We need to use the system shell to correctly interpret ppxs, however, when doing so, it makes windows pop up an annoying cmd window on every keystroke. @bryphe's suggestion was to wrap it in a `create_process("cmd.exe", [| theCommand |])`- that got rid of the popup, but it had one problem which we couldn't explain:  The same exact command would not work. I dug into it and it looks like any time you send a command to `cmd.exe` through `create_process`, some quotes get escaped unnecessarily. It doesn't happen with `Sys.command`. I almost gave up hope but at the last minute I thought of a hack: Pass the information through environment variables which will bypass the escaping!