### PR TITLE
Type-enclosing gives a module when it should give a module type

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -810,6 +810,21 @@
 (alias (name runtest) (deps (alias type-enclosing-letop)))
 
 (alias
+ (name type-enclosing-module_type)
+ (deps (:t ./test-dirs/type-enclosing/module_type.t)
+       (source_tree ./test-dirs/type-enclosing)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/type-enclosing
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias type-enclosing-module_type)))
+
+(alias
  (name type-expr-test)
  (deps (:t ./test-dirs/type-expr/test.t)
        (source_tree ./test-dirs/type-expr)

--- a/tests/test-dirs/type-enclosing/module_type.mli
+++ b/tests/test-dirs/type-enclosing/module_type.mli
@@ -1,0 +1,6 @@
+
+module type T = sig type a end
+
+module T : sig type b end
+
+include T

--- a/tests/test-dirs/type-enclosing/module_type.t
+++ b/tests/test-dirs/type-enclosing/module_type.t
@@ -1,0 +1,30 @@
+Get the type of a module type with the same name as a module:
+
+  $ $MERLIN single type-enclosing -position 6:8 -verbosity 0 \
+  > -filename ./module_type.mli < ./module_type.mli | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 6,
+        "col": 8
+      },
+      "end": {
+        "line": 6,
+        "col": 9
+      },
+      "type": "sig type b end",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 6,
+        "col": 8
+      },
+      "end": {
+        "line": 6,
+        "col": 9
+      },
+      "type": "T",
+      "tail": "no"
+    }
+  ]


### PR DESCRIPTION
Given an `.mli` with:

```ocaml
module type T = sig type a end

module T : sig type b end

include T
```

type-enclosing on the last `T` will return the module type `sig type b end` when it should give `sig type a end`.

This PR adds a test demonstrating this issue.