### PR TITLE
Type-enclosing gives wrong type on shadowing let

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -795,6 +795,21 @@
 (alias (name runtest) (deps (alias short-paths-test)))
 
 (alias
+ (name type-enclosing-let)
+ (deps (:t ./test-dirs/type-enclosing/let.t)
+       (source_tree ./test-dirs/type-enclosing)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/type-enclosing
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias type-enclosing-let)))
+
+(alias
  (name type-enclosing-letop)(enabled_if (>= %{ocaml_version} 4.08.0))
  (deps (:t ./test-dirs/type-enclosing/letop.t)
        (source_tree ./test-dirs/type-enclosing)

--- a/tests/test-dirs/type-enclosing/let.ml
+++ b/tests/test-dirs/type-enclosing/let.ml
@@ -1,0 +1,4 @@
+
+let def = 6
+
+let def : float = float_of_int def

--- a/tests/test-dirs/type-enclosing/let.t
+++ b/tests/test-dirs/type-enclosing/let.t
@@ -1,0 +1,30 @@
+Get type of a shadowing let binding:
+
+  $ $MERLIN single type-enclosing -position 4:4 -verbosity 0 \
+  > -filename ./let.ml < ./let.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 4,
+        "col": 4
+      },
+      "end": {
+        "line": 4,
+        "col": 7
+      },
+      "type": "int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 4,
+        "col": 4
+      },
+      "end": {
+        "line": 4,
+        "col": 7
+      },
+      "type": "float",
+      "tail": "no"
+    }
+  ]


### PR DESCRIPTION
Given:
```ocaml
let def = 6

let def : float = float_of_int def
```
Merlin will say `int` when asked for the type on the second `def`.

This PR adds a test demonstrating the issue.