### PR TITLE
Complete-prefix ignoring some infix operators

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -15,6 +15,21 @@
 (alias (name runtest) (deps (alias completion-expansion)))
 
 (alias
+ (name completion-infix)
+ (deps (:t ./test-dirs/completion/infix.t)
+       (source_tree ./test-dirs/completion)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/completion
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias completion-infix)))
+
+(alias
  (name completion-parenthesize)
  (deps (:t ./test-dirs/completion/parenthesize.t)
        (source_tree ./test-dirs/completion)

--- a/tests/test-dirs/completion/infix.ml
+++ b/tests/test-dirs/completion/infix.ml
@@ -1,0 +1,10 @@
+
+module Z = struct
+  let (>>) = 0
+  let (|+) = 0
+  let (|-) = 0
+  let (>>=) = 0
+  let (>>|) = 0
+end
+
+let _ = Z.

--- a/tests/test-dirs/completion/infix.t
+++ b/tests/test-dirs/completion/infix.t
@@ -1,0 +1,32 @@
+  $ $MERLIN single complete-prefix -position 11:10 -prefix "Z." \
+  > -filename infix.ml < infix.ml | jq ".value.entries | sort_by(.name)"
+  [
+    {
+      "name": "(>>)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(>>=)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(>>|)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(|+)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    }
+  ]


### PR DESCRIPTION
Given:
```ocaml
module Z = struct
  let (>>) = 0
  let (|+) = 0
  let (|-) = 0
  let (>>=) = 0
  let (>>|) = 0
end

let _ = Z.
```
complete-prefix offers all the operators as candidates except `(|-)`.

This PR adds this example as a test case.