### PR TITLE
Updated README.md to mention merlin-extend package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ If you have a working [Opam](https://opam.ocaml.org/) installation, Merlin is on
 ```shell
 opam install merlin
 opam user-setup install
+opam install merlin-extend
 ```
 
 [opam-user-setup](https://github.com/OCamlPro/opam-user-setup) takes care of configuring Emacs and Vim to make best use of your current install.
+
+[merlin-extend](https://github.com/let-def/merlin-extend) is needed to use Merlin with BuckleScript or ReasonML development.
 
 You can also [configure the editor](#editor-setup) yourself, if you prefer.
 


### PR DESCRIPTION
It is not obvious to new users how to make merlin work with BuckleScript or ReasonML projects that have dependencies. Without merlin-extend, Merlin will show Unbound module SomeModuleName even though bsb can find it and compile the project successfully.