### PR TITLE
[Based on #1108] Use context to prevent typing of small enclosings in strings

### DIFF
--- a/src/analysis/context.ml
+++ b/src/analysis/context.ml
@@ -41,6 +41,7 @@ type t =
   | Module_type
   | Patt
   | Type
+  | Constant
   | Unknown
 
 let to_string = function
@@ -50,6 +51,7 @@ let to_string = function
   | Module_path -> "module path"
   | Module_type -> "module type"
   | Patt -> "pattern"
+  | Constant -> "constant"
   | Type -> "type"
   | Unknown -> "unknown"
 
@@ -116,6 +118,7 @@ let inspect_expression ~cursor ~lid e : t =
       Expr
     else
       Module_path
+  | Texp_constant _ -> Constant
   | _ ->
     Expr
 

--- a/src/analysis/context.mli
+++ b/src/analysis/context.mli
@@ -37,6 +37,7 @@ type t =
   | Module_type
   | Patt
   | Type
+  | Constant
   | Unknown
 
 val to_string : t -> string

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -606,7 +606,8 @@ module Namespace = struct
   let from_context : Context.t -> inferred list = function
     | Type          -> [ `Type ; `Mod ; `Modtype ; `Constr ; `Labels ; `Vals ]
     | Module_type   -> [ `Modtype ; `Mod ; `Type ; `Constr ; `Labels ; `Vals ]
-    | Expr          -> [ `Vals ; `Mod ; `Modtype ; `Constr ; `Labels ; `Type ]
+    | Expr | Constant ->
+      [ `Vals ; `Mod ; `Modtype ; `Constr ; `Labels ; `Type ]
     | Patt          -> [ `Mod ; `Modtype ; `Type ; `Constr ; `Labels ; `Vals ]
     | Unknown       -> [ `Vals ; `Type ; `Constr ; `Mod ; `Modtype ; `Labels ]
     | Label lbl     -> [ `This_label lbl ]

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -81,6 +81,7 @@ let from_reconstructed ~nodes ~cursor ~verbosity exprs =
         let ppf, to_string = Format.to_string () in
         Type_utils.print_constr ~verbosity env ppf cd;
         Some (loc, String (to_string ()), `No)
+      | Some Context.Constant -> None
       | _ ->
         let context = Option.value ~default:Context.Expr context in
         (* Else use the reconstructed identifier *)

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -283,22 +283,6 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
       | [] -> []
       | browse -> Browse_misc.annotate_tail_calls browse
     in
-    let exprs = reconstruct_identifier pipeline pos expro in
-
-    let () =
-      Logger.log ~section:Type_enclosing.log_section
-        ~title:"reconstruct identifier" "%a"
-        Logger.json (fun () ->
-          let lst =
-            List.map exprs ~f:(fun { Location.loc; txt } ->
-              `Assoc [ "start", Lexing.json_of_position loc.Location.loc_start
-                     ; "end",   Lexing.json_of_position loc.Location.loc_end
-                     ; "identifier", `String txt]
-            )
-          in
-          `List lst
-        )
-    in
 
     let result = Type_enclosing.from_nodes ~path in
 

--- a/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
+++ b/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
@@ -154,11 +154,11 @@ We aim to fix that in the future.
     }
   ]
 
-FIXME: the following two tests works only because of
+FIXME: the following two tests work only because of
 the fallbacks implemented in type_utils. Context is
-unable to answer correctly du to the enclosing node
+unable to answer correctly due to the enclosing node
 being "Texp_constant" and not "Texp_construct". in
-the expression (M.A x).
+the expression reconstructed from  (M|.A 3).
   $ $MERLIN single type-enclosing -position 24:15 -verbosity 0 \
   > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
   [

--- a/tests/test-dirs/type-enclosing/issue1116.t/issue1116.ml
+++ b/tests/test-dirs/type-enclosing/issue1116.t/issue1116.ml
@@ -1,0 +1,2 @@
+let some_int = 5
+let x = "some_int"

--- a/tests/test-dirs/type-enclosing/issue1116.t/run.t
+++ b/tests/test-dirs/type-enclosing/issue1116.t/run.t
@@ -1,0 +1,33 @@
+  $ $MERLIN single type-enclosing -position 2:13 -verbosity 0 \
+  > -filename ./issue1116.ml < ./issue1116.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
+        "col": 18
+      },
+      "type": "string",
+      "tail": "no"
+    }
+  ]
+
+  $ $MERLIN single type-enclosing -position 1:16 -verbosity 0 \
+  > -filename ./issue1116.ml < ./issue1116.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 15
+      },
+      "end": {
+        "line": 1,
+        "col": 16
+      },
+      "type": "int",
+      "tail": "no"
+    }
+  ]


### PR DESCRIPTION
This PR fixes #1116

If the context of a small enclosing is a string we do not try to type it anymore.