### PR TITLE
RFC: don't fail on directives when the file starts with `#!`

### DIFF
--- a/src/kernel/mreader_parser.ml
+++ b/src/kernel/mreader_parser.ml
@@ -33,6 +33,7 @@ module I = Parser_raw.MenhirInterpreter
 type kind =
   | ML
   | MLI
+  | SCRIPT
   (*| MLL | MLY*)
 
 module Dump = struct
@@ -65,6 +66,7 @@ type 'a step =
 type tree = [
   | `Interface of Parsetree.signature
   | `Implementation of Parsetree.structure
+  | `Script of Parsetree.toplevel_phrase list
 ]
 
 type t = {
@@ -154,15 +156,14 @@ let run_parser warnings lexer kind =
   let initial_pos = Mreader_lexer.initial_position lexer in
   match kind with
   | ML  ->
-    let result =
-      let state = Parser_raw.Incremental.implementation initial_pos in
-      parse state tokens in
-    `Implementation result
+    let state = Parser_raw.Incremental.implementation initial_pos in
+    `Implementation (parse state tokens)
   | MLI ->
-    let result =
-      let state = Parser_raw.Incremental.interface initial_pos in
-      parse state tokens in
-    `Interface result
+    let state = Parser_raw.Incremental.interface initial_pos in
+    `Interface (parse state tokens)
+  | SCRIPT ->
+    let state = Parser_raw.Incremental.use_file initial_pos in
+    `Script (parse state tokens)
 
 let make warnings lexer kind =
   errors_ref := [];

--- a/src/kernel/mreader_parser.mli
+++ b/src/kernel/mreader_parser.mli
@@ -29,6 +29,7 @@
 type kind =
   | ML
   | MLI
+  | SCRIPT
   (*| MLL | MLY*)
 
 type t
@@ -38,6 +39,7 @@ val make : Warnings.state -> Mreader_lexer.t -> kind -> t
 type tree = [
   | `Interface of Parsetree.signature
   | `Implementation of Parsetree.structure
+  | `Script of Parsetree.toplevel_phrase list
 ]
 
 val result : t -> tree


### PR DESCRIPTION
This MR tries to fix #1023 .

When a file starts with `#!` it is now parsed with `Parser_raw.Incremental.use_file` instead of the usual `Parser_raw.Incremental.implementation`.

In the first patch, all the toplevel directives are ignored. The second patch adds handling of `#require`. The third and last patch drafts an implementation of `#use` and `#mod_use`.