### PR TITLE
Completion bug

### DIFF
--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -487,15 +487,15 @@ let complete_prefix ?get_doc ?target_type ?(kinds=[]) ~prefix ~is_label
     make_candidate ~get_doc ~attrs ~exact name ?loc ?path ty in
   let find ?prefix_path ~is_label prefix =
     let valid tag name =
-      let no_leak =
+      let no_leak () =
         (* Prevent identifiers introduced by type checker
           and recovery to leak *)
         List.for_all ~f:(fun by -> not (String.is_prefixed ~by name))
           ["self-"; "selfpat-"; "*type-"]
       in
-      no_leak
-      && (String.is_prefixed ~by:prefix name)
+      String.is_prefixed ~by:prefix name
       && uniq (tag,name)
+      && no_leak ()
     in
     (* Hack to prevent extensions namespace to leak
        + another to hide the "Library_name__Module" present at Jane Street *)

--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -487,12 +487,15 @@ let complete_prefix ?get_doc ?target_type ?(kinds=[]) ~prefix ~is_label
     make_candidate ~get_doc ~attrs ~exact name ?loc ?path ty in
   let find ?prefix_path ~is_label prefix =
     let valid tag name =
-      try
-        (* Prevent identifiers introduced by type checker to leak *)
-        ignore (String.index name '-' : int);
-        false
-      with Not_found ->
-        String.is_prefixed ~by:prefix name && uniq (tag,name)
+      let no_leak =
+        (* Prevent identifiers introduced by type checker
+          and recovery to leak *)
+        List.for_all ~f:(fun by -> not (String.is_prefixed ~by name))
+          ["self-"; "selfpat-"; "*type-"]
+      in
+      no_leak
+      && (String.is_prefixed ~by:prefix name)
+      && uniq (tag,name)
     in
     (* Hack to prevent extensions namespace to leak
        + another to hide the "Library_name__Module" present at Jane Street *)

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -30,6 +30,21 @@
 (alias (name runtest) (deps (alias completion-expansion)))
 
 (alias
+ (name completion-infix)
+ (deps (:t ./test-dirs/completion/infix.t)
+       (source_tree ./test-dirs/completion)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server})
+ (action
+   (chdir ./test-dirs/completion
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias completion-infix)))
+
+(alias
  (name completion-parenthesize)
  (deps (:t ./test-dirs/completion/parenthesize.t)
        (source_tree ./test-dirs/completion)

--- a/tests/test-dirs/completion/infix.ml
+++ b/tests/test-dirs/completion/infix.ml
@@ -1,0 +1,9 @@
+module Z = struct
+  let (>>) = 0
+  let (|+) = 0
+  let (|-) = 0
+  let (>>=) = 0
+  let (>>|) = 0
+end
+
+let _ = Z.

--- a/tests/test-dirs/completion/infix.t
+++ b/tests/test-dirs/completion/infix.t
@@ -1,0 +1,39 @@
+  $ $MERLIN single complete-prefix -position 11:10 -prefix "Z." \
+  > -filename infix.ml < infix.ml | jq ".value.entries | sort_by(.name)"
+  [
+    {
+      "name": "(>>)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(>>=)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(>>|)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(|+)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    },
+    {
+      "name": "(|-)",
+      "kind": "Value",
+      "desc": "int",
+      "info": "",
+      "deprecated": false
+    }
+  ]


### PR DESCRIPTION
This fixes the completion bug described in https://github.com/ocaml/merlin/pull/1107 

Merlin was eliminating all completion contestant with a `-` in their name to prevent leakage of internal compiler-introduced names.

This PR restrict the check to names starting with `self-`, `selfpat-` and `*type-`. The last one may be useless ? It is to prevent types from Merlin's recovery to be suggested.