### PR TITLE
dune: remove duplicated rules for profile=release

### DIFF
--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -41,11 +41,13 @@ Printf.ksprintf J.send {|
 
 (menhir
  (modules parser_raw)
+ (enabled_if (<> %%{profile} "release"))
  (mode    (promote-into %s))
  (flags :standard --inspection --table --cmly))
 
 (rule
   (targets parser_recover.ml)
+  (enabled_if (<> %%{profile} "release"))
   (deps    parser_raw.cmly)
   (mode    (promote-into %s))
   (action
@@ -54,6 +56,7 @@ Printf.ksprintf J.send {|
 
 (rule
   (targets parser_explain.ml)
+  (enabled_if (<> %%{profile} "release"))
   (deps    parser_raw.cmly)
   (mode    (promote-into %s))
   (action
@@ -62,6 +65,7 @@ Printf.ksprintf J.send {|
 
 (rule
   (targets parser_printer.ml)
+  (enabled_if (<> %%{profile} "release"))
   (deps    parser_raw.cmly)
   (mode    (promote-into %s))
   (action


### PR DESCRIPTION
Currently, attempting to build in profile release mode will
result in dune complaining about duplicate rules:

```
$ dune build --profile=release
Error: Multiple rules generated for
_build/default/src/ocaml/preprocess/parser_recover.ml:
- _build/.dune/default/src/ocaml/preprocess/dune:14
- _build/.dune/default/src/ocaml/preprocess/dune:39
```

This fixes compilation of merlin in a dune monorepo with
`dune build --profile=release`.  I'm not quite clear on why
the opam merlin package worked, as I thought `-p` activates
the release profile...