### PR TITLE
Fix opam ci

### DIFF
--- a/merlin.opam
+++ b/merlin.opam
@@ -7,10 +7,10 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "4.11"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
   "yojson" {>= "1.6.0"}

--- a/tests/test-dirs/file-cache/test.t
+++ b/tests/test-dirs/file-cache/test.t
@@ -64,3 +64,5 @@ If we remove the dep and try again, the "Unbound module" error should reappear:
     ],
     "notifications": []
   }
+
+  $ $MERLIN server stop-server

--- a/tests/test-dirs/locate/context-detection/mod_constr.t
+++ b/tests/test-dirs/locate/context-detection/mod_constr.t
@@ -1,9 +1,9 @@
 
-  $ $MERLIN single locate -look-for ml -position 2:13 -filename ./mod_constr.ml < ./mod_constr.ml
+  $ $MERLIN single locate -look-for ml -position 2:13 -filename ./mod_constr.ml < ./mod_constr.ml | sed 's/"[^""]*string.ml"/"irrelevant_path\/string.ml"/'
   {
     "class": "return",
     "value": {
-      "file": "~opam/lib/ocaml/string.ml",
+      "file": "irrelevant_path/string.ml",
       "pos": {
         "line": 1,
         "col": 0

--- a/tests/test-dirs/typer-cache/test.t
+++ b/tests/test-dirs/typer-cache/test.t
@@ -1,4 +1,4 @@
-Instances of the typechecker are cached based on configuration 
+Instances of the typechecker are cached based on configuration
 (values of type `Mconfig.t`).
 
 Older versions of Merlin ignored some components resulting in possible
@@ -92,7 +92,7 @@ We should check in the other direction too. Starting from a visible dep and
 hidding it.  Older versions of the typechecker (before the 4.08 revamp of Env)
 would accumulate dependencies and forget to flush the cache when a dependency
 disappeared.
- 
+
   $ $MERLIN server stop-server
 
 
@@ -169,3 +169,5 @@ Reference:
 Now some cleanup.
 
   $ rm sub/dep.cm*
+
+  $ $MERLIN server stop-server


### PR DESCRIPTION
This PR is an attempt to fix Merlin tests that are failing on some of the opam repository CIs:
https://github.com/ocaml/opam-repository/pull/16608

- [x] Tests should not be run on OCaml <= 4.03
- [x] Merlin is not compatible with OCaml 4.11
- [x] Travis CI fails due to absolute link to opam install in test `mod_constr`
- [ ] ocaml-ci fails on OCaml 4.05, 4.06, 4.07, 4.08 and 4.09 due to either `warnings/backtrack.t` or `typer-cache/test.t` raising `abnormal termination`. I have not been able to reproduce this behaviour yet.

```
# --- a/tests/test-dirs/file-cache/test.t
# +++ b/tests/test-dirs/file-cache/test.t.corrected
# @@ -6,24 +6,12 @@ clean slate:
#  First try: nothing has been built:
#  
#    $ $MERLIN server errors -filename test.ml < test.ml
# +  abnormal termination
# +  merlin path: /home/opam/.opam/4.08/.opam-switch/build/merlin.3.3.5/_build/default/src/frontend/ocamlmerlin/ocamlmerlin_server.exe
# +  socket path: /tmp/ocamlmerlin_1000_239_63581488.socket
#    {
# -    "class": "return",
# -    "value": [
# -      {
# -        "start": {
# -          "line": 1,
# -          "col": 8
# -        },
# -        "end": {
# -          "line": 1,
# -          "col": 22
# -        },
# -        "type": "typer",
# -        "sub": [],
# -        "valid": true,
# -        "message": "Unbound module Dep"
# -      }
# -    ],
# +    "class": "failure",
# +    "value": "abnormal termination",
#      "notifications": []
#    }
#  
``` 