### PR TITLE
Support controlling ocamlmerlin socket with environment variable

### DIFF
--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -546,6 +546,13 @@ static void compute_socketname(char socketname[PATHSZ], struct stat *st)
   snprintf(socketname, PATHSZ,
       "\\\\.\\pipe\\%s", eventname);
 #else
+  const char *merlin_socket = getenv("MERLIN_SOCKET");
+  if (merlin_socket != NULL)
+  {
+    strcpy(socket_path, merlin_socket);
+    return;
+  }
+
   snprintf(socketname, PATHSZ,
       "ocamlmerlin_%llu_%llu_%llu.socket",
       (unsigned long long)getuid(),


### PR DESCRIPTION
Whilst benchmarking short-paths a few years ago, I found it useful to be able to control which socket ocamlmerlin used. It let me open several merlin servers in parallel without them interfering with each other. Someone else just mentioned they had a similar use case, so I thought I'd make a PR of the code. Fair warning: I haven't tested it, or even compiled it, since it was rebased.