### PR TITLE
Check if dune is compatible with new external reader

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -120,6 +120,7 @@ let dump_merlin x =
       );
     "log_file"     , Json.option Json.string x.log_file;
     "log_sections" , Json.list Json.string x.log_sections;
+    "dune_support", `Bool x.dune_support;
     "flags_to_apply"   , `List (List.map ~f:dump_flag_list x.flags_to_apply);
 
     "failures"         , `List (List.map ~f:Json.string x.failures);

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -82,6 +82,7 @@ type merlin = {
   log_file    : string option;
   log_sections : string list;
   config_path : string option;
+  dune_support : bool;
 
   exclude_query_dir : bool;
 
@@ -206,7 +207,8 @@ let rec normalize t =
 let get_external_config path t =
   let path = Misc.canonicalize_filename path in
   let directory = Filename.dirname path in
-  match Mconfig_dot.find_project_context directory with
+  let dune_support = t.merlin.dune_support in
+  match Mconfig_dot.find_project_context ~dune_support directory with
   | None -> t
   | Some (ctxt, config_path) ->
     let dot, failures = Mconfig_dot.get_config ctxt path in
@@ -596,6 +598,7 @@ let initial = {
     log_file    = None;
     log_sections = [];
     config_path = None;
+    dune_support = check_dune_version ();
 
     exclude_query_dir = false;
 

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -40,6 +40,7 @@ type merlin = {
   log_file    : string option;
   log_sections: string list;
   config_path : string option;
+  dune_support : bool;
 
   exclude_query_dir : bool;
 

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -202,40 +202,9 @@ let get_config (dir, cfg) path =
     empty_config, [ Printf.sprintf "couldn't retrieve the config from %s"
                       (Configurator.to_string cfg)]
 
-let check_dune_version () =
-  (* We only allow dune as a configuration reader if the subcommand
-  [ocaml-merlin] exists and dune's version is at least 2.7 *)
-  let prog = "dune" in
-  let stdin_r, stdin_w = Unix.pipe ~cloexec:true () in
-  let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
-  let dune_out = Unix.in_channel_of_descr stdout_r in
-  let pid =
-    Unix.create_process prog [|prog; "ocaml-merlin"; "--version"|] stdin_r stdout_w stdout_w
-  in
-  let rec wait_exit_0 () =
-    try (snd (Unix.waitpid [] pid)) = Unix.WEXITED 0 with
-    | Unix.Unix_error (EINTR, _, _) -> wait_exit_0 ()
-    | _ -> false
-  in
-  let close_all () =
-    List.iter ~f:Unix.close [stdin_r; stdin_w; stdout_r; stdout_w];
-    close_in dune_out
-  in
-  try begin
-    let version = input_line dune_out in
-    let res = wait_exit_0 () && version >= "2.7.0" in
-    close_all ();
-    res
-  end
-  with _ ->
-    Unix.kill pid 9;
-    ignore (wait_exit_0 ());
-    close_all ();
-    false
-
-let find_project_context start_dir =
+let find_project_context ~dune_support start_dir =
   let config_files = ".merlin" :: (
-    if check_dune_version ()
+    if dune_support
     then ["dune-project"; "dune-workspace"]
     else [])
   in

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -202,13 +202,47 @@ let get_config (dir, cfg) path =
     empty_config, [ Printf.sprintf "couldn't retrieve the config from %s"
                       (Configurator.to_string cfg)]
 
+let check_dune_version () =
+  (* We only allow dune as a configuration reader if the subcommand
+  [ocaml-merlin] exists and dune's version is at least 2.7 *)
+  let prog = "dune" in
+  let stdin_r, stdin_w = Unix.pipe ~cloexec:true () in
+  let stdout_r, stdout_w = Unix.pipe ~cloexec:true () in
+  let dune_out = Unix.in_channel_of_descr stdout_r in
+  let pid =
+    Unix.create_process prog [|prog; "ocaml-merlin"; "--version"|] stdin_r stdout_w stdout_w
+  in
+  let rec wait_exit_0 () =
+    try (snd (Unix.waitpid [] pid)) = Unix.WEXITED 0 with
+    | Unix.Unix_error (EINTR, _, _) -> wait_exit_0 ()
+    | _ -> false
+  in
+  let close_all () =
+    List.iter ~f:Unix.close [stdin_r; stdin_w; stdout_r; stdout_w];
+    close_in dune_out
+  in
+  try begin
+    let version = input_line dune_out in
+    let res = wait_exit_0 () && version >= "2.7.0" in
+    close_all ();
+    res
+  end
+  with _ ->
+    Unix.kill pid 9;
+    ignore (wait_exit_0 ());
+    close_all ();
+    false
+
 let find_project_context start_dir =
+  let config_files = ".merlin" :: (
+    if check_dune_version ()
+    then ["dune-project"; "dune-workspace"]
+    else [])
+  in
   let rec loop dir =
     try
       Some (
-        List.find_map [
-            ".merlin" ; "dune-project"; "dune-workspace"
-          ]
+        List.find_map config_files
           ~f:(fun f ->
             let fname = Filename.concat dir f in
             if Sys.file_exists fname && not (Sys.is_directory fname)

--- a/src/kernel/mconfig_dot.mli
+++ b/src/kernel/mconfig_dot.mli
@@ -45,7 +45,7 @@ type context
 
 val get_config : context -> string -> config * string list
 
-val find_project_context : string -> (context * string) option
+val find_project_context : dune_support:bool -> string -> (context * string) option
 (** [find_project_config dir] searches for a "project configuration file" in dir
     and its parent directories. Stopping on the first one it finds and returning
     a configuration context along with the path to the configuration file,


### PR DESCRIPTION
Merlin should check if the installed dune is recent enough to have the `dune ocaml-merlin` subcommand.

This is done in this PR by reading the output of the `dune ocaml-merlin` command: if it exited with status 0 and the printed version is `>= 2.7.0` then we enabled the functionality.

This check is done only once when building the initial configuration.