### PR TITLE
Add error messages for external configuration readers and disable quoting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@ merlin dev
 ============
 
   + merlin binary
-    - fix completion of pattern matchings with exception patterns
+    - fix completion of pattern matchings with exception patterns (#1169)
+    - delegate configuration reading to external programs via a simple protocol
+    and create a new package `dot-merlin-reader` with a binary that reads
+    `.merlin` files. (#1123, #1152)
 
 merlin 3.3.8
 ============

--- a/src/dot-merlin/dot-protocol/dot_protocol.ml
+++ b/src/dot-merlin/dot-protocol/dot_protocol.ml
@@ -35,7 +35,7 @@ module Directive = struct
 
   type no_processing_required =
     [ `EXT of string list
-    | `FLG of string
+    | `FLG of string list
     | `STDLIB of string
     | `SUFFIX of string
     | `READER of string list
@@ -84,7 +84,6 @@ module Sexp = struct
         | "B" -> `B value
         | "CMI" -> `CMI value
         | "CMT" -> `CMT value
-        | "FLG" -> `FLG value
         | "STDLIB" -> `STDLIB value
         | "SUFFIX" -> `SUFFIX value
         | "ERROR" -> `ERROR_MSG value
@@ -94,6 +93,7 @@ module Sexp = struct
         let value = strings_of_atoms l in
         begin match tag with
         | "EXT" -> `EXT value
+        | "FLG" -> `FLG value
         | "READER" -> `READER value
         | tag -> make_error tag
       end
@@ -110,7 +110,7 @@ module Sexp = struct
         | `CMI s -> ("CMI", single s)
         | `CMT s -> ("CMT", single s)
         | `EXT ss -> ("EXT", [ List (atoms_of_strings ss) ])
-        | `FLG s -> ("FLG", single s)
+        | `FLG ss -> ("FLG", [ List (atoms_of_strings ss) ])
         | `STDLIB s -> ("STDLIB", single s)
         | `SUFFIX s -> ("SUFFIX", single s)
         | `READER ss -> ("READER", [ List (atoms_of_strings ss) ])

--- a/src/dot-merlin/dot-protocol/dot_protocol.ml
+++ b/src/dot-merlin/dot-protocol/dot_protocol.ml
@@ -147,7 +147,7 @@ type read_error =
 let read ~in_channel =
   match Csexp.input in_channel with
   | Ok (Sexp.List directives) ->
-      Ok (List.rev (List.map directives ~f:Sexp.to_directive))
+      Ok (List.map directives ~f:Sexp.to_directive)
   | Ok sexp ->
     let msg = Printf.sprintf
       "A list of directives was expected, instead got: \"%s\""

--- a/src/dot-merlin/dot-protocol/dot_protocol.ml
+++ b/src/dot-merlin/dot-protocol/dot_protocol.ml
@@ -87,6 +87,10 @@ module Sexp = struct
         | "STDLIB" -> `STDLIB value
         | "SUFFIX" -> `SUFFIX value
         | "ERROR" -> `ERROR_MSG value
+        | "FLG" ->
+            (* This means merlin asked dune 2.6 for configuration.
+              But the protocole evolved, only dune 2.8 should be used *)
+            `ERROR_MSG "No .merlin file found. Try building the project."
         | tag -> make_error tag
       end
     | List [ Atom tag; List l ] ->

--- a/src/dot-merlin/dot-protocol/dot_protocol.mli
+++ b/src/dot-merlin/dot-protocol/dot_protocol.mli
@@ -78,8 +78,12 @@ module Commands : sig
   val send_file : out_channel:out_channel -> string -> unit
 end
 
+type read_error =
+  | Unexpected_output of string
+  | Csexp_parse_error of string
+
 (** [read inc] reads one csexp from the channel [inc] and returns the list of
   directives it represents *)
-val read : in_channel:in_channel -> directive list
+val read : in_channel:in_channel -> (directive list, read_error) Std.Result.t
 
 val write : out_channel:out_channel -> directive list -> unit

--- a/src/dot-merlin/dot-protocol/dot_protocol.mli
+++ b/src/dot-merlin/dot-protocol/dot_protocol.mli
@@ -47,7 +47,7 @@ module Directive : sig
 
   type no_processing_required =
     [ `EXT of string list
-    | `FLG of string
+    | `FLG of string list
     | `STDLIB of string
     | `SUFFIX of string
     | `READER of string list

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -359,7 +359,7 @@ let prepend_config ~cwd ~cfg =
 
 let process_one ~cfg {path;directives; _ } =
   let cwd = Filename.dirname path in
-  prepend_config ~cwd ~cfg directives
+  prepend_config ~cwd ~cfg (List.rev directives)
 
 let expand =
   let filter path =

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -84,7 +84,7 @@ module Cache = File_cache.Make (struct
           else if String.is_prefixed ~by:"EXT " line then
             tell (`EXT (rev_split_words (String.drop 4 line)))
           else if String.is_prefixed ~by:"FLG " line then
-            tell (`FLG (String.drop 4 line))
+            tell (`FLG (Shell.split_command (String.drop 4 line)))
           else if String.is_prefixed ~by:"REC" line then
             recurse := true
           else if String.is_prefixed ~by:". " line then
@@ -441,11 +441,9 @@ let postprocess cfg =
     match Ppxsetup.command_line ppxsetup with
     | [] -> []
     | lst ->
-      let cmd =
-        List.map lst ~f:Import_from_dune.quote
-        |> String.concat ~sep:" "
+      let cmd = String.concat ~sep:" " lst
       in
-      [ `FLG ("-ppx " ^ cmd) ]
+      [ `FLG ["-ppx"; cmd] ]
   in
   List.concat
     [ List.concat_map cfg.to_canonicalize ~f:(fun (dir, directive) ->

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -86,7 +86,7 @@ let prepend_config ~dir:cwd (directives : directive list) config =
     | `SUFFIX suffix ->
       {config with suffixes = (parse_suffix suffix) @ config.suffixes}, errors
     | `FLG flags ->
-      let flags = {workdir = cwd; workval = Shell.split_command flags} in
+      let flags = {workdir = cwd; workval = flags} in
       {config with flags = flags :: config.flags}, errors
     | `STDLIB path ->
       {config with stdlib = Some path}, errors

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -119,6 +119,23 @@
 (alias (name runtest) (deps (alias config-dot-merlin-reader-erroneous-config)))
 
 (alias
+ (name config-dot-merlin-reader-quoting)
+ (package merlin)
+ (deps (:t ./test-dirs/config/dot-merlin-reader/quoting.t)
+       (source_tree ./test-dirs/config/dot-merlin-reader)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server}
+       %{bin:dot-merlin-reader})
+ (action
+   (chdir ./test-dirs/config/dot-merlin-reader
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias config-dot-merlin-reader-quoting)))
+
+(alias
  (name config-flags-invalid)
  (package merlin)
  (deps (:t ./test-dirs/config/flags/invalid.t)

--- a/tests/test-dirs/config/dot-merlin-reader/erroneous-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/erroneous-config.t
@@ -39,3 +39,5 @@ Also, see that the failure is reported to the user:
     ],
     "notifications": []
   }
+
+  $ rm .merlin

--- a/tests/test-dirs/config/dot-merlin-reader/quoting.t
+++ b/tests/test-dirs/config/dot-merlin-reader/quoting.t
@@ -1,0 +1,72 @@
+  $ cat > .merlin <<EOF \
+  > EXCLUDE_QUERY_DIR \
+  > FLG -pp 'I/definitly/need/quoting.exe -nothing' \
+  > FLG -ppx '/path/to/ppx.exe --as-ppx --cookie '\\''library-name="model"'\\''' \
+  > FLG -w @3 \
+  > EOF
+
+  $ FILE=$(pwd)/test.ml; dot-merlin-reader <<EOF | sed 's#[0-9]*:#?:#g' \
+  > (4:File${#FILE}:$FILE) \
+  > EOF
+  ((?:EXCLUDE_QUERY_DIR)(?:FLG(?:-pp?:I/definitly/need/quoting.exe -nothing))(?:FLG(?:-ppx?:/path/to/ppx.exe --as-ppx --cookie 'library-name="model"'))(?:FLG(?:-w?:@3)))
+
+  $ echo | $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
+  {
+    "build_path": [],
+    "source_path": [],
+    "cmi_path": [],
+    "cmt_path": [],
+    "flags_applied": [
+      {
+        "workdir": "tests/test-dirs/config/dot-merlin-reader",
+        "workval": [
+          "-pp",
+          "I/definitly/need/quoting.exe -nothing"
+        ]
+      },
+      {
+        "workdir": "tests/test-dirs/config/dot-merlin-reader",
+        "workval": [
+          "-ppx",
+          "/path/to/ppx.exe --as-ppx --cookie 'library-name=\"model\"'"
+        ]
+      },
+      {
+        "workdir": "tests/test-dirs/config/dot-merlin-reader",
+        "workval": [
+          "-w",
+          "@3"
+        ]
+      }
+    ],
+    "extensions": [],
+    "suffixes": [
+      {
+        "impl": ".ml",
+        "intf": ".mli"
+      },
+      {
+        "impl": ".re",
+        "intf": ".rei"
+      }
+    ],
+    "stdlib": null,
+    "reader": [],
+    "protocol": "json",
+    "log_file": null,
+    "log_sections": [],
+    "flags_to_apply": [],
+    "failures": [],
+    "assoc_suffixes": [
+      {
+        "extension": ".re",
+        "reader": "reason"
+      },
+      {
+        "extension": ".rei",
+        "reader": "reason"
+      }
+    ]
+  }
+
+  $ rm .merlin


### PR DESCRIPTION
This PR add better error reporting for the external readers.

Covered cases:

- External reader unexpectedly not-running:
  - `A problem occurred with merlin external configuration reader. Check that 'dot-merlin-reader' is installed. If the problem persists, please file an issue on Merlin's tracker.`
  - `A problem occurred with merlin external configuration reader. Check that 'dune' is installed and up-to-date. If the problem persists, please file an issue on Merlin's tracker.`

- Bad output from the external reader. That can happen if merlin tries to start `dune ocaml-merlin` with a version of dune that doesn't support this sub-command. Dune then prints it's help, which is not a valid csexp.
  - `Merlin could not load its configuration from the external reader.  Building your project with 'dune' might solve this issue.`

This PR broke the tests: most of the tests do not have a `.merlin` file and the closest config file in parent directories was the `dune-project` file. This triggers a `Project is not built` message from the `dune ocaml-merlin` config reader.

To prevent that behaviour I added a dummy `merlin` file to the `test-dirs` directory to trick merlin in using `dot-merlin-reader`.