### PR TITLE
Limit test jobs to one

### DIFF
--- a/merlin.opam
+++ b/merlin.opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test & os != "macos" & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}


### PR DESCRIPTION
This change may fix the OPAM CI which otherwise runs tests in parallel on 31 jobs.