### PR TITLE
Add the hash of opam packages to the cache key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           # A directory to store and save the cache
           path: ~/.opam
           # An explicit key for restoring and saving the cache
-          key: ${{ matrix.os }}-${{ matrix.ocaml-version }}-build
+          key: ${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ hashFiles('*.opam') }}-build
       - name: Set up OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1.0.1
         with:


### PR DESCRIPTION
We need to invalidate the cache if the opam file changes.

(CI builds may still be a bit non-reproducible due to the absence of a lock file that could be hashed in the cache key)