### PR TITLE
Use local env when printing outline to benefit from -short-paths

### DIFF
--- a/src/analysis/outline.ml
+++ b/src/analysis/outline.ml
@@ -50,7 +50,8 @@ let get_class_field_desc_infos = function
 
 let outline_type ~env typ =
   let ppf, to_string = Format.to_string () in
-  Type_utils.print_type_with_decl ~verbosity:0 env ppf typ;
+  Printtyp.wrap_printing_env env (fun () ->
+  Type_utils.print_type_with_decl ~verbosity:0 env ppf typ);
   Some (to_string ())
 
 let rec summarize node =

--- a/tests/test-dirs/outline/path.ml
+++ b/tests/test-dirs/outline/path.ml
@@ -1,0 +1,5 @@
+module A = struct 
+  type a = int 
+end 
+open A 
+let x = (5 : a)

--- a/tests/test-dirs/outline/run.t
+++ b/tests/test-dirs/outline/run.t
@@ -236,3 +236,9 @@
     ],
     "notifications": []
   }
+  $ $MERLIN single outline < path.ml | jq '.value[].type'
+  "A.a"
+  null
+  $ $MERLIN single outline -short-paths < path.ml | jq '.value[].type'
+  "a"
+  null


### PR DESCRIPTION
This should fix issue #971 : outline types are now printed using the local environment.
I don't know enough about LSP to test in this setting.