### PR TITLE
Testsuite: Add compatibility with clang when used as main C++ compiler

### DIFF
--- a/tests/test-dirs/pp/simple-pp.t
+++ b/tests/test-dirs/pp/simple-pp.t
@@ -21,7 +21,7 @@
     ],
     "notifications": []
   }
-  $ $MERLIN single errors -pp 'cpp -E' -filename test.ml <<EOF \
+  $ $MERLIN single errors -pp 'cpp -Wno-everything -E' -filename test.ml <<EOF \
   > #ifndef FOO \
   > let x : int = "hello" \
   > #else \
@@ -48,7 +48,7 @@
     ],
     "notifications": []
   }
-  $ $MERLIN single errors -pp 'cpp -E' -filename test.ml <<EOF \
+  $ $MERLIN single errors -pp 'cpp -Wno-everything -E' -filename test.ml <<EOF \
   > #ifdef FOO \
   > let x : int = "hello" \
   > #else \


### PR DESCRIPTION
This fixes the issue encountered when testing merlin on FreeBSD:
```
#=== ERROR while compiling merlin.3.3.9 =======================================#
# context     2.0.6 | freebsd/x86_64 | ocaml-base-compiler.4.09.1 | file:///usr/home/travis/build/ocaml/opam-repository
# path        /usr/home/travis/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/merlin.3.3.9
# command     /usr/home/travis/.opam/ocaml-base-compiler.4.09.1/bin/dune runtest -p merlin -j 1
# exit-code   1
# env-file    /usr/home/travis/.opam/log/merlin-10058-d2816f.env
# output-file /usr/home/travis/.opam/log/merlin-10058-d2816f.out
### output ###
# [...]
- File "tests/test-dirs/pp/simple-pp.t", line 1, characters 0-0:
-          git (internal) (exit 1)
- (cd _build/default && /usr/local/bin/git diff --no-index --color=always -u tests/test-dirs/pp/simple-pp.t tests/test-dirs/pp/simple-pp.t.corrected)
- diff --git a/tests/test-dirs/pp/simple-pp.t b/tests/test-dirs/pp/simple-pp.t.corrected
- index 639d0d2..ee0d5c8 100644
- --- a/tests/test-dirs/pp/simple-pp.t
- +++ b/tests/test-dirs/pp/simple-pp.t.corrected
- @@ -28,6 +28,7 @@
-    > let x : int = 42 \
-    > #endif \
-    > EOF
- +  cpp: warning: argument unused during compilation: '-E' [-Wunused-command-line-argument]
-    {
-      "class": "return",
-      "value": [
- @@ -55,6 +56,7 @@
-    > let x : int = 42 \
-    > #endif \
-    > EOF
- +  cpp: warning: argument unused during compilation: '-E' [-Wunused-command-line-argument]
-    {
-      "class": "return",
-      "value": [],
```
*Testsuite entirely tested successfully using `FreeBSD 13.0-CURRENT arm64` locally*