### PR TITLE
Fix use of local store from 409 to 411

### DIFF
--- a/src/ocaml/typing/409/btype.ml
+++ b/src/ocaml/typing/409/btype.ml
@@ -87,9 +87,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/409/btype.mli
+++ b/src/ocaml/typing/409/btype.mli
@@ -236,9 +236,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/410/btype.ml
+++ b/src/ocaml/typing/410/btype.ml
@@ -83,9 +83,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/410/btype.mli
+++ b/src/ocaml/typing/410/btype.mli
@@ -251,9 +251,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/typing/411/btype.ml
+++ b/src/ocaml/typing/411/btype.ml
@@ -83,9 +83,7 @@ type changes =
   | Unchanged
   | Invalid
 
-let state = Local_store.new_bindings ()
-let sref f = Local_store.ref state f
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let trail = sref (fun () -> Weak.create 1)
 

--- a/src/ocaml/typing/411/btype.mli
+++ b/src/ocaml/typing/411/btype.mli
@@ -254,9 +254,6 @@ val iter_type_expr_cstr_args: (type_expr -> unit) ->
 val map_type_expr_cstr_args: (type_expr -> type_expr) ->
   (constructor_arguments -> constructor_arguments)
 
-(** merlin: internal state *)
-val state : Local_store.bindings
-
 (** merlin: check if a snapshot has been invalidated *)
 val is_valid: snapshot -> bool
 

--- a/src/ocaml/utils/409/load_path.ml
+++ b/src/ocaml/utils/409/load_path.ml
@@ -17,8 +17,7 @@ module SMap = Misc.String.Map
 (* Mapping from basenames to full filenames *)
 type registry = string SMap.t ref
 
-let state = Local_store.new_bindings ()
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let files : registry = srefk SMap.empty
 let files_uncap : registry = srefk SMap.empty
@@ -39,6 +38,7 @@ end
 let dirs = srefk []
 
 let reset () =
+  assert (Local_store.is_bound compiler_state);
   files := SMap.empty;
   files_uncap := SMap.empty;
   dirs := []
@@ -47,6 +47,7 @@ let get () = !dirs
 let get_paths () = List.map Dir.path !dirs
 
 let add dir =
+  assert (Local_store.is_bound compiler_state);
   let add_file base =
     let fn = Filename.concat dir.Dir.path base in
     files := SMap.add base fn !files;
@@ -56,6 +57,7 @@ let add dir =
   dirs := dir :: !dirs
 
 let remove_dir dir =
+  assert (Local_store.is_bound compiler_state);
   let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
   if new_dirs <> !dirs then begin
     reset ();
@@ -71,12 +73,14 @@ let init l =
 let is_basename fn = Filename.basename fn = fn
 
 let find fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find fn !files
   else
     Misc.find_in_path (get_paths ()) fn
 
 let find_uncap fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find (String.uncapitalize_ascii fn) !files_uncap
   else

--- a/src/ocaml/utils/410/load_path.ml
+++ b/src/ocaml/utils/410/load_path.ml
@@ -17,8 +17,7 @@ module SMap = Misc.String.Map
 (* Mapping from basenames to full filenames *)
 type registry = string SMap.t ref
 
-let state = Local_store.new_bindings ()
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let files : registry = srefk SMap.empty
 let files_uncap : registry = srefk SMap.empty
@@ -39,6 +38,7 @@ end
 let dirs = srefk []
 
 let reset () =
+  assert (Local_store.is_bound compiler_state);
   files := SMap.empty;
   files_uncap := SMap.empty;
   dirs := []
@@ -47,6 +47,7 @@ let get () = !dirs
 let get_paths () = List.map Dir.path !dirs
 
 let add dir =
+  assert (Local_store.is_bound compiler_state);
   let add_file base =
     let fn = Filename.concat dir.Dir.path base in
     files := SMap.add base fn !files;
@@ -56,6 +57,7 @@ let add dir =
   dirs := dir :: !dirs
 
 let remove_dir dir =
+  assert (Local_store.is_bound compiler_state);
   let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
   if new_dirs <> !dirs then begin
     reset ();
@@ -71,12 +73,14 @@ let init l =
 let is_basename fn = Filename.basename fn = fn
 
 let find fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find fn !files
   else
     Misc.find_in_path (get_paths ()) fn
 
 let find_uncap fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find (String.uncapitalize_ascii fn) !files_uncap
   else

--- a/src/ocaml/utils/411/load_path.ml
+++ b/src/ocaml/utils/411/load_path.ml
@@ -17,8 +17,7 @@ module SMap = Misc.String.Map
 (* Mapping from basenames to full filenames *)
 type registry = string SMap.t ref
 
-let state = Local_store.new_bindings ()
-let srefk k = Local_store.ref state (fun () -> k)
+open Local_store.Compiler
 
 let files : registry = srefk SMap.empty
 let files_uncap : registry = srefk SMap.empty
@@ -39,6 +38,7 @@ end
 let dirs = srefk []
 
 let reset () =
+  assert (Local_store.is_bound compiler_state);
   files := SMap.empty;
   files_uncap := SMap.empty;
   dirs := []
@@ -47,6 +47,7 @@ let get () = !dirs
 let get_paths () = List.map Dir.path !dirs
 
 let add dir =
+  assert (Local_store.is_bound compiler_state);
   let add_file base =
     let fn = Filename.concat dir.Dir.path base in
     files := SMap.add base fn !files;
@@ -56,6 +57,7 @@ let add dir =
   dirs := dir :: !dirs
 
 let remove_dir dir =
+  assert (Local_store.is_bound compiler_state);
   let new_dirs = List.filter (fun d -> Dir.path d <> dir) !dirs in
   if new_dirs <> !dirs then begin
     reset ();
@@ -71,12 +73,14 @@ let init l =
 let is_basename fn = Filename.basename fn = fn
 
 let find fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find fn !files
   else
     Misc.find_in_path (get_paths ()) fn
 
 let find_uncap fn =
+  assert (Local_store.is_bound compiler_state);
   if is_basename fn then
     SMap.find (String.uncapitalize_ascii fn) !files_uncap
   else


### PR DESCRIPTION
On these versions, the compiler backends weren't using `Local_store.Compiler` :scream: 