### PR TITLE
Travis: Test macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: c
 dist: xenial
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: |
-  bash -ex .travis-opam.sh
+script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_DEPS="dot-merlin-reader"
   - PINS="dot-merlin-reader.3.4.0:."
-  - ASSUME_ALWAYS_YES=YES
+  - PACKAGE=merlin
   matrix:
   - OCAML_VERSION=4.11
-    PACKAGE=merlin
 os:
   - linux
-#  - osx
+  - osx
   - freebsd
+osx_image: xcode11.3
 jobs:
   include:
   - os: linux
-    env: OCAML_VERSION=4.02 PACKAGE=merlin TESTS=false
+    env: OCAML_VERSION=4.02 TESTS=false


### PR DESCRIPTION
This PR just adds macos to Travis (I'm not sure what was different in https://github.com/ocaml/merlin/pull/1168 from opam-repository, I'm guessing it's the `osx_image` value so let's test that), and remove the missing `ASSUME_ALWAYS_YES=YES` fixed by https://github.com/ocaml/ocaml-ci-scripts/pull/343.

(as well as simplifying the yaml file a little)