### PR TITLE
Issue 596: replace exception by "not allowed" message

### DIFF
--- a/src/analysis/destruct.ml.new
+++ b/src/analysis/destruct.ml.new
@@ -237,8 +237,9 @@ let rec get_every_pattern = function
       in
       loc, patterns
     | _ ->
-      let s = Json.to_string (Browse_misc.dump_browse parent) in
-      raise  (Wrong_parent (sprintf "get_every_pattern: %s" s)) (* Something went wrong. *)
+      (* We were not in a match *)
+      let s = Mbrowse.print_node () parent in
+      raise  (Not_allowed s)
 
 let rec destructible patt =
   let open Typedtree in

--- a/src/analysis/destruct.ml.old
+++ b/src/analysis/destruct.ml.old
@@ -241,8 +241,9 @@ let rec get_every_pattern = function
       in
       loc, patterns
     | _ ->
-      let s = Json.to_string (Browse_misc.dump_browse parent) in
-      raise  (Wrong_parent (sprintf "get_every_pattern: %s" s)) (* Something went wrong. *)
+      (* We were not in a match *)
+      let s = Mbrowse.print_node () parent in
+      raise  (Not_allowed s)
 
 let rec destructible patt =
   let open Typedtree in

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -306,6 +306,23 @@
 (alias (name runtest) (deps (alias destruct-from_val)))
 
 (alias
+ (name destruct-issue596)
+ (package merlin)
+ (deps (:t ./test-dirs/destruct/issue596.t)
+       (source_tree ./test-dirs/destruct)
+       %{bin:ocamlmerlin}
+       %{bin:ocamlmerlin-server}
+       %{bin:dot-merlin-reader})
+ (action
+   (chdir ./test-dirs/destruct
+     (setenv MERLIN %{exe:merlin-wrapper}
+     (setenv OCAMLC %{ocamlc}
+       (progn
+         (run %{bin:mdx} test --syntax=cram %{t})
+         (diff? %{t} %{t}.corrected)))))))
+(alias (name runtest) (deps (alias destruct-issue596)))
+
+(alias
  (name errors-alerts-test-pre-408)(enabled_if (< %{ocaml_version} 4.08.0))
  (package merlin)
  (deps (:t ./test-dirs/errors/alerts/test-pre-408.t)

--- a/tests/test-dirs/destruct/basic.t
+++ b/tests/test-dirs/destruct/basic.t
@@ -134,12 +134,8 @@ pprintast).
 
   $ echo "let () = ()" | $MERLIN single case-analysis -start 1:4 -end 1:4 -filename stacktrace.ml | grep -E -v "Raised|Called|Re-raised"
   {
-    "class": "exception",
-    "value": "Destruct.Wrong_parent(\"get_every_pattern: [{\\\"filename\\\":\\\"stacktrace.ml\\\",\\\"start\\\":{\\\"line\\\":1,\\\"col\\\":0},\\\"end\\\":{\\\"line\\\":1,\\\"col\\\":11},\\\"ghost\\\":false,\\\"attrs\\\":[],\\\"kind\\\":\\\"value_binding\\\",\\\"children\\\":[{\\\"filename\\\":\\\"stacktrace.ml\\\",\\\"start\\\":{\\\"line\\\":1,\\\"col\\\":4},\\\"end\\\":{\\\"line\\\":1,\\\"col\\\":6},\\\"ghost\\\":false,\\\"attrs\\\":[],\\\"kind\\\":\\\"pattern (stacktrace.ml[1,0+4]..stacktrace.ml[1,0+6])\\\
-    Tpat_construct \\\\\\\"()\\\\\\\"\\\
-    []\\\
-  \\\",\\\"children\\\":[]},{\\\"filename\\\":\\\"stacktrace.ml\\\",\\\"start\\\":{\\\"line\\\":1,\\\"col\\\":9},\\\"end\\\":{\\\"line\\\":1,\\\"col\\\":11},\\\"ghost\\\":false,\\\"attrs\\\":[],\\\"kind\\\":\\\"expression\\\",\\\"children\\\":[]}]}]\")
-  ",
+    "class": "error",
+    "value": "Destruct not allowed on value_binding",
     "notifications": []
   }
 

--- a/tests/test-dirs/destruct/issue596.t
+++ b/tests/test-dirs/destruct/issue596.t
@@ -1,0 +1,8 @@
+  $ $MERLIN single case-analysis -start 1:5 -end 1:5 -filename bug.ml <<EOF | sed -e 's/,_)/, _)/g' \
+  > let a = 1 in a + 1 ;; \
+  > EOF
+  {
+    "class": "error",
+    "value": "Destruct not allowed on value_binding",
+    "notifications": []
+  }


### PR DESCRIPTION
This fixes #596 

I guess that it is reasonable to assume that when `get_every_pattern` finds an unexpected parent that means we are not in a position where destruct is allowed.