### PR TITLE
new Local_store API

### DIFF
--- a/src/kernel/mocaml.ml
+++ b/src/kernel/mocaml.ml
@@ -5,7 +5,7 @@ open Local_store.Compiler
 
 type typer_state = Local_store.scope
 
-let current_state = srefk None
+let current_state = s_ref None
 
 let new_state () =
   let scope = Local_store.fresh compiler_state in

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -18,7 +18,7 @@ type typedtree = [
   | `Implementation of Typedtree.structure
 ]
 
-let cache = srefk None
+let cache = s_ref None
 
 let fresh_env config =
   let env0 = Typer_raw.fresh_env () in

--- a/src/ocaml/typing/402/btype.ml
+++ b/src/ocaml/typing/402/btype.ml
@@ -17,6 +17,8 @@
 open Misc
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -39,7 +41,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; id = !new_id }

--- a/src/ocaml/typing/402/btype.ml
+++ b/src/ocaml/typing/402/btype.ml
@@ -602,9 +602,9 @@ type snapshot = changes ref * int
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
-let last_snapshot = sref (fun () -> 0)
-let linked_variables = sref (fun () -> 0)
+let trail = s_table Weak.create 1
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()

--- a/src/ocaml/typing/402/ctype.ml
+++ b/src/ocaml/typing/402/ctype.ml
@@ -19,6 +19,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -113,10 +115,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/402/env.ml
+++ b/src/ocaml/typing/402/env.ml
@@ -28,14 +28,14 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -78,9 +78,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -296,7 +296,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 type pers_typemap =
@@ -313,11 +313,11 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
 let imported_units = ref String.Set.empty
 

--- a/src/ocaml/typing/402/ident.ml
+++ b/src/ocaml/typing/402/ident.ml
@@ -11,6 +11,7 @@
 (***********************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; mutable flags: int }
 
@@ -19,7 +20,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/402/subst.ml
+++ b/src/ocaml/typing/402/subst.ml
@@ -19,6 +19,8 @@ open Path
 open Types
 open Btype
 
+open Local_store.Compiler
+
 type t =
   { types: (Ident.t, Path.t) Tbl.t;
     modules: (Ident.t, Path.t) Tbl.t;
@@ -95,7 +97,7 @@ let type_path s = function
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/403/btype.ml
+++ b/src/ocaml/typing/403/btype.ml
@@ -88,7 +88,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -647,8 +647,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/403/btype.ml
+++ b/src/ocaml/typing/403/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; id = !new_id }

--- a/src/ocaml/typing/403/ctype.ml
+++ b/src/ocaml/typing/403/ctype.ml
@@ -22,6 +22,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -87,10 +89,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/403/env.ml
+++ b/src/ocaml/typing/403/env.ml
@@ -31,14 +31,14 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -78,9 +78,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -335,7 +335,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -353,18 +353,18 @@ type pers_struct = {
 }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -389,7 +389,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -734,7 +734,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =

--- a/src/ocaml/typing/403/ident.ml
+++ b/src/ocaml/typing/403/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; mutable flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/403/subst.ml
+++ b/src/ocaml/typing/403/subst.ml
@@ -20,6 +20,8 @@ open Path
 open Types
 open Btype
 
+open Local_store.Compiler
+
 type t =
   { types: (Ident.t, Path.t) Tbl.t;
     modules: (Ident.t, Path.t) Tbl.t;
@@ -107,7 +109,7 @@ let type_path s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/404/btype.ml
+++ b/src/ocaml/typing/404/btype.ml
@@ -88,7 +88,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -647,8 +647,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/404/btype.ml
+++ b/src/ocaml/typing/404/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; id = !new_id }

--- a/src/ocaml/typing/404/ctype.ml
+++ b/src/ocaml/typing/404/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -85,10 +87,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/404/env.ml
+++ b/src/ocaml/typing/404/env.ml
@@ -29,15 +29,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -77,9 +77,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -346,7 +346,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -359,18 +359,18 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -395,7 +395,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -767,7 +767,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1193,7 +1193,7 @@ let lookup_cltype ?loc lid env =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env mty =
   match mty with
@@ -2447,8 +2447,8 @@ let summary env =
   if PathMap.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/404/ident.ml
+++ b/src/ocaml/typing/404/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; mutable flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/404/subst.ml
+++ b/src/ocaml/typing/404/subst.ml
@@ -20,6 +20,8 @@ open Path
 open Types
 open Btype
 
+open Local_store.Compiler
+
 type t =
   { types: (Ident.t, Path.t) Tbl.t;
     modules: (Ident.t, Path.t) Tbl.t;
@@ -107,7 +109,7 @@ let type_path s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/405/btype.ml
+++ b/src/ocaml/typing/405/btype.ml
@@ -89,7 +89,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -652,8 +652,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/405/btype.ml
+++ b/src/ocaml/typing/405/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; id = !new_id }

--- a/src/ocaml/typing/405/ctype.ml
+++ b/src/ocaml/typing/405/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -85,10 +87,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/405/env.ml
+++ b/src/ocaml/typing/405/env.ml
@@ -29,15 +29,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -77,9 +77,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -346,7 +346,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -359,18 +359,18 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -395,7 +395,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -767,7 +767,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1193,7 +1193,7 @@ let lookup_cltype ?loc lid env =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env mty =
   match mty with
@@ -2443,8 +2443,8 @@ let summary env =
   if PathMap.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/405/ident.ml
+++ b/src/ocaml/typing/405/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; mutable flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/405/subst.ml
+++ b/src/ocaml/typing/405/subst.ml
@@ -20,6 +20,8 @@ open Path
 open Types
 open Btype
 
+open Local_store.Compiler
+
 type t =
   { types: (Ident.t, Path.t) Tbl.t;
     modules: (Ident.t, Path.t) Tbl.t;
@@ -103,7 +105,7 @@ let type_path s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/406/btype.ml
+++ b/src/ocaml/typing/406/btype.ml
@@ -89,7 +89,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -652,8 +652,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/406/btype.ml
+++ b/src/ocaml/typing/406/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; id = !new_id }

--- a/src/ocaml/typing/406/ctype.ml
+++ b/src/ocaml/typing/406/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -85,10 +87,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/406/env.ml
+++ b/src/ocaml/typing/406/env.ml
@@ -29,15 +29,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -77,9 +77,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -576,7 +576,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -595,7 +595,7 @@ type pers_struct_key =
   }
 
 let persistent_structures : (string, pers_struct_key) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 let get_persistent_structure label =
   try Hashtbl.find !persistent_structures label
@@ -611,14 +611,14 @@ let has_persistent_structure label =
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -643,7 +643,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -1016,7 +1016,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1435,7 +1435,7 @@ let lookup_cltype ?loc lid env =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env mty =
   match mty with
@@ -2649,8 +2649,8 @@ let summary env =
   if PathMap.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/406/ident.ml
+++ b/src/ocaml/typing/406/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; mutable flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/406/subst.ml
+++ b/src/ocaml/typing/406/subst.ml
@@ -26,6 +26,8 @@ type type_replacement =
 
 module PathMap = Path.Map
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement PathMap.t;
     modules: Path.t PathMap.t;
@@ -131,7 +133,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/407/btype.ml
+++ b/src/ocaml/typing/407/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = None; id = !new_id }

--- a/src/ocaml/typing/407/btype.ml
+++ b/src/ocaml/typing/407/btype.ml
@@ -90,7 +90,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -654,8 +654,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/407/ctype.ml
+++ b/src/ocaml/typing/407/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -85,10 +87,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/407/env.ml
+++ b/src/ocaml/typing/407/env.ml
@@ -29,15 +29,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -77,9 +77,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -567,7 +567,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -580,18 +580,18 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -616,7 +616,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -986,7 +986,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1420,7 +1420,7 @@ let lookup_cltype ?loc ?(mark = true) lid env =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env mty =
   match mty with
@@ -2624,8 +2624,8 @@ let summary env =
   if PathMap.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/407/ident.ml
+++ b/src/ocaml/typing/407/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/407/subst.ml
+++ b/src/ocaml/typing/407/subst.ml
@@ -26,6 +26,8 @@ type type_replacement =
 
 module PathMap = Path.Map
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement PathMap.t;
     modules: Path.t PathMap.t;
@@ -131,7 +133,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/407_0/btype.ml
+++ b/src/ocaml/typing/407_0/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = None; id = !new_id }

--- a/src/ocaml/typing/407_0/btype.ml
+++ b/src/ocaml/typing/407_0/btype.ml
@@ -90,7 +90,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -654,8 +654,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/407_0/ctype.ml
+++ b/src/ocaml/typing/407_0/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -85,10 +87,10 @@ exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/407_0/env.ml
+++ b/src/ocaml/typing/407_0/env.ml
@@ -29,15 +29,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -77,9 +77,9 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
-let prefixed_sg = sref (fun () -> Hashtbl.create 113)
+let prefixed_sg = s_table Hashtbl.create 113
 
 type error =
   | Illegal_renaming of string * string * string
@@ -567,7 +567,7 @@ let get_components c =
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 (* Persistent structure descriptions *)
 
@@ -580,18 +580,18 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -616,7 +616,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_ref Short_paths.Basis.create
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -986,7 +986,7 @@ let find_module ~alias path env =
           raise Not_found
       end
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1421,7 +1421,7 @@ let lookup_cltype ?loc ?(mark = true) lid env =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env mty =
   match mty with
@@ -2625,8 +2625,8 @@ let summary env =
   if PathMap.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/407_0/ident.ml
+++ b/src/ocaml/typing/407_0/ident.ml
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 open Format
+open Local_store.Compiler
 
 type t = { stamp: int; name: string; flags: int }
 
@@ -22,7 +23,7 @@ let predef_exn_flag = 2
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
+let currentstamp = s_ref 0
 
 let create s =
   incr currentstamp;

--- a/src/ocaml/typing/407_0/subst.ml
+++ b/src/ocaml/typing/407_0/subst.ml
@@ -26,6 +26,8 @@ type type_replacement =
 
 module PathMap = Path.Map
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement PathMap.t;
     modules: Path.t PathMap.t;
@@ -131,7 +133,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/408/btype.ml
+++ b/src/ocaml/typing/408/btype.ml
@@ -89,7 +89,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -699,8 +699,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/408/btype.ml
+++ b/src/ocaml/typing/408/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = lowest_level; id = !new_id }

--- a/src/ocaml/typing/408/ctype.ml
+++ b/src/ocaml/typing/408/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -169,10 +171,10 @@ exception Cannot_apply
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/408/env.ml
+++ b/src/ocaml/typing/408/env.ml
@@ -28,15 +28,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -76,7 +76,7 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
 type error =
   | Illegal_renaming of string * string * string
@@ -553,7 +553,7 @@ type can_load_cmis =
   | Can_load_cmis
   | Cannot_load_cmis of EnvLazy.log
 
-let can_load_cmis = srefk Can_load_cmis
+let can_load_cmis = s_ref Can_load_cmis
 
 let without_cmis f x =
   let log = EnvLazy.log () in
@@ -626,7 +626,7 @@ let rec print_address ppf = function
 (* The name of the compilation unit currently compiled.
    "" if outside a compilation unit. *)
 
-let current_unit = srefk ""
+let current_unit = s_ref ""
 
 let find_same_module id tbl =
   match IdTbl.find_same id tbl with
@@ -652,18 +652,18 @@ type pers_struct =
     ps_flags: pers_flags list }
 
 let persistent_structures : (string, pers_struct option) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 17)
+  s_table Hashtbl.create 17
 
 (* Consistency between persistent structures *)
 
-let crc_units = sref Consistbl.create
+let crc_units = s_table Consistbl.create ()
 
-let imported_units = srefk String.Set.empty
+let imported_units = s_ref String.Set.empty
 
 let add_import s =
   imported_units := String.Set.add s !imported_units
 
-let imported_opaque_units = srefk String.Set.empty
+let imported_opaque_units = s_ref String.Set.empty
 
 let add_imported_opaque s =
   imported_opaque_units := String.Set.add s !imported_opaque_units
@@ -688,7 +688,7 @@ let check_consistency ps =
 
 (* Short paths basis *)
 
-let short_paths_basis = sref Short_paths.Basis.create
+let short_paths_basis = s_table Short_paths.Basis.create ()
 
 let short_paths_module_components_desc' = ref (fun _ -> assert false)
 
@@ -1127,7 +1127,7 @@ let find_constructor_address path env =
   | Papply _ ->
       raise Not_found
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1630,7 +1630,7 @@ let may_subst subst_f sub x =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env sub mty =
   match mty with
@@ -3041,8 +3041,8 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/408/ident.ml
+++ b/src/ocaml/typing/408/ident.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Local_store.Compiler
+
 let lowest_scope  = 0
 let highest_scope = 100000000
 
@@ -26,8 +28,8 @@ type t =
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
-let predefstamp = ref 0
+let currentstamp = s_ref 0
+let predefstamp = s_ref 0
 
 let create_scoped ~scope s =
   incr currentstamp;

--- a/src/ocaml/typing/408/subst.ml
+++ b/src/ocaml/typing/408/subst.ml
@@ -24,6 +24,8 @@ type type_replacement =
   | Path of Path.t
   | Type_function of { params : type_expr list; body : type_expr }
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -129,7 +131,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/409/btype.ml
+++ b/src/ocaml/typing/409/btype.ml
@@ -89,7 +89,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -699,8 +699,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/409/btype.ml
+++ b/src/ocaml/typing/409/btype.ml
@@ -19,6 +19,8 @@ open Misc
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -41,7 +43,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = lowest_level; id = !new_id }

--- a/src/ocaml/typing/409/ctype.ml
+++ b/src/ocaml/typing/409/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -180,10 +182,10 @@ exception Cannot_apply
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/409/env.ml
+++ b/src/ocaml/typing/409/env.ml
@@ -28,15 +28,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -76,7 +76,7 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
 type error =
   | Missing_module of Location.t * Path.t * Path.t
@@ -688,7 +688,7 @@ let read_sign_of_cmi = sign_of_cmi ~freshen:true
 let save_sign_of_cmi = sign_of_cmi ~freshen:false
 
 let persistent_env : persistent_module Persistent_env.t ref =
-  sref Persistent_env.empty
+  s_table Persistent_env.empty ()
 
 let without_cmis f x =
   Persistent_env.without_cmis !persistent_env f x
@@ -948,7 +948,7 @@ let find_constructor_address path env =
   | Papply _ ->
       raise Not_found
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -1461,7 +1461,7 @@ let may_subst subst_f sub x =
    not yet evaluated structures) *)
 
 type iter_cont = unit -> unit
-let iter_env_cont = srefk []
+let iter_env_cont = s_ref []
 
 let rec scrape_alias_for_visit env sub mty =
   match mty with
@@ -2826,8 +2826,8 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/409/ident.ml
+++ b/src/ocaml/typing/409/ident.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Local_store.Compiler
+
 let lowest_scope  = 0
 let highest_scope = 100000000
 
@@ -26,8 +28,8 @@ type t =
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
-let predefstamp = ref 0
+let currentstamp = s_ref 0
+let predefstamp = s_ref 0
 
 let create_scoped ~scope s =
   incr currentstamp;

--- a/src/ocaml/typing/409/subst.ml
+++ b/src/ocaml/typing/409/subst.ml
@@ -24,6 +24,8 @@ type type_replacement =
   | Path of Path.t
   | Type_function of { params : type_expr list; body : type_expr }
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -129,7 +131,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/410/btype.ml
+++ b/src/ocaml/typing/410/btype.ml
@@ -18,6 +18,8 @@
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -40,7 +42,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = lowest_level; id = !new_id }

--- a/src/ocaml/typing/410/btype.ml
+++ b/src/ocaml/typing/410/btype.ml
@@ -85,7 +85,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -720,8 +720,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/410/ctype.ml
+++ b/src/ocaml/typing/410/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -187,10 +189,10 @@ exception Cannot_apply
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/410/env.ml
+++ b/src/ocaml/typing/410/env.ml
@@ -28,15 +28,15 @@ open Local_store.Compiler
 let add_delayed_check_forward = ref (fun _ -> assert false)
 
 let value_declarations : ((string * Location.t), (unit -> unit)) Hashtbl.t ref =
-  sref (fun () -> Hashtbl.create 16)
+  s_table Hashtbl.create 16
     (* This table is used to usage of value declarations.  A declaration is
        identified with its name and location.  The callback attached to a
        declaration is called whenever the value is used explicitly
        (lookup_value) or implicitly (inclusion test between signatures,
        cf Includemod.value_descriptions). *)
 
-let type_declarations = sref (fun () -> Hashtbl.create 16)
-let module_declarations = sref (fun () -> Hashtbl.create 16)
+let type_declarations = s_table Hashtbl.create 16
+let module_declarations = s_table Hashtbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -88,7 +88,7 @@ let constructor_usages () =
 
 let used_constructors :
     (string * Location.t * string, (constructor_usage -> unit)) Hashtbl.t ref
-  = sref (fun () -> Hashtbl.create 16)
+  = s_table Hashtbl.create 16
 
 (** Map indexed by the name of module components. *)
 module NameMap = String.Map
@@ -822,7 +822,7 @@ let read_sign_of_cmi = sign_of_cmi ~freshen:true
 let save_sign_of_cmi = sign_of_cmi ~freshen:false
 
 let persistent_env : module_data Persistent_env.t ref =
-  sref Persistent_env.empty
+  s_table Persistent_env.empty ()
 
 let without_cmis f x =
   Persistent_env.without_cmis !persistent_env f x
@@ -1115,7 +1115,7 @@ let find_hash_type path env =
   | Papply _ ->
       raise Not_found
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -3110,8 +3110,8 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/410/ident.ml
+++ b/src/ocaml/typing/410/ident.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Local_store.Compiler
+
 let lowest_scope  = 0
 let highest_scope = 100000000
 
@@ -26,8 +28,8 @@ type t =
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
-let predefstamp = ref 0
+let currentstamp = s_ref 0
+let predefstamp = s_ref 0
 
 let create_scoped ~scope s =
   incr currentstamp;

--- a/src/ocaml/typing/410/subst.ml
+++ b/src/ocaml/typing/410/subst.ml
@@ -24,6 +24,8 @@ type type_replacement =
   | Path of Path.t
   | Type_function of { params : type_expr list; body : type_expr }
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -129,7 +131,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/typing/411/btype.ml
+++ b/src/ocaml/typing/411/btype.ml
@@ -85,7 +85,7 @@ type changes =
 
 open Local_store.Compiler
 
-let trail = sref (fun () -> Weak.create 1)
+let trail = s_table Weak.create 1
 
 let log_change ch =
   match Weak.get !trail 0 with None -> ()
@@ -722,8 +722,8 @@ let undo_change = function
   | Cfun f -> f ()
 
 type snapshot = changes ref * int
-let last_snapshot = srefk 0
-let linked_variables = srefk 0
+let last_snapshot = s_ref 0
+let linked_variables = s_ref 0
 
 let log_type ty =
   if ty.id <= !last_snapshot then log_change (Ctype (ty, ty.desc))

--- a/src/ocaml/typing/411/btype.ml
+++ b/src/ocaml/typing/411/btype.ml
@@ -18,6 +18,8 @@
 open Asttypes
 open Types
 
+open Local_store.Compiler
+
 (**** Sets, maps and hashtables of types ****)
 
 module TypeSet = Set.Make(TypeOps)
@@ -40,7 +42,7 @@ let pivot_level = 2 * lowest_level - 1
 
 (**** Some type creators ****)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 
 let newty2 level desc  =
   incr new_id; { desc; level; scope = lowest_level; id = !new_id }

--- a/src/ocaml/typing/411/ctype.ml
+++ b/src/ocaml/typing/411/ctype.ml
@@ -20,6 +20,8 @@ open Asttypes
 open Types
 open Btype
 
+open Local_store.Compiler
+
 (*
    Type manipulation after type inference
    ======================================
@@ -187,10 +189,10 @@ exception Cannot_apply
 
 (**** Type level management ****)
 
-let current_level = ref 0
-let nongen_level = ref 0
-let global_level = ref 1
-let saved_level = ref []
+let current_level = s_ref 0
+let nongen_level = s_ref 0
+let global_level = s_ref 1
+let saved_level = s_ref []
 
 type levels =
     { current_level: int; nongen_level: int; global_level: int;

--- a/src/ocaml/typing/411/env.ml
+++ b/src/ocaml/typing/411/env.ml
@@ -37,9 +37,9 @@ type 'a usage_tbl = ('a -> unit) Types.Uid.Tbl.t
     (inclusion test between signatures, cf Includemod.value_descriptions, ...).
 *)
 
-let value_declarations  : unit usage_tbl ref = sref (fun () -> Types.Uid.Tbl.create 16)
-let type_declarations   : unit usage_tbl ref = sref (fun () -> Types.Uid.Tbl.create 16)
-let module_declarations : unit usage_tbl ref = sref (fun () -> Types.Uid.Tbl.create 16)
+let value_declarations  : unit usage_tbl ref = s_table Types.Uid.Tbl.create 16
+let type_declarations   : unit usage_tbl ref = s_table Types.Uid.Tbl.create 16
+let module_declarations : unit usage_tbl ref = s_table Types.Uid.Tbl.create 16
 
 type constructor_usage = Positive | Pattern | Privatize
 type constructor_usages =
@@ -67,7 +67,7 @@ let constructor_usages () =
   {cu_positive = false; cu_pattern = false; cu_privatize = false}
 
 let used_constructors : constructor_usage usage_tbl ref =
-  sref (fun () -> Types.Uid.Tbl.create 16)
+  s_table Types.Uid.Tbl.create 16
 
 (** Map indexed by the name of module components. *)
 module NameMap = String.Map
@@ -806,7 +806,7 @@ let read_sign_of_cmi = sign_of_cmi ~freshen:true
 let save_sign_of_cmi = sign_of_cmi ~freshen:false
 
 let persistent_env : module_data Persistent_env.t ref =
-  sref Persistent_env.empty
+  s_table Persistent_env.empty ()
 
 let without_cmis f x =
   Persistent_env.without_cmis !persistent_env f x
@@ -1106,7 +1106,7 @@ let find_hash_type path env =
   | Papply _ ->
       raise Not_found
 
-let required_globals = srefk []
+let required_globals = s_ref []
 let reset_required_globals () = required_globals := []
 let get_required_globals () = !required_globals
 let add_required_global id =
@@ -3100,8 +3100,8 @@ let summary env =
   if Path.Map.is_empty env.local_constraints then env.summary
   else Env_constraints (env.summary, env.local_constraints)
 
-let last_env = srefk empty
-let last_reduced_env = srefk empty
+let last_env = s_ref empty
+let last_reduced_env = s_ref empty
 
 let keep_only_summary env =
   if !last_env == env then !last_reduced_env

--- a/src/ocaml/typing/411/ident.ml
+++ b/src/ocaml/typing/411/ident.ml
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Local_store.Compiler
+
 let lowest_scope  = 0
 let highest_scope = 100000000
 
@@ -26,8 +28,8 @@ type t =
 
 (* A stamp of 0 denotes a persistent identifier *)
 
-let currentstamp = ref 0
-let predefstamp = ref 0
+let currentstamp = s_ref 0
+let predefstamp = s_ref 0
 
 let create_scoped ~scope s =
   incr currentstamp;

--- a/src/ocaml/typing/411/subst.ml
+++ b/src/ocaml/typing/411/subst.ml
@@ -24,6 +24,8 @@ type type_replacement =
   | Path of Path.t
   | Type_function of { params : type_expr list; body : type_expr }
 
+open Local_store.Compiler
+
 type t =
   { types: type_replacement Path.Map.t;
     modules: Path.t Path.Map.t;
@@ -129,7 +131,7 @@ let to_subst_by_type_function s p =
 
 (* Special type ids for saved signatures *)
 
-let new_id = ref (-1)
+let new_id = s_ref (-1)
 let reset_for_saving () = new_id := -1
 
 let newpersty desc =

--- a/src/ocaml/utils/402/config.ml
+++ b/src/ocaml/utils/402/config.ml
@@ -36,7 +36,7 @@ and ast_intf_magic_number = "Caml1999N015"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T004"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/403/config.ml
+++ b/src/ocaml/utils/403/config.ml
@@ -43,7 +43,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T007"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/404/config.ml
+++ b/src/ocaml/utils/404/config.ml
@@ -47,7 +47,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T008"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/405/config.ml
+++ b/src/ocaml/utils/405/config.ml
@@ -47,7 +47,7 @@ and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T009"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/406/config.ml
+++ b/src/ocaml/utils/406/config.ml
@@ -50,7 +50,7 @@ and cmxs_magic_number = "Caml1999D022"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T022"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/407/config.ml
+++ b/src/ocaml/utils/407/config.ml
@@ -50,7 +50,7 @@ and cmxs_magic_number = "Caml1999D023"
     (* cmxs_magic_number is duplicated in otherlibs/dynlink/natdynlink.ml *)
 and cmt_magic_number = "Caml1999T024"
 
-let load_path = srefk ([] : string list)
+let load_path = s_ref ([] : string list)
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/408/load_path.ml
+++ b/src/ocaml/utils/408/load_path.ml
@@ -19,8 +19,8 @@ type registry = string SMap.t ref
 
 open Local_store.Compiler
 
-let files : registry = srefk SMap.empty
-let files_uncap : registry = srefk SMap.empty
+let files : registry = s_ref SMap.empty
+let files_uncap : registry = s_ref SMap.empty
 
 module Dir = struct
   type t = {
@@ -35,7 +35,7 @@ module Dir = struct
     { path; files = Array.to_list (Directory_content_cache.read path) }
 end
 
-let dirs = srefk []
+let dirs = s_ref []
 
 let reset () =
   assert (Local_store.is_bound compiler_state);

--- a/src/ocaml/utils/409/load_path.ml
+++ b/src/ocaml/utils/409/load_path.ml
@@ -19,8 +19,8 @@ type registry = string SMap.t ref
 
 open Local_store.Compiler
 
-let files : registry = srefk SMap.empty
-let files_uncap : registry = srefk SMap.empty
+let files : registry = s_ref SMap.empty
+let files_uncap : registry = s_ref SMap.empty
 
 module Dir = struct
   type t = {
@@ -35,7 +35,7 @@ module Dir = struct
     { path; files = Array.to_list (Directory_content_cache.read path) }
 end
 
-let dirs = srefk []
+let dirs = s_ref []
 
 let reset () =
   assert (Local_store.is_bound compiler_state);

--- a/src/ocaml/utils/410/load_path.ml
+++ b/src/ocaml/utils/410/load_path.ml
@@ -19,8 +19,8 @@ type registry = string SMap.t ref
 
 open Local_store.Compiler
 
-let files : registry = srefk SMap.empty
-let files_uncap : registry = srefk SMap.empty
+let files : registry = s_ref SMap.empty
+let files_uncap : registry = s_ref SMap.empty
 
 module Dir = struct
   type t = {
@@ -35,7 +35,7 @@ module Dir = struct
     { path; files = Array.to_list (Directory_content_cache.read path) }
 end
 
-let dirs = srefk []
+let dirs = s_ref []
 
 let reset () =
   assert (Local_store.is_bound compiler_state);

--- a/src/ocaml/utils/411/load_path.ml
+++ b/src/ocaml/utils/411/load_path.ml
@@ -19,8 +19,8 @@ type registry = string SMap.t ref
 
 open Local_store.Compiler
 
-let files : registry = srefk SMap.empty
-let files_uncap : registry = srefk SMap.empty
+let files : registry = s_ref SMap.empty
+let files_uncap : registry = s_ref SMap.empty
 
 module Dir = struct
   type t = {
@@ -35,7 +35,7 @@ module Dir = struct
     { path; files = Array.to_list (Directory_content_cache.read path) }
 end
 
-let dirs = srefk []
+let dirs = s_ref []
 
 let reset () =
   assert (Local_store.is_bound compiler_state);

--- a/src/utils/local_store.ml
+++ b/src/utils/local_store.ml
@@ -1,6 +1,7 @@
-open Std
+type ref_and_reset =
+  | Table : { ref: 'a ref; init: unit -> 'a } -> ref_and_reset
+  | Immutable : { ref: 'a ref; mutable snapshot: 'a } -> ref_and_reset
 
-type ref_and_reset = F : 'a ref * (unit -> 'a) -> ref_and_reset
 type bindings = {
   mutable refs: ref_and_reset list;
   mutable frozen : bool;
@@ -14,45 +15,50 @@ let is_bound t = !(t.is_bound)
 
 let reset t =
   assert (is_bound t);
-  List.iter ~f:(fun (F (ref, initializer_)) -> ref := initializer_ ()) t.refs
+  List.iter (function
+    | Table { ref; init } -> ref := init ()
+    | Immutable { ref; snapshot } -> ref := snapshot
+  ) t.refs
 
-let ref t f =
-  let result = ref (f ()) in
+let table t create size =
+  let init () = create size in
+  let ref = ref (init ()) in
   assert (not t.frozen);
-  t.refs <- (F (result, f)) :: t.refs;
-  result
+  t.refs <- (Table { ref; init }) :: t.refs;
+  ref
 
-type 'a slot = { ref : 'a ref; mutable value : 'a }
-type a_slot = Slot : 'a slot -> a_slot
-type scope = { slots: a_slot list; scope_bound : bool ref }
+let ref t k =
+  let ref = ref k in
+  assert (not t.frozen);
+  t.refs <- (Immutable { ref; snapshot = k }) :: t.refs;
+  ref
+
+type slot = Slot : { ref : 'a ref; mutable value : 'a } -> slot
+type scope = { slots: slot list; scope_bound : bool ref }
 
 let fresh t =
+  let slots =
+    List.map (function
+      | Table { ref; init } -> Slot {ref; value = init ()}
+      | Immutable r ->
+          if not t.frozen then r.snapshot <- !(r.ref);
+          Slot { ref = r.ref; value = r.snapshot }
+    ) t.refs
+  in
   t.frozen <- true;
-  { slots = List.map ~f:(fun (F(ref,f)) -> Slot {ref; value = f ()}) t.refs;
-    scope_bound = t.is_bound }
-
-type ref_and_value = V : 'a ref * 'a -> ref_and_value
-let restore l = List.iter ~f:(fun (V(r,v)) -> r := v) l
+  { slots; scope_bound = t.is_bound }
 
 let with_scope { slots; scope_bound } f =
   assert (not !scope_bound);
   scope_bound := true;
-  let backup = List.rev_map ~f:(fun (Slot {ref;_}) -> V (ref,!ref)) slots in
-  List.iter ~f:(fun (Slot {ref;value}) -> ref := value) slots;
-  match f () with
-  | x ->
-    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) slots;
-    scope_bound := false;
-    restore backup;
-    x
-  | exception exn ->
-    List.iter ~f:(fun (Slot s) -> s.value <- !(s.ref)) slots;
-    scope_bound := false;
-    restore backup;
-    reraise exn
+  List.iter (fun (Slot {ref;value}) -> ref := value) slots;
+  Fun.protect f ~finally:(fun () ->
+    List.iter (fun (Slot s) -> s.value <- !(s.ref)) slots;
+    scope_bound := false
+  )
 
 module Compiler = struct
   let compiler_state = new_bindings ()
-  let sref f = ref compiler_state f
-  let srefk k = ref compiler_state (fun () -> k)
+  let s_table f n = table compiler_state f n
+  let s_ref k = ref compiler_state k
 end

--- a/src/utils/local_store.mli
+++ b/src/utils/local_store.mli
@@ -5,7 +5,8 @@ val new_bindings : unit -> bindings
 val is_bound : bindings -> bool
 val reset : bindings -> unit
 
-val ref : bindings -> (unit -> 'a) -> 'a ref
+val table : bindings -> ('a -> 'b) -> 'a -> 'b ref
+val ref : bindings -> 'a -> 'a ref
 
 type scope
 val fresh : bindings -> scope
@@ -15,6 +16,6 @@ val with_scope : scope -> (unit -> 'a) -> 'a
 
 module Compiler : sig
   val compiler_state : bindings
-  val sref : (unit -> 'a) -> 'a ref
-  val srefk : 'a -> 'a ref
+  val s_ref : 'a -> 'a ref
+  val s_table : ('a -> 'b) -> 'a -> 'b ref
 end


### PR DESCRIPTION
Some pre-upstreaming simplifications.
There are now two kinds of things that can be bound in the local store:
- tables (which are mutable) and must come with an initializer
- refs to immutable values: these take an initial value but get snapshoted once the bindings are frozen

This reimplement #1180 and a bit more using these new primitives.