### PR TITLE
The dot-merlin-reader package is always only valid for a limited set of OCaml compilers

### DIFF
--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "4.12"}
   "dune" {>= "1.8.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}


### PR DESCRIPTION
This package currently fails on 4.12 with the following error:
```
#=== ERROR while compiling dot-merlin-reader.3.4.1 ============================#
# context              2.1.0~beta2 | linux/x86_64 | ocaml-variants.4.12.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0+trunk/.opam-switch/build/dot-merlin-reader.3.4.1
# command              ~/.opam/4.12.0+trunk/bin/dune build -p dot-merlin-reader -j 71
# exit-code            1
# env-file             ~/.opam/log/dot-merlin-reader-7-af57d6.env
# output-file          ~/.opam/log/dot-merlin-reader-7-af57d6.out
### output ###
# File "_build/.dune/default/src/ocaml/utils/dune", line 2, characters 13-25:
# 2 | (copy_files# 412/*.ml{,i})
#                  ^^^^^^^^^^^^
# Error: Cannot find directory: src/ocaml/utils/412
```
I believe it should always be constrained if it uses compiler version dependent code.