### PR TITLE
Add MerlinLocateImpl, MerlinLocateIntf commands

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -250,11 +250,9 @@ def differs_from_current_file(path):
 def vim_fnameescape(s):
     return vim.eval("fnameescape('%s')" % s.replace("'","''"))
 
-def command_locate(path, pos, choice):
+def command_locate(path, pos):
     try:
-        if choice is None:
-            choice = vim.eval('g:merlin_locate_preference')
-
+        choice = vim.eval('g:merlin_locate_preference')
         if pos is None:
             return command("locate", "-prefix", path, "-look-for", choice)
         else:
@@ -431,16 +429,10 @@ def vim_loclist(vimvar, ignore_warnings):
 
 # Locate
 def vim_locate_at_cursor(path):
-    command_locate(path, vim.current.window.cursor, None)
+    command_locate(path, vim.current.window.cursor)
 
 def vim_locate_under_cursor():
     vim_locate_at_cursor(None)
-
-def vim_locate_choice_at_cursor(path, choice):
-    command_locate(path, vim.current.window.cursor, choice)
-
-def vim_locate_choice_under_cursor(choice):
-    vim_locate_choice_at_cursor(None, choice)
 
 # Jump and Phrase motion
 def vim_jump_to(target):

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -250,9 +250,11 @@ def differs_from_current_file(path):
 def vim_fnameescape(s):
     return vim.eval("fnameescape('%s')" % s.replace("'","''"))
 
-def command_locate(path, pos):
+def command_locate(path, pos, choice):
     try:
-        choice = vim.eval('g:merlin_locate_preference')
+        if choice is None:
+            choice = vim.eval('g:merlin_locate_preference')
+
         if pos is None:
             return command("locate", "-prefix", path, "-look-for", choice)
         else:
@@ -429,10 +431,16 @@ def vim_loclist(vimvar, ignore_warnings):
 
 # Locate
 def vim_locate_at_cursor(path):
-    command_locate(path, vim.current.window.cursor)
+    command_locate(path, vim.current.window.cursor, None)
 
 def vim_locate_under_cursor():
     vim_locate_at_cursor(None)
+
+def vim_locate_choice_at_cursor(path, choice):
+    command_locate(path, vim.current.window.cursor, choice)
+
+def vim_locate_choice_under_cursor(choice):
+    vim_locate_choice_at_cursor(None, choice)
 
 # Jump and Phrase motion
 def vim_jump_to(target):

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -385,23 +385,17 @@ function! merlin#Locate(...)
 endfunction
 
 function! merlin#LocateImpl(...)
-  if (a:0 > 1)
-    echoerr "Locate: too many arguments (expected 0 or 1)"
-  elseif (a:0 == 0) || (a:1 == "")
-    MerlinPy merlin.vim_locate_choice_under_cursor("implementation")
-  else
-    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "implementation")
-  endif
+  let l:pref = g:merlin_locate_preference
+  let g:merlin_locate_preference = 'implementation'
+  call call("merlin#Locate", a:000)
+  let g:merlin_locate_preference = l:pref
 endfunction
 
 function! merlin#LocateIntf(...)
-  if (a:0 > 1)
-    echoerr "Locate: too many arguments (expected 0 or 1)"
-  elseif (a:0 == 0) || (a:1 == "")
-    MerlinPy merlin.vim_locate_choice_under_cursor("interface")
-  else
-    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "interface")
-  endif
+  let l:pref = g:merlin_locate_preference
+  let g:merlin_locate_preference = 'interface'
+  call call("merlin#Locate", a:000)
+  let g:merlin_locate_preference = l:pref
 endfunction
 
 function! merlin#Jump(...)

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -388,9 +388,9 @@ function! merlin#LocateImpl(...)
   if (a:0 > 1)
     echoerr "Locate: too many arguments (expected 0 or 1)"
   elseif (a:0 == 0) || (a:1 == "")
-    MerlinPy merlin.vim_locate_choice_under_cursor("ml")
+    MerlinPy merlin.vim_locate_choice_under_cursor("implementation")
   else
-    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "ml)
+    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "implementation")
   endif
 endfunction
 
@@ -398,9 +398,9 @@ function! merlin#LocateIntf(...)
   if (a:0 > 1)
     echoerr "Locate: too many arguments (expected 0 or 1)"
   elseif (a:0 == 0) || (a:1 == "")
-    MerlinPy merlin.vim_locate_choice_under_cursor("mli")
+    MerlinPy merlin.vim_locate_choice_under_cursor("interface")
   else
-    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "mli")
+    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "interface")
   endif
 endfunction
 

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -376,11 +376,31 @@ endfunction
 
 function! merlin#Locate(...)
   if (a:0 > 1)
-    echoerr "Locate: to many arguments (expected 0 or 1)"
+    echoerr "Locate: too many arguments (expected 0 or 1)"
   elseif (a:0 == 0) || (a:1 == "")
     MerlinPy merlin.vim_locate_under_cursor()
   else
     MerlinPy merlin.vim_locate_at_cursor(vim.eval("a:1"))
+  endif
+endfunction
+
+function! merlin#LocateImpl(...)
+  if (a:0 > 1)
+    echoerr "Locate: too many arguments (expected 0 or 1)"
+  elseif (a:0 == 0) || (a:1 == "")
+    MerlinPy merlin.vim_locate_choice_under_cursor("ml")
+  else
+    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "ml)
+  endif
+endfunction
+
+function! merlin#LocateIntf(...)
+  if (a:0 > 1)
+    echoerr "Locate: too many arguments (expected 0 or 1)"
+  elseif (a:0 == 0) || (a:1 == "")
+    MerlinPy merlin.vim_locate_choice_under_cursor("mli")
+  else
+    MerlinPy merlin.vim_locate_choice_at_cursor(vim.eval("a:1"), "mli")
   endif
 endfunction
 
@@ -570,6 +590,8 @@ function! merlin#Register()
 
   """ Locate  ------------------------------------------------------------------
   command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinLocate call merlin#Locate(<q-args>)
+  command! -buffer -nargs=? MerlinLocateImpl call merlin#LocateImpl(<q-args>)
+  command! -buffer -nargs=? MerlinLocateIntf call merlin#LocateIntf(<q-args>)
   command! -buffer -nargs=0 MerlinILocate call merlin#InteractiveLocate()
 
 

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -590,8 +590,8 @@ function! merlin#Register()
 
   """ Locate  ------------------------------------------------------------------
   command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinLocate call merlin#Locate(<q-args>)
-  command! -buffer -nargs=? MerlinLocateImpl call merlin#LocateImpl(<q-args>)
-  command! -buffer -nargs=? MerlinLocateIntf call merlin#LocateIntf(<q-args>)
+  command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinLocateImpl call merlin#LocateImpl(<q-args>)
+  command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinLocateIntf call merlin#LocateIntf(<q-args>)
   command! -buffer -nargs=0 MerlinILocate call merlin#InteractiveLocate()
 
 


### PR DESCRIPTION
I added these as part of my debugging for #1202, but they have turned out to be generally useful and low-cost to add.

The commands behave as `MerlinLocate`, but jumping to either the implementation or interface regardless of the contents of `g:merlin_locate_preference`.