### PR TITLE
Remove unused Emacs rule

### DIFF
--- a/emacs/dune
+++ b/emacs/dune
@@ -9,7 +9,3 @@
         (merlin-xref.el as emacs/site-lisp/merlin-xref.el)
         (merlin.el as emacs/site-lisp/merlin.el)))
 
-(rule
- (targets merlin.elc)
- (action (run
-   %{bin:emacs} --batch --no-init-file -f batch-byte-compile %{dep:merlin.el})))


### PR DESCRIPTION
Fixes #1210 

The target of the incriminating rule is not used anywhere else in the project. It is very unlikely that is is used by anyone.
This PR removes the rule.