### PR TITLE
Add OCAMLMERLIN_PATH env var to facilitate Merlin development

### DIFF
--- a/vim/merlin/plugin/merlin.vim
+++ b/vim/merlin/plugin/merlin.vim
@@ -9,8 +9,12 @@
 if !exists('g:merlin') | let g:merlin = {} | endif | let s:c = g:merlin
 let g:merlin_ignore_warnings = "false"
 
-let s:c.merlin_home = expand('<sfile>:h:h:h:h')
-let s:c.merlin_parent = expand('<sfile>:h:h:h:h:h')
+if exists("$OCAMLMERLIN_PATH")
+  let s:c.ocamlmerlin_path = $OCAMLMERLIN_PATH
+else
+  let s:c.merlin_home = expand('<sfile>:h:h:h:h')
+  let s:c.merlin_parent = expand('<sfile>:h:h:h:h:h')
+endif
 
 " Highlight the expression which type is given
 hi def link EnclosingExpr IncSearch


### PR DESCRIPTION
Allow OCAMLMERLIN_PATH env var to override the computed path for the ocamlmerlin
binary. This facilitates iterative development on Merlin.