### PR TITLE
Fix [List.uniq] to dedup non-adjacent elmements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
+_opam
 .merlin
 jbuild-workspace
 dune-workspace

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -281,7 +281,7 @@ module Utils = struct
           (Mconfig.source_path config) file
       ) Mconfig.(config.merlin.suffixes)
     in
-    List.uniq files ~cmp:String.compare
+    List.dedup_adjacent files ~cmp:String.compare
 
   let find_file_with_path ~config ?(with_fallback=false) file path =
     if File.name file = Misc.unitname Mconfig.(config.query.filename) then

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -668,7 +668,7 @@ let source_path config =
     [[config.query.directory];
      stdlib;
      config.merlin.source_path]
-  |> List.uniq ~cmp:String.compare
+  |> List.dedup_adjacent ~cmp:String.compare
 
 let build_path config = (
   let dirs =

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -668,6 +668,7 @@ let source_path config =
     [[config.query.directory];
      stdlib;
      config.merlin.source_path]
+  |> List.uniq ~cmp:String.compare
 
 let build_path config = (
   let dirs =

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -668,7 +668,7 @@ let source_path config =
     [[config.query.directory];
      stdlib;
      config.merlin.source_path]
-  |> List.dedup_adjacent ~cmp:String.compare
+  |> List.filter_dup
 
 let build_path config = (
   let dirs =

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -279,17 +279,6 @@ module List = struct
      be adjacent. *)
   let sort_uniq ~cmp l = dedup_adjacent ~cmp (sort ~cmp l)
 
-  let uniq (type t) ~cmp l =
-    let module Set = Set.Make (struct type nonrec t = t let compare = cmp end) in
-    let rec uniq ~cmp ~seen = function
-      | [] -> []
-      | x :: xs ->
-        match Set.mem x seen with
-        | true -> uniq ~cmp ~seen xs
-        | false -> x :: uniq ~cmp ~seen:(Set.add x seen) xs
-    in
-    uniq ~cmp ~seen:Set.empty l
-
   let print f () l =
     "[ " ^ String.concat "; " (List.map (f ()) l) ^ " ]"
 end


### PR DESCRIPTION
[List.uniq] only dedups adjacent duplicates. This is sufficient for
[List.sort_uniq], but can be surprising when invoked directly. This commit
patches [List.uniq] to dedup the whole list. It is also now used when retrieving
source paths, which can be duplicates but for which we might want to preserve
ordering.