### PR TITLE
Fix [locate] to look for non-pp source files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ git version
     - filter dups in source paths (#1218)
     - improve load path performance (#1323)
     - fix handlink of ppx's under Windows (#1413)
+    - locate: look for original source files before looking for preprocessed
+      files (#1219 by @ddickstein, fixes #894)
 
 merlin 4.4
 ==========
@@ -151,7 +153,7 @@ Tue Feb  2 03:13:37 PM CET 2021
     - emacs: add missing mandatory argument for define-obsolete-function-alias
       (#1250, by Atharva Shukla, fixes #1234)
     - emacs: use "opam var" instead of "opam config var" (#1249, by Raja Boujbel)
-    - vim: fix CursorMoved semantics (#1213, by Daniel Dickstein)
+    - vim: fix CursorMoved semantics (#1213, by @ddickstein)
     - vim: add :MerlinLocateImpl and :MerlinLocateIntf (#1208 by Matthew Ryan)
   + test suite
     - replace mdx usage by dune's cram mechanism

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -312,26 +312,33 @@ end
 
 exception Cmt_cache_store of Typedtrie.t
 
+let move_to_root root cmt_infos =
+  let digest =
+    (* [None] only for packs, and we wouldn't have a trie if the cmt was for a
+       pack. *)
+    let sourcefile = Option.get cmt_infos.Cmt_format.cmt_sourcefile in
+    match String.split_on_char ~sep:'.' sourcefile |> List.rev with
+    | ext :: "pp" :: rev_path ->
+       (* If the source file was a post-processed file (.pp.mli?), use the regular
+          .mli? file for locate. *)
+       let sourcefile = (ext :: rev_path) |> List.rev |> String.concat ~sep:"." in
+       Digest.file (cmt_infos.cmt_builddir ^ "/" ^ sourcefile)
+    | _ -> Option.get cmt_infos.cmt_source_digest
+  in
+  File_switching.move_to ~digest root;
+;;
+
 let trie_of_cmt root =
   let open Cmt_format in
   let cached = Cmt_cache.read root in
   log ~title:"browse_cmts" "inspecting %s" root ;
   begin match cached.Cmt_cache.location_trie with
   | Cmt_cache_store _ ->
-    let digest =
-      (* [None] only for packs, and we wouldn't have a trie if the cmt was for a
-         pack. *)
-      Option.get cached.cmt_infos.cmt_source_digest
-    in
-    File_switching.move_to ~digest root;
+    move_to_root root cached.cmt_infos;
     log ~title:"browse_cmts" "trie already cached"
   | Not_found ->
     let trie_of_nodes nodes =
-      let digest =
-        (* [None] only for packs. *)
-        Option.get cached.cmt_infos.cmt_source_digest
-      in
-      File_switching.move_to ~digest root;
+      move_to_root root cached.cmt_infos;
       let trie =
         Typedtrie.of_browses (List.map ~f:Browse_tree.of_node nodes)
       in

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -319,10 +319,13 @@ let move_to_root root cmt_infos =
     let sourcefile = Option.get cmt_infos.Cmt_format.cmt_sourcefile in
     match String.split_on_char ~sep:'.' sourcefile |> List.rev with
     | ext :: "pp" :: rev_path ->
-       (* If the source file was a post-processed file (.pp.mli?), use the regular
-          .mli? file for locate. *)
-       let sourcefile = (ext :: rev_path) |> List.rev |> String.concat ~sep:"." in
-       Digest.file (cmt_infos.cmt_builddir ^ "/" ^ sourcefile)
+      (* If the source file was a post-processed file (.pp.mli?), use the regular
+         .mli? file for locate. *)
+      let builddir = cmt_infos.cmt_builddir in
+      let sourcefile = (ext :: rev_path) |> List.rev |> String.concat ~sep:"." in
+      (match Misc.exact_file_exists ~dirname:builddir ~basename:sourcefile with
+       | true -> Digest.file (Filename.concat builddir sourcefile)
+       | false -> Option.get cmt_infos.cmt_source_digest)
     | _ -> Option.get cmt_infos.cmt_source_digest
   in
   File_switching.move_to ~digest root;

--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -12,4 +12,5 @@ ocamlmerlin "$@" \
     | jq 'del(.timing)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \
     | sed -e 's:\\n:\
-:g'
+:g' \
+    | sed -e "s:$TMPDIR:\$TMPDIR:g"

--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -8,14 +8,8 @@ if [ ! -f dune-project ]; then
   touch .merlin
 fi
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  # On MacOS, $TMPDIR is /var/folders/... but /var is a symlink to /private/var.
-  TMPDIR="/private$TMPDIR"
-fi
-
 ocamlmerlin "$@" \
     | jq 'del(.timing)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \
     | sed -e 's:\\n:\
-:g' \
-    | sed -e "s:$TMPDIR:\$TMPDIR:g"
+:g'

--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -8,6 +8,11 @@ if [ ! -f dune-project ]; then
   touch .merlin
 fi
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # On MacOS, $TMPDIR is /var/folders/... but /var is a symlink to /private/var.
+  TMPDIR="/private$TMPDIR"
+fi
+
 ocamlmerlin "$@" \
     | jq 'del(.timing)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \

--- a/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
@@ -45,7 +45,7 @@ Then our test files:
   $ cat >libb/dune <<EOF
   > (library
   >  (name libb)
-  >  (preprocess (action (system "./prep.exe %{input-file}"))))
+  >  (preprocess (action (system "$TMPDIR/project/prep.exe %{input-file}"))))
   > EOF
 
   $ cat >dune <<EOF

--- a/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
@@ -68,7 +68,7 @@ Then our test files:
 
 Now build with dune:
 
-  $ BUILD_PATH_PREFIX_MAP= dune build
+  $ BUILD_PATH_PREFIX_MAP= dune build 2>/dev/null
 
 And confirm that locate works on both deps:
 

--- a/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
@@ -1,0 +1,112 @@
+Running `dune build` will not work properly inside the testcase root, so we run
+this test in a separate directory under $TMPDIR.
+
+  $ mkdir "$TMPDIR/project"
+  $ trap "rm -rf $TMPDIR/project" EXIT
+  $ cd "$TMPDIR/project"
+
+First, prepare our preprocessor:
+
+  $ cat >prep.ml <<EOF
+  > let output_to_stdout fn str =
+  >   output_string stdout Config.ast_impl_magic_number;
+  >   output_value  stdout (fn : string);
+  >   output_value  stdout (str : Parsetree.structure)
+  > 
+  > let () =
+  >   let to_file, in_file =
+  >     match Sys.argv.(1) with
+  >     | "-dump-to-file" -> true, Sys.argv.(2)
+  >     | filename -> false, filename
+  >   in
+  >   let str = Pparse.parse_implementation ~tool_name:"prep" in_file in
+  >   if to_file then
+  >     let out_file = Filename.chop_suffix in_file "ml" ^ "pp.ml" in
+  >     Pparse.write_ast Structure out_file str
+  >   else
+  >     output_to_stdout in_file str
+  > EOF
+
+  $ $OCAMLC -I +compiler-libs ocamlcommon.cma -o prep.exe prep.ml
+  $ rm prep.cm* prep.ml
+
+Then our test files:
+
+  $ mkdir liba libb
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.7)
+  > EOF
+
+  $ cat >liba/dune <<EOF
+  > (library (name liba))
+  > EOF
+
+  $ cat >libb/dune <<EOF
+  > (library
+  >  (name libb)
+  >  (preprocess (action (system "./prep.exe %{input-file}"))))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (library (name test) (libraries liba libb))
+  > EOF
+
+  $ cat >liba/dep.ml <<EOF
+  > let x = "A"
+  > EOF
+
+  $ cat >libb/dep.ml <<EOF
+  > let x = "B"
+  > EOF
+
+  $ cat >liba/liba.ml <<EOF
+  > module Dep = Dep
+  > EOF
+
+  $ cat >libb/libb.ml <<EOF
+  > module Dep = Dep
+  > EOF
+
+  $ cat >test.ml <<EOF
+  > let _ = Liba.Dep.x
+  > let _ = Libb.Dep.x
+  > EOF
+
+Now build with dune:
+
+  $ dune build
+
+And confirm that locate works on both deps:
+
+  $ $MERLIN single locate -look-for ml -position 1:15 \
+  > -build-path _build/default/liba -source-path liba \
+  > -build-path _build/default/libb -source-path libb \
+  > -filename test.ml < ./test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TMPDIR/project/liba/dep.ml",
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single locate -look-for ml -position 2:15 \
+  > -build-path _build/default/liba -source-path liba \
+  > -build-path _build/default/libb -source-path libb \
+  > -filename test.ml < ./test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TMPDIR/project/libb/dep.ml",
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
@@ -68,7 +68,7 @@ Then our test files:
 
 Now build with dune:
 
-  $ dune build
+  $ BUILD_PATH_PREFIX_MAP= dune build
 
 And confirm that locate works on both deps:
 
@@ -90,6 +90,12 @@ And confirm that locate works on both deps:
   > -filename test.ml < ./test.ml
   {
     "class": "return",
-    "value": "Several source files in your path have the same name, and merlin doesn't know which is the right one: $TESTCASE_ROOT/libb/dep.ml, $TESTCASE_ROOT/liba/dep.ml",
+    "value": {
+      "file": "$TESTCASE_ROOT/libb/dep.ml",
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
     "notifications": []
   }

--- a/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml-dune.t
@@ -1,10 +1,3 @@
-Running `dune build` will not work properly inside the testcase root, so we run
-this test in a separate directory under $TMPDIR.
-
-  $ mkdir "$TMPDIR/project"
-  $ trap "rm -rf $TMPDIR/project" EXIT
-  $ cd "$TMPDIR/project"
-
 First, prepare our preprocessor:
 
   $ cat >prep.ml <<EOF
@@ -45,7 +38,7 @@ Then our test files:
   $ cat >libb/dune <<EOF
   > (library
   >  (name libb)
-  >  (preprocess (action (system "$TMPDIR/project/prep.exe %{input-file}"))))
+  >  (preprocess (action (system "./prep.exe %{input-file}"))))
   > EOF
 
   $ cat >dune <<EOF
@@ -80,13 +73,11 @@ Now build with dune:
 And confirm that locate works on both deps:
 
   $ $MERLIN single locate -look-for ml -position 1:15 \
-  > -build-path _build/default/liba -source-path liba \
-  > -build-path _build/default/libb -source-path libb \
   > -filename test.ml < ./test.ml
   {
     "class": "return",
     "value": {
-      "file": "$TMPDIR/project/liba/dep.ml",
+      "file": "$TESTCASE_ROOT/liba/dep.ml",
       "pos": {
         "line": 1,
         "col": 0
@@ -96,17 +87,9 @@ And confirm that locate works on both deps:
   }
 
   $ $MERLIN single locate -look-for ml -position 2:15 \
-  > -build-path _build/default/liba -source-path liba \
-  > -build-path _build/default/libb -source-path libb \
   > -filename test.ml < ./test.ml
   {
     "class": "return",
-    "value": {
-      "file": "$TMPDIR/project/libb/dep.ml",
-      "pos": {
-        "line": 1,
-        "col": 0
-      }
-    },
+    "value": "Several source files in your path have the same name, and merlin doesn't know which is the right one: $TESTCASE_ROOT/libb/dep.ml, $TESTCASE_ROOT/liba/dep.ml",
     "notifications": []
   }

--- a/tests/test-dirs/pp/dot-pp-dot-ml.t
+++ b/tests/test-dirs/pp/dot-pp-dot-ml.t
@@ -29,11 +29,11 @@ Then our test files:
   $ mkdir liba libb
 
   $ cat >liba/dep.ml <<EOF
-  > let x = ()
+  > let x = "A"
   > EOF
 
   $ cat >libb/dep.ml <<EOF
-  > let x = ()
+  > let x = "B"
   > EOF
 
   $ cat >test.ml <<EOF

--- a/tests/test-dirs/pp/dune
+++ b/tests/test-dirs/pp/dune
@@ -1,4 +1,4 @@
 (cram
- (applies_to dot-pp-dot-ml simple-pp)
+ (applies_to dot-pp-dot-ml-dune dot-pp-dot-ml simple-pp)
  (enabled_if
   (<> %{os_type} Win32)))


### PR DESCRIPTION
When ppx is used, the cmt sourcefile that is recorded is the *.pp.mli? file,
and we compare its digest to the digests of the files in the source directory.
Often the .pp.mli? file isn't there, and even when it is we probably do not
want to prefer it over the normal .mli? file for locate. This patch checks if
the file is a .pp.mli? file, and if so uses the digest of the regular .mli?
file instead.