### PR TITLE
Fix issue #1222

### DIFF
--- a/src/ocaml/parsing/411/ast_helper.ml
+++ b/src/ocaml/parsing/411/ast_helper.ml
@@ -18,6 +18,7 @@
 open Asttypes
 open Parsetree
 open Docstrings
+open Msupport_parsing
 
 type 'a with_loc = 'a Location.loc
 type loc = Location.t
@@ -85,7 +86,7 @@ module Typ = struct
   let varify_constructors var_names t =
     let check_variable vl loc v =
       if List.mem v vl then
-        raise Syntaxerr.(Error(Variable_in_scope(loc,v))) in
+        raise_error Syntaxerr.(Error(Variable_in_scope(loc,v))) in
     let var_names = List.map (fun v -> v.txt) var_names in
     let rec loop t =
       let desc =

--- a/tests/test-dirs/errors/issue1222.t
+++ b/tests/test-dirs/errors/issue1222.t
@@ -1,0 +1,26 @@
+  $ $MERLIN single errors -filename issue1222.ml <<EOF
+  > let minimal : type a. 'a t
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 22
+        },
+        "end": {
+          "line": 1,
+          "col": 24
+        },
+        "type": "parser",
+        "sub": [],
+        "valid": true,
+        "message": "In this scoped type, variable 'a is reserved for the local type a."
+      }
+    ],
+    "notifications": []
+  }
+
+Merlin would fail to catch this new exception:
+"In this scoped type, variable 'a is reserved for the local type a.",


### PR DESCRIPTION
Since OCaml 4.11 a new error is raised by the parser, this PR replaces the raising function by `Msupport.raise_error`.

Fix #1222 