### PR TITLE
Add type-enclosing tests

### DIFF
--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -55,3 +55,129 @@
       "tail": "no"
     }
   ]
+
+FIXME: A type with a type param shouldn't equal itself - 1
+
+  $ $MERLIN single type-enclosing -position 7:9 -verbosity 0 \
+  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 7,
+        "col": 8
+      },
+      "end": {
+        "line": 7,
+        "col": 9
+      },
+      "type": "type 'a t = 'b t",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 7,
+        "col": 0
+      },
+      "end": {
+        "line": 7,
+        "col": 14
+      },
+      "type": "type 'a t = 'a",
+      "tail": "no"
+    }
+  ]
+
+FIXME: A type with a type param shouldn't equal itself - aliasing a user-defined type
+
+  $ $MERLIN single type-enclosing -position 9:9 -verbosity 0 \
+  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 9,
+        "col": 8
+      },
+      "end": {
+        "line": 9,
+        "col": 9
+      },
+      "type": "type 'a s = 'b s",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 9,
+        "col": 0
+      },
+      "end": {
+        "line": 9,
+        "col": 16
+      },
+      "type": "type 'a s = 'a t",
+      "tail": "no"
+    }
+  ]
+
+FIXME: A type with a type param shouldn't equal itself - aliasing a list type
+
+  $ $MERLIN single type-enclosing -short-paths -position 11:9 -verbosity 0 \
+  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 11,
+        "col": 8
+      },
+      "end": {
+        "line": 11,
+        "col": 9
+      },
+      "type": "type 'a l = 'b l",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 11,
+        "col": 0
+      },
+      "end": {
+        "line": 11,
+        "col": 19
+      },
+      "type": "type 'a l = 'a l",
+      "tail": "no"
+    }
+  ]
+
+FIXME: A type with a type param shouldn't be empty
+
+  $ $MERLIN single type-enclosing -short-paths -position 17:9 -verbosity 0 \
+  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  [
+    {
+      "start": {
+        "line": 17,
+        "col": 8
+      },
+      "end": {
+        "line": 17,
+        "col": 9
+      },
+      "type": "type 'a v",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 17,
+        "col": 0
+      },
+      "end": {
+        "line": 17,
+        "col": 21
+      },
+      "type": "type 'a v = Foo of 'a",
+      "tail": "no"
+    }
+  ]
+
+

--- a/tests/test-dirs/type-enclosing/types.t/types.ml
+++ b/tests/test-dirs/type-enclosing/types.t/types.ml
@@ -3,3 +3,15 @@ let x = 3
 type x = Foo
 
 let foo : x = Foo
+
+type 'a t = 'a
+
+type 'a s = 'a t
+
+type 'a l = 'a list
+
+module M = struct
+  type 'a t = 'a
+end
+
+type 'a v = Foo of 'a


### PR DESCRIPTION
A follow-up on @trefis's request in #1216 to add some tests that show how `type-enclosing` with `verbosity=0` returns undesired types. 

These tests show the pattern that `type-enclosing` run on a type definition of a type with type param(s), it either returns type itself, e.g., for `type 'a t = 'a`, `type-enclosing` returns `type 'a t = 'a t`, or it returns just the type, e.g., for `type 'a v = Foo of 'a`, it returns `type 'a v` without the actual definition. This is probably not an exhaustive list of cases when `type-enclosing` returns a less desired type, but I hope this helps.