### PR TITLE
Type-enclosing wasn't always looking at the right node

### DIFF
--- a/src/analysis/context.mli
+++ b/src/analysis/context.mli
@@ -27,7 +27,7 @@
 )* }}} *)
 
 type t =
-  | Constructor of Types.constructor_description
+  | Constructor of Types.constructor_description * Location.t
     (* We attach the constructor description here so in the case of
       disambiguated constructors we actually directly look for the type
       path (cf. #486, #794). *)

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -610,8 +610,8 @@ module Namespace = struct
     | Patt          -> [ `Mod ; `Modtype ; `Type ; `Constr ; `Labels ; `Vals ]
     | Unknown       -> [ `Vals ; `Type ; `Constr ; `Mod ; `Modtype ; `Labels ]
     | Label lbl     -> [ `This_label lbl ]
-    | Constructor c -> [ `This_cstr c ]
     | Module_path   -> [ `Mod ]
+    | Constructor (c, _) -> [ `This_cstr c ]
 end
 
 module Env_lookup : sig

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -75,10 +75,10 @@ let from_reconstructed ~nodes ~cursor ~verbosity exprs =
             source (Context.to_string ctx));
       match context with
       (* Retrieve the type from the AST when it is possible *)
-      | Some (Context.Constructor cd) ->
+      | Some (Context.Constructor (cd, loc)) ->
         log ~title:"from_reconstructed" "ctx: constructor %s"
           cd.cstr_name;
-        Some (Mbrowse.node_loc node, Type (env, cd.cstr_res), `No)
+        Some (loc, Type (env, cd.cstr_res), `No)
       | _ ->
         let context = Option.value ~default:Context.Expr context in
         (* Else use the reconstructed identifier *)

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -78,7 +78,9 @@ let from_reconstructed ~nodes ~cursor ~verbosity exprs =
       | Some (Context.Constructor (cd, loc)) ->
         log ~title:"from_reconstructed" "ctx: constructor %s"
           cd.cstr_name;
-        Some (loc, Type (env, cd.cstr_res), `No)
+        let ppf, to_string = Format.to_string () in
+        Type_utils.print_constr ~verbosity env ppf cd;
+        Some (loc, String (to_string ()), `No)
       | _ ->
         let context = Option.value ~default:Context.Expr context in
         (* Else use the reconstructed identifier *)

--- a/src/analysis/type_utils.ml
+++ b/src/analysis/type_utils.ml
@@ -231,16 +231,15 @@ let print_modpath ppf verbosity env lid =
   in
   print_short_modtype verbosity env ppf (md.md_type)
 
+let print_cstr_desc ppf cstr_desc =
+  !Oprint.out_type ppf (Browse_misc.print_constructor cstr_desc)
+
 let print_constr ppf env lid =
   let cstr_desc =
     Env.find_constructor_by_name lid.Asttypes.txt env
   in
-  (*
-    Format.pp_print_string ppf name;
-    Format.pp_print_string ppf " : ";
-  *)
   (* FIXME: support Reader printer *)
-  !Oprint.out_type ppf (Browse_misc.print_constructor cstr_desc)
+  print_cstr_desc ppf cstr_desc
 
 exception Fallback
 let type_in_env ?(verbosity=0) ?keywords ~context env ppf expr =
@@ -311,6 +310,10 @@ let type_in_env ?(verbosity=0) ?keywords ~context env ppf expr =
     | `Other ->
       try print_expr e; true
       with exn -> print_exn ppf exn; false
+
+let print_constr ~verbosity env ppf cd =
+  Printtyp.wrap_printing_env env ~verbosity @@ fun () ->
+  print_cstr_desc ppf cd
 
 (* From doc-ock
    https://github.com/lpw25/doc-ock/blob/master/src/docOckAttrs.ml *)

--- a/src/analysis/type_utils.mli
+++ b/src/analysis/type_utils.mli
@@ -69,3 +69,6 @@ val read_doc_attributes : Parsetree.attributes -> (string * Location.t) option
 (** [read_doc_attributes] looks for a docstring in an attribute list. *)
 
 val is_deprecated : Parsetree.attributes -> bool
+
+val print_constr : verbosity:int -> Env.t -> Format.formatter ->
+  Types.constructor_description -> unit

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -304,10 +304,9 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
           `List lst
         )
     in
-    let nodes = Mtyper.node_at typer pos in
     let small_enclosings =
       Type_enclosing.from_reconstructed exprs
-       ~nodes ~cursor:pos ~verbosity
+       ~nodes:structures ~cursor:pos ~verbosity
     in
     Logger.log ~section:Type_enclosing.log_section ~title:"small enclosing" "%a"
       Logger.fmt (fun fmt ->

--- a/tests/test-dirs/type-enclosing/gadt_wrong.t
+++ b/tests/test-dirs/type-enclosing/gadt_wrong.t
@@ -1,5 +1,4 @@
-FIXME: Int here is not the Int module  but a constructor!
-See issue https://github.com/ocaml/merlin/issues/1125
+Initially from issue https://github.com/ocaml/merlin/issues/1125
 
   $ cat > gadt.ml <<EOF
   > 
@@ -57,7 +56,7 @@ See issue https://github.com/ocaml/merlin/issues/1125
         "line": 9,
         "col": 7
       },
-      "type": "(module Stdlib__int)",
+      "type": "int -> int term",
       "tail": "no"
     },
     {

--- a/tests/test-dirs/type-enclosing/issue1226.t
+++ b/tests/test-dirs/type-enclosing/issue1226.t
@@ -1,4 +1,4 @@
-FIXME
+Fixed.
 
   $ $MERLIN single type-enclosing  -position 5:9 -filename test.ml <<EOF
   > module Foo = struct
@@ -19,7 +19,7 @@ FIXME
           "line": 5,
           "col": 11
         },
-        "type": "sig val bar : int end",
+        "type": "int -> t",
         "tail": "no"
       },
       {


### PR DESCRIPTION
It shouldn't have been using `Mtyper.node_at` which doesn't necessarily return the node around the cursor (that's something that should also be looked at, at some point).
Funnily enough, we were only using `node_at` for the small enclosing, not when getting the type from the AST.

This PR:
- removes the call to `node_at` and reuses the same nodes as the rest of the analysis.
- unifies the printing of constructor types between `type-enclosing` and `type-expr` (by reusing the one of `type-expr`, which I deemed to be the better of the two)