### PR TITLE
type-enclosing result on type expressions

### DIFF
--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -113,6 +113,45 @@ FIXME: A type with a type param shouldn't equal itself - aliasing a list type
     }
   ]
 
+Same result regardless of verbosity:
+
+  $ $MERLIN single type-enclosing -short-paths -position 11:9 -verbosity 1 \
+  > -filename ./types.ml < ./types.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 11,
+        "col": 0
+      },
+      "end": {
+        "line": 11,
+        "col": 19
+      },
+      "type": "type 'a l = 'a l",
+      "tail": "no"
+    }
+  ]
+
+OK without -short-paths
+
+  $ $MERLIN single type-enclosing -position 11:9 -verbosity 0 \
+  > -filename ./types.ml < ./types.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 11,
+        "col": 0
+      },
+      "end": {
+        "line": 11,
+        "col": 19
+      },
+      "type": "type 'a l = 'a list",
+      "tail": "no"
+    }
+  ]
+
+
 FIXED: small enclosing at EOF was incorrect?
 
   $ $MERLIN single type-enclosing -short-paths -position 17:9 -verbosity 0 \

--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -1,5 +1,5 @@
   $ $MERLIN single type-enclosing -position 5:11 -verbosity 0 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {
@@ -28,7 +28,7 @@
   ]
 
   $ $MERLIN single type-enclosing -position 5:11 -verbosity 1 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {
@@ -59,7 +59,7 @@
 FIXED: small enclosing was incorrect?
 
   $ $MERLIN single type-enclosing -position 7:9 -verbosity 0 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {
@@ -78,7 +78,7 @@ FIXED: small enclosing was incorrect?
 FIXED: small enclosing was incorrect?
 
   $ $MERLIN single type-enclosing -position 9:9 -verbosity 0 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {
@@ -97,7 +97,7 @@ FIXED: small enclosing was incorrect?
 FIXME: A type with a type param shouldn't equal itself - aliasing a list type
 
   $ $MERLIN single type-enclosing -short-paths -position 11:9 -verbosity 0 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {
@@ -116,7 +116,7 @@ FIXME: A type with a type param shouldn't equal itself - aliasing a list type
 FIXED: small enclosing at EOF was incorrect?
 
   $ $MERLIN single type-enclosing -short-paths -position 17:9 -verbosity 0 \
-  > -filename ./types.ml < ./types.ml | jq ".value[0:2]"
+  > -filename ./types.ml < ./types.ml | jq ".value"
   [
     {
       "start": {


### PR DESCRIPTION
This PR is in response to #1230 (cc @ulugbekna).

First, I discovered that after rebasing past #1232 (which was merged last week), all but one of the FIXMEs were indeed fixed (hurrah!).
The diff is visible in https://github.com/ocaml/merlin/commit/5125e54a7aa033d444514c3af1122076845d57b6.

As for the remaining FIXME, it doesn't look like a bug, but rather like the expected behavior of `-short-paths`.
You can see that if we remove that flag, the result is the one you seem to expect @ulugbekna.

However, going back to the initial discuss of `verbosity`'s value (started in #1216), you can also notice that with that flag, the result stays the same regardless of the verbosity level.