### PR TITLE
Make OCaml-CI happy

### DIFF
--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -16,4 +16,5 @@ depends: [
   "ocamlfind" {>= "1.6.0"}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}
+  "menhirLib" {dev}
 ]

--- a/merlin.opam
+++ b/merlin.opam
@@ -18,6 +18,8 @@ depends: [
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}
   "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
 ]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"


### PR DESCRIPTION
`ocaml-dune-lint` used by OCaml-CI checks that every libraries explicitly used by a project is listed in the opam file.