### PR TITLE
completion: add "keyword" kind

### DIFF
--- a/src/analysis/completion.mli
+++ b/src/analysis/completion.mli
@@ -56,6 +56,7 @@ val branch_complete
                -> [> `Found of string ])
   -> ?target_type:Types.type_expr
   -> ?kinds:Compl.kind list
+  -> keywords:string list
   -> string
   -> Mbrowse.t
   -> raw_info Compl.raw_entry list

--- a/src/frontend/ocamlmerlin/new/new_commands.ml
+++ b/src/frontend/ocamlmerlin/new/new_commands.ml
@@ -44,6 +44,7 @@ let marg_completion_kind f = Marg.param "completion-kind"
       | "l" | "label" | "labels"         -> f `Labels
       | "m" | "mod" | "module"           -> f `Modules
       | "mt" | "modtype" | "module-type" -> f `Modules_type
+      | "k" | "kw" | "keyword"           -> f `Keywords
       | str ->
         failwithf "expecting completion kind, got %S. \
                    kind can be value, variant, constructor, \

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -46,6 +46,7 @@ let dump (type a) : a t -> json =
   let kinds_to_json kind =
     `List (List.map ~f:(function
         | `Constructor  -> `String "constructor"
+        | `Keywords     -> `String "keywords"
         | `Labels       -> `String "label"
         | `Modules      -> `String "module"
         | `Modules_type -> `String "module-type"
@@ -212,6 +213,7 @@ let string_of_completion_kind = function
   | `MethodCall  -> "#"
   | `Exn         -> "Exn"
   | `Class       -> "Class"
+  | `Keyword     -> "Keyword"
 
 let with_location ?(skip_none=false) loc assoc =
   if skip_none && loc = Location.none then

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -418,10 +418,12 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         Some (Locate.get_doc ~config ~env ~local_defs
                 ~comments:(Mpipeline.reader_comments pipeline) ~pos)
     in
+    let keywords = Mpipeline.reader_lexer_keywords pipeline in
     let entries =
       Printtyp.wrap_printing_env env ~verbosity @@ fun () ->
-      Completion.branch_complete config ~kinds ?get_doc ?target_type prefix branch |>
-      print_completion_entries ~with_types config source
+      Completion.branch_complete config ~kinds ?get_doc ?target_type ~keywords
+        prefix branch
+      |> print_completion_entries ~with_types config source
     and context = match context with
       | `Application context when no_labels ->
         `Application {context with Compl.labels = []}

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -31,7 +31,7 @@ struct
   type 'desc raw_entry = {
     name: string;
     kind: [`Value|`Constructor|`Variant|`Label|
-           `Module|`Modtype|`Type|`MethodCall];
+           `Module|`Modtype|`Type|`MethodCall|`Keyword];
     desc: 'desc;
     info: 'desc;
     deprecated: bool;
@@ -59,6 +59,7 @@ struct
     | `Types
     | `Values
     | `Variants
+    | `Keywords
   ]
 end
 

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -114,6 +114,7 @@ let typer  t = Lazy.force t.typer
 let reader_config    t = (snd (reader t))
 let reader_parsetree t = (fst (reader t)).Mreader.parsetree
 let reader_comments  t = (fst (reader t)).Mreader.comments
+let reader_lexer_keywords  t = (fst (reader t)).Mreader.lexer_keywords
 let reader_lexer_errors  t = (fst (reader t)).Mreader.lexer_errors
 let reader_parser_errors t = (fst (reader t)).Mreader.parser_errors
 let reader_no_labels_for_completion t =

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -12,6 +12,7 @@ val get_lexing_pos : t -> [< Msource.position] -> Lexing.position
 val reader_config : t -> Mconfig.t
 val reader_comments : t -> (string * Location.t) list
 val reader_parsetree : t -> Mreader.parsetree
+val reader_lexer_keywords : t -> string list
 val reader_lexer_errors : t -> exn list
 val reader_parser_errors : t -> exn list
 val reader_no_labels_for_completion : t -> bool

--- a/src/kernel/mreader.ml
+++ b/src/kernel/mreader.ml
@@ -9,6 +9,7 @@ type comment = (string * Location.t)
 
 type result = {
   config        : Mconfig.t;
+  lexer_keywords: string list;
   lexer_errors  : exn list;
   parser_errors : exn list;
   comments      : comment list;
@@ -47,12 +48,13 @@ let normal_parse ?for_completion config source =
       Mreader_lexer.for_completion lexer pos
   in
   let parser = Mreader_parser.make Mconfig.(config.ocaml.warnings) lexer kind in
-  let lexer_errors = Mreader_lexer.errors lexer
+  let lexer_keywords = Mreader_lexer.keywords lexer
+  and lexer_errors = Mreader_lexer.errors lexer
   and parser_errors = Mreader_parser.errors parser
   and parsetree = Mreader_parser.result parser
   and comments = Mreader_lexer.comments lexer
   in
-  { config; lexer_errors; parser_errors; comments; parsetree;
+  { config; lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
     no_labels_for_completion; }
 
 (* Pretty-printing *)
@@ -167,7 +169,8 @@ let parse ?for_completion config source =
   with
   | Some (`No_labels no_labels_for_completion, parsetree) ->
     let (lexer_errors, parser_errors, comments) = ([], [], []) in
-    { config; lexer_errors; parser_errors; comments; parsetree;
+    let lexer_keywords = [] (* TODO? *) in
+    { config; lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
       no_labels_for_completion; }
   | None -> normal_parse ?for_completion config source
 

--- a/src/kernel/mreader.mli
+++ b/src/kernel/mreader.mli
@@ -7,6 +7,7 @@ type comment = (string * Location.t)
 
 type result = {
   config        : Mconfig.t;
+  lexer_keywords: string list;
   lexer_errors  : exn list;
   parser_errors : exn list;
   comments      : comment list;

--- a/src/kernel/mreader_lexer.ml
+++ b/src/kernel/mreader_lexer.ml
@@ -121,6 +121,9 @@ let tokens t =
   rev_filter_map t.items
     ~f:(function Triple t -> Some t | _ -> None)
 
+let keywords t =
+  Lexer_raw.list_keywords t.keywords
+
 let errors t =
   rev_filter_map t.items
     ~f:(function Error (err, loc) -> Some (Lexer_raw.Error (err, loc))

--- a/src/kernel/mreader_lexer.mli
+++ b/src/kernel/mreader_lexer.mli
@@ -40,6 +40,7 @@ val for_completion: t -> Lexing.position ->
 val initial_position : t -> Lexing.position
 
 val tokens   : t -> triple list
+val keywords : t -> string list
 val errors   : t -> exn list
 val comments : t -> (string * Location.t) list
 

--- a/src/ocaml/preprocess/lexer_raw.mli
+++ b/src/ocaml/preprocess/lexer_raw.mli
@@ -28,6 +28,10 @@ exception Error of error * Location.t
 type keywords
 val keywords: (string * Parser_raw.token) list -> keywords
 
+val list_keywords : keywords -> string list
+(* [list_keywords kws] not only lists the keys of [kw], but also OCaml's
+   keywords. *)
+
 (* Monad in which the lexer evaluates *)
 type 'a result =
   | Return of 'a

--- a/src/ocaml/preprocess/lexer_raw.mll
+++ b/src/ocaml/preprocess/lexer_raw.mll
@@ -142,6 +142,12 @@ let keyword_table : keywords =
 
 let keywords l = create_hashtable 11 l
 
+let list_keywords =
+  let add_kw str _tok kws = str :: kws in
+  let init = Hashtbl.fold add_kw keyword_table [] in
+  fun keywords ->
+    Hashtbl.fold add_kw keywords init
+
 (* To store the position of the beginning of a string and comment *)
 let in_comment state = state.comment_start_loc <> []
 

--- a/tests/test-dirs/completion/kind.t/run.t
+++ b/tests/test-dirs/completion/kind.t/run.t
@@ -1,0 +1,60 @@
+Default completion:
+
+  $ $MERLIN single complete-prefix -position 3:10 -filename test.ml \
+  > -prefix fu < test.ml| jq ".value.entries[].name"
+  "funnyny"
+
+Keywords only:
+
+  $ $MERLIN single complete-prefix -position 3:10 -filename test.ml \
+  > -kind k -prefix fu < test.ml| jq ".value.entries[].name"
+  "function"
+  "fun"
+  "functor"
+
+Keywords and values:
+
+  $ $MERLIN single complete-prefix -position 3:10 -filename test.ml \
+  > -kind keyword -kind value -prefix fu < test.ml| jq ".value.entries[].name"
+  "funnyny"
+  "function"
+  "fun"
+  "functor"
+
+Keywords only including extension:
+
+  $ echo "f" | $MERLIN single complete-prefix -position 1:2 -filename test.ml \
+  > -kind k -prefix f -extension lwt | jq ".value.entries[].name"
+  "finally"
+  "for_lwt"
+  "function"
+  "false"
+  "fun"
+  "for"
+  "functor"
+
+And let's also make sure we don't offer keywords when we completing under a
+certain path
+
+  $ $MERLIN single complete-prefix -position 5:14 -filename test.ml \
+  > -prefix List.f < test.ml| jq ".value.entries[].name"
+  "fast_sort"
+  "filter"
+  "filter_map"
+  "filteri"
+  "find"
+  "find_all"
+  "find_map"
+  "find_opt"
+  "flatten"
+  "fold_left"
+  "fold_left2"
+  "fold_left_map"
+  "fold_right"
+  "fold_right2"
+  "for_all"
+  "for_all2"
+
+  $ $MERLIN single complete-prefix -position 5:14 -filename test.ml \
+  > -kind k -prefix List.f < test.ml| jq ".value.entries"
+  []

--- a/tests/test-dirs/completion/kind.t/test.ml
+++ b/tests/test-dirs/completion/kind.t/test.ml
@@ -1,0 +1,5 @@
+let funnyny = fun ny -> ny
+
+let _ = fu
+
+let _ = List.f


### PR DESCRIPTION
Alternative implementation of #1137

The code is very similar, but it's on an up-to-date merlin.
Also, it made me realize that all the plumbing @rgrinberg had implemented is actually necessary if you want to also list keywords added by extensions (which you can't if you just access `Lexer_raw.keyword_table`).