### PR TITLE
adds module, module type, and class imenu items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ git version
     - handle `=` syntax in compiler flags (#1409)
     - expose all destruct exceptions in the api (#1437)
     - fix superfluous break in error reporting (#1432)
+  + editor modes
+    - add module, module type, and class imenu items for emacs (#1244, @ivg)
   + test suite
     - cover locate calls on module aliases with and without dune
     - Add a test expliciting the interaction between locate and Dune's generated

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -18,6 +18,9 @@
 (defvar-local merlin-imenu--value-list nil)
 (defvar-local merlin-imenu--type-list nil)
 (defvar-local merlin-imenu--exception-list nil)
+(defvar-local merlin-imenu--module-list nil)
+(defvar-local merlin-imenu--signature-list nil)
+(defvar-local merlin-imenu--class-list nil)
 
 (defun merlin-imenu-compute-position (line col)
   "Get location of the item."
@@ -58,6 +61,12 @@
              (setq merlin-imenu--value-list (cons marker merlin-imenu--value-list)))
             ((string= kind "Type")
              (setq merlin-imenu--type-list (cons marker merlin-imenu--type-list)))
+            ((string= kind "Module")
+             (setq merlin-imenu--module-list (cons marker merlin-imenu--module-list)))
+            ((string= kind "Signature")
+             (setq merlin-imenu--signature-list (cons marker merlin-imenu--signature-list)))
+            ((string= kind "Class")
+             (setq merlin-imenu--class-list (cons marker merlin-imenu--class-list)))
             ((string= kind "Exn")
              (setq merlin-imenu--exception-list (cons marker merlin-imenu--exception-list))))
       (when sub-trees
@@ -68,6 +77,9 @@
   ;; Reset local vars
   (setq merlin-imenu--value-list nil
         merlin-imenu--type-list nil
+        merlin-imenu--module-list nil
+        merlin-imenu--signature-list nil
+        merlin-imenu--class-list nil
         merlin-imenu--exception-list nil)
   ;; Read outline tree
   (merlin-imenu-parse-outline "" (merlin-call "outline"))
@@ -78,6 +90,12 @@
       (push (cons "Exception" merlin-imenu--exception-list) index))
     (when merlin-imenu--type-list
       (push (cons "Type" merlin-imenu--type-list) index))
+    (when merlin-imenu--module-list
+      (push (cons "Module" merlin-imenu--module-list) index))
+    (when merlin-imenu--signature-list
+      (push (cons "Signature" merlin-imenu--signature-list) index))
+    (when merlin-imenu--class-list
+      (push (cons "Class" merlin-imenu--class-list) index))
     index))
 
 ;;;###autoload


### PR DESCRIPTION
These are important syntactic categories, which I am missing a lot. In fact, the modules category is the most important as it enables to quickly move between submodules and significantly reduces cognition burden during developing OCaml programs. The class category fits into the same niche, except when the OOP style is employed. There is also a constructor category, though I am not really sure if is useful, and given that it can pollute the outline I decided to leave it.