### PR TITLE
Fixes #1234

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1818,12 +1818,12 @@ Empty string defaults to jumping to all these."
 (defun merlin/sync ())
 (make-obsolete 'merlin/sync nil "Synchronization happens automatically since Merlin 3.0")
 
-(define-obsolete-function-alias 'merlin-project-check 'merlin-configuration-check)
+(define-obsolete-function-alias 'merlin-project-check 'merlin-configuration-check "v2.5.4")
 
-(define-obsolete-function-alias 'merlin--copy-enclosing 'merlin-copy-enclosing)
-(define-obsolete-function-alias 'merlin--destruct-enclosing 'merlin-destruct-enclosing)
+(define-obsolete-function-alias 'merlin--copy-enclosing 'merlin-copy-enclosing "v2.5.4")
+(define-obsolete-function-alias 'merlin--destruct-enclosing 'merlin-destruct-enclosing "v2.5.4")
 
-(define-obsolete-function-alias 'merlin-restart-process 'merlin-stop-server)
+(define-obsolete-function-alias 'merlin-restart-process 'merlin-stop-server "v2.5.4")
 
 ;;;###autoload
 (define-minor-mode merlin-mode

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1818,12 +1818,12 @@ Empty string defaults to jumping to all these."
 (defun merlin/sync ())
 (make-obsolete 'merlin/sync nil "Synchronization happens automatically since Merlin 3.0")
 
-(define-obsolete-function-alias 'merlin-project-check 'merlin-configuration-check "v2.5.4")
+(define-obsolete-function-alias 'merlin-project-check 'merlin-configuration-check "v3.0.0")
 
-(define-obsolete-function-alias 'merlin--copy-enclosing 'merlin-copy-enclosing "v2.5.4")
-(define-obsolete-function-alias 'merlin--destruct-enclosing 'merlin-destruct-enclosing "v2.5.4")
+(define-obsolete-function-alias 'merlin--copy-enclosing 'merlin-copy-enclosing "v3.0.0")
+(define-obsolete-function-alias 'merlin--destruct-enclosing 'merlin-destruct-enclosing "v3.0.0")
 
-(define-obsolete-function-alias 'merlin-restart-process 'merlin-stop-server "v2.5.4")
+(define-obsolete-function-alias 'merlin-restart-process 'merlin-stop-server "v3.0.0")
 
 ;;;###autoload
 (define-minor-mode merlin-mode


### PR DESCRIPTION
Adding a "when" argument is mandatory for define-obsolete-function-alias since emacs Emacs-23.1. If this is not added, emacs shows an error on startup (See Issue #1234).

NOTE: I'm guessing the functions are made obsolete in v2.5.4 (I simply looked at the "blame" date on github and matched with the version that was released after 28th Feb 2017) Maintainers may be able to provide a more accurate version/date for this argument