### PR TITLE
Make canonical Windows paths more canonicals

### DIFF
--- a/src/utils/misc.ml
+++ b/src/utils/misc.ml
@@ -116,9 +116,19 @@ let remove_file filename =
   with Sys_error _msg -> ()
 
 let rec split_path path acc =
-  match Filename.dirname path, Filename.basename path with
-  | dir, _ when dir = path -> dir :: acc
-  | dir, base -> split_path dir (base :: acc)
+  match Filename.dirname path with
+  | dir when dir = path ->
+    let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') in
+    let dir =
+      if String.length dir > 2 && is_letter dir.[0] && dir.[1] = ':'
+      then
+        Printf.sprintf "%s%s"
+          (String.sub dir ~pos:0 ~len:2)
+          Filename.dir_sep
+      else dir
+    in
+    dir :: acc
+  | dir -> split_path dir (Filename.basename path :: acc)
 
 (* Deal with case insensitive FS *)
 

--- a/src/utils/misc.ml
+++ b/src/utils/misc.ml
@@ -120,10 +120,10 @@ let rec split_path path acc =
   | dir when dir = path ->
     let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') in
     let dir =
-      if String.length dir > 2 && is_letter dir.[0] && dir.[1] = ':'
+      if not Sys.unix && String.length dir > 2 && is_letter dir.[0] && dir.[1] = ':'
       then
-        Printf.sprintf "%s%s"
-          (String.sub dir ~pos:0 ~len:2)
+        Printf.sprintf "%c:%s"
+          dir.[0]
           Filename.dir_sep
       else dir
     in


### PR DESCRIPTION
These changes ensure that the `/ ` or `\` in the drive part of a Windows path (`c:\`) is correctly converted to the current platform separator.

It also always make the drive letter uppercase. This seems to be the standard (even if Windows understand both) and matches `Sys.getcwd ()` style.

This fixes communication issues between Merlin and Dune's `ocaml-merlin` configuration server on WIndows.

# Todo
- [ ] Propagate to 411
- [ ] Propagate to 412
