### PR TITLE
fix same file documentation bug

### DIFF
--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -832,7 +832,7 @@ let get_doc ~config ~env ~local_defs ~comments ~pos =
   | `Found (loc, None) ->
     let comments =
       match File_switching.where_am_i () with
-      | None -> List.rev comments
+      | None -> comments
       | Some cmt_path ->
         let {Cmt_cache. cmt_infos; _ } = Cmt_cache.read cmt_path in
         cmt_infos.Cmt_format.cmt_comments

--- a/tests/test-dirs/src-documentation/run.t
+++ b/tests/test-dirs/src-documentation/run.t
@@ -1,0 +1,38 @@
+documentation for the last defined value (in the same file) is shown
+  $ $MERLIN single document -position 7:10 <<EOF
+  > (** first function *)
+  > let f () = ()
+  > 
+  > (** second function *)
+  > let g () = ()
+  > 
+  > let () = g (f ())
+  > 
+  > let list_rev = List.rev
+  > EOF
+  {
+    "class": "return",
+    "value": "second function",
+    "notifications": []
+  }
+
+documentation for the non-last defined value (in the same file) is show
+(we care about "non-last" value because of issue #1261)
+  $ $MERLIN single document -position 7:13 <<EOF
+  > (** first function *)
+  > let f () = ()
+  > 
+  > (** second function *)
+  > let g () = ()
+  > 
+  > let () = g (f ())
+  > 
+  > let list_rev = List.rev
+  > EOF
+  {
+    "class": "return",
+    "value": "first function",
+    "notifications": []
+  }
+
+


### PR DESCRIPTION
Hi! 

Fixes #1261 

tl;dr `Ocamldoc.associate_comment` needs a list of doc-comments from the start to the end of file (non-decreasing positions of comments), but `Locate.get_doc` returned the comments from the end to the start of the file (non-increasing positions of comments). The last doc-comment was available because the last elem of non-decr list = head of non-incr list.

More detailed: 

`Ocamldoc.associate_comment` takes a list of doc-comments (with their positions) from a file and compares positions of those comments with the position `p` of the cursor. If a doc-comment `d` with position `p1` has `p1 > p` (ie documentation occurs later in the file than `p`), it considered there the list doesn't contain documentation for position `p`. (see [code](https://github.com/ocaml/merlin/blob/2a0dd5c16178efcc4b8132e3c3b3c2a6cc7b13ea/src/analysis/ocamldoc.ml#L42-L46))

Since `Locate.get_doc` was returning `List.rev comments`, it returned doc-comments in a non-decreasing order, which meant that head of the list would have position "larger" than `p` causing the `associate_comment` return `None`.