### PR TITLE
system command variant: do not open a window console when launching a…

### DIFF
--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -38,6 +38,8 @@ let report_error = function
     log ~title:"report_error"
       "External preprocessor does not produce a valid file. Command line: %s" cmd
 
+external merlin_system_command : string -> int = "ml_merlin_system_command"
+
 let ppx_commandline cmd fn_in fn_out =
   Printf.sprintf "%s %s %s 1>&2"
     cmd (Filename.quote fn_in) (Filename.quote fn_out)
@@ -54,7 +56,7 @@ let apply_rewriter magic ppx (fn_in, failures) =
   end;
   let comm = ppx_commandline ppx.workval fn_in fn_out in
   let failure =
-    let ok = Sys.command comm = 0 in
+    let ok = merlin_system_command comm = 0 in
     if not ok then Some (CannotRun comm)
     else if not (Sys.file_exists fn_out) then
       Some (WrongMagic comm)
@@ -159,7 +161,7 @@ let apply_pp ~workdir ~filename ~source ~pp =
   end;
   let fn_out = fn_in ^ ".out" in
   let comm = pp_commandline pp fn_in fn_out in
-  let ok = Sys.command comm = 0 in
+  let ok = merlin_system_command comm = 0 in
   Misc.remove_file fn_in;
   if not ok then begin
     Misc.remove_file fn_out;

--- a/src/platform/platform_misc.c
+++ b/src/platform/platform_misc.c
@@ -1,6 +1,7 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
+#include <stdlib.h>
 
 /* FS case */
 
@@ -54,12 +55,48 @@ value ml_merlin_dont_inherit_stdio(value vstatus)
   return Val_unit;
 }
 
+/* Run ppx-command without opening a sub console */
+
+#define MAX_SYSTEM_PROGRAM 4096
+
+static int windows_system(const char *cmd)
+{
+    PROCESS_INFORMATION p_info;
+    STARTUPINFOW s_info;
+    DWORD ReturnValue;
+
+    memset(&s_info, 0, sizeof(s_info));
+    memset(&p_info, 0, sizeof(p_info));
+    s_info.cb = sizeof(s_info);
+
+    wchar_t utf16cmd[MAX_SYSTEM_PROGRAM] = {0};
+    MultiByteToWideChar(CP_UTF8, 0, cmd, -1, utf16cmd, MAX_SYSTEM_PROGRAM);
+    if (CreateProcessW(NULL, utf16cmd, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &s_info, &p_info))
+    {
+        WaitForSingleObject(p_info.hProcess, INFINITE);
+        GetExitCodeProcess(p_info.hProcess, &ReturnValue);
+        CloseHandle(p_info.hProcess);
+        CloseHandle(p_info.hThread);
+    }
+    return ReturnValue;
+}
+
+value ml_merlin_system_command(value command)
+{
+  return Val_int(windows_system(String_val(command)));
+}
+
 #else
 
 value ml_merlin_dont_inherit_stdio(value vstatus)
 {
   (void)vstatus;
   return Val_unit;
+}
+
+value ml_merlin_system_command(value command)
+{
+  return Val_int(system(String_val(command)));
 }
 
 #endif

--- a/src/platform/platform_misc.c
+++ b/src/platform/platform_misc.c
@@ -82,9 +82,15 @@ static int windows_system(const char *cmd)
         GetExitCodeProcess(p_info.hProcess, &ReturnValue);
         CloseHandle(p_info.hProcess);
         CloseHandle(p_info.hThread);
+
+        caml_stat_free(utf16cmd);
+        return ReturnValue;
     }
-    caml_stat_free(utf16cmd);
-    return ReturnValue;
+    else
+    {
+        caml_stat_free(utf16cmd);
+        return -1;
+    }
 }
 
 value ml_merlin_system_command(value command)

--- a/src/platform/platform_misc.c
+++ b/src/platform/platform_misc.c
@@ -1,3 +1,10 @@
+#ifdef _WIN32
+#define CAML_NAME_SPACE
+#define CAML_INTERNALS
+#include <caml/misc.h>
+#include <caml/osdeps.h>
+#endif
+
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -57,8 +64,6 @@ value ml_merlin_dont_inherit_stdio(value vstatus)
 
 /* Run ppx-command without opening a sub console */
 
-#define MAX_SYSTEM_PROGRAM 4096
-
 static int windows_system(const char *cmd)
 {
     PROCESS_INFORMATION p_info;
@@ -69,8 +74,8 @@ static int windows_system(const char *cmd)
     memset(&p_info, 0, sizeof(p_info));
     s_info.cb = sizeof(s_info);
 
-    wchar_t utf16cmd[MAX_SYSTEM_PROGRAM] = {0};
-    MultiByteToWideChar(CP_UTF8, 0, cmd, -1, utf16cmd, MAX_SYSTEM_PROGRAM);
+    char_os *utf16cmd;
+    utf16cmd = caml_stat_strdup_to_os(cmd);
     if (CreateProcessW(NULL, utf16cmd, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &s_info, &p_info))
     {
         WaitForSingleObject(p_info.hProcess, INFINITE);
@@ -78,6 +83,7 @@ static int windows_system(const char *cmd)
         CloseHandle(p_info.hProcess);
         CloseHandle(p_info.hThread);
     }
+    caml_stat_free(utf16cmd);
     return ReturnValue;
 }
 


### PR DESCRIPTION
… ppx under windows

This is an alternative to #1101 and should fix the same problem.
This patch does not go through `cmd.exe` and that seems to improve the latency (in my informal experiments).