### PR TITLE
vim & emacs : implement MerlinUse/merlin-use/-package in editor modes

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -225,6 +225,9 @@ The association list can contain the following optional keys:
 (defvar-local merlin-buffer-packages nil
    "List of packages loaded in the buffer")
 
+(defvar-local merlin-buffer-packages-path nil
+   "List of path of packages loaded in the buffer")
+
 (defvar-local merlin-buffer-extensions nil
    "List of syntax extensions active in the buffer")
 
@@ -493,8 +496,8 @@ return (LOC1 . LOC2)."
                          merlin-logfile))
         (extensions  (merlin--map-flatten (lambda (x) (cons "-extension" x))
                                           merlin-buffer-extensions))
-        (packages    (merlin--map-flatten (lambda (x) (cons "-package" x))
-                                          merlin-buffer-packages))
+        (packages    (merlin--map-flatten (lambda (x) (cons "-I" x))
+                                          merlin-buffer-packages-path))
         (filename    (buffer-file-name (buffer-base-buffer))))
     ;; Update environment
     (dolist (binding (merlin-lookup 'env merlin-buffer-configuration))
@@ -1302,7 +1305,9 @@ strictly within, or nil if there is no such element."
 
 (defun merlin-get-packages ()
   "Get the list of available findlib package."
-  (merlin/call "findlib-list"))
+  (let* ((packages-string (shell-command-to-string "ocamlfind list"))
+        (packages-list (split-string packages-string "\n")))
+    (mapcar 'car (mapcar 'split-string packages-list))))
 
 (defun merlin--project-get ()
   "Returns a pair of two string lists (dot_merlins . failures) with a list of
@@ -1324,6 +1329,10 @@ loading"
             (mapconcat 'identity merlin-buffer-packages " ")))))
   (setq merlin-buffer-packages
         (delete-dups (merlin--map-flatten 'identity pkgs)))
+  (let* ((arguments (cons "ocamlfind query" merlin-buffer-packages))
+        (command (mapconcat 'identity arguments " "))
+        (paths (shell-command-to-string command)))
+    (setq merlin-buffer-packages-path (split-string paths "\n")))
   (merlin-error-reset)
   (merlin-configuration-check t))
 

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -164,7 +164,7 @@ def command2(args, context=None, track_verbosity=None):
         log_errors = []
     cmdline = ["server"] + list(args) + ["-filename",filename] + verbosity + \
             concat_map(lambda ext: ("-extension",ext), vim_list_if_set("b:merlin_extensions")) + \
-            concat_map(lambda pkg: ("-package",pkg), vim_list_if_set("b:merlin_packages")) + \
+            concat_map(lambda pkg: ("-I",pkg), vim_list_if_set("b:merlin_packages_path")) + \
             concat_map(lambda dm: ("-dot-merlin",dm), vim_list_if_set("b:merlin_dot_merlins")) + \
             log_errors + \
             vim.eval('g:merlin_binary_flags') + \

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -164,11 +164,20 @@ function! merlin#Extensions(...)
 endfunction
 
 function! merlin#CompletePackages(ArgLead, CmdLine, CursorPos)
-  return s:MakeCompletionList("b:merlin_packages", "merlin.vim_findlib_list")
+  let l:all = map(systemlist("ocamlfind list"), "split(v:val)[0]")
+  if exists("b:merlin_packages")
+    let l:existing = copy(b:merlin_packages)
+    let l:all = filter(l:all, "index(l:existing, v:val) == -1")
+    call insert(l:all, join(map(l:existing, "fnameescape(v:val)"), " "))
+  endif
+  return join(l:all, "\n")
 endfunction
 
 function! merlin#Packages(...)
-  let b:merlin_packages = a:000
+  let b:merlin_packages = copy(a:000)
+  let arguments = join(map(b:merlin_packages, "shellescape(v:val)"), ' ')
+  let cmd = 'ocamlfind query ' . arguments
+  let b:merlin_packages_path = systemlist(cmd)
 endfunction
 
 function! merlin#CompleteFlags(ArgLead, CmdLine, CursorPos)


### PR DESCRIPTION
Merlin used to support the `-package` flag to load an ocamlfind/findlib package. This was exposed by the `:MerlinUse` and `merlin-use` commands in vim and emacs.

The commands are still there but the support for `-package` was dropped when packaging logic was moved to dune (via the reader helper). So they are broken in the latest release...

This PR reimplements the command so they work entirely on editor side: `ocamlfind` is invoked to list packages and resolve package names to include path. Only theses paths are passed to merlin using the `-I` flag.

Tradeoffs:
- ocamlfind is called from the editor environment... the answers might be out of date if the user changed to another opam switch. Workaround: maybe we should call `opam exec ocamlfind` instead of `ocamlfind`? (That's much slower... but maybe we shouldn't mind?)
- only the include path is considered... This won't work with ppx and other fancy features supported by ocamlfind. I don't mind these use cases, any thoughts?