### PR TITLE
Use cl-letf instead of flet. (#1268)

### DIFF
--- a/emacs/merlin-iedit.el
+++ b/emacs/merlin-iedit.el
@@ -44,7 +44,7 @@
                           "-identifier-at" (merlin/unmake-point (point)))))
       (when r
         (if (listp r)
-            (flet ((iedit-printable (a)
+            (cl-letf ((iedit-printable (a)
                      (merlin-iedit--printable))
                    (iedit-make-occurrences-overlays (a b c)
                      (merlin-iedit--make-occurrences-overlays a)))


### PR DESCRIPTION
This is what emacs suggests doing in the deprecation warning. This should fix the deprecation warning at startup.