### PR TITLE
Completion: use type information

### DIFF
--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -2955,6 +2955,8 @@ and type_expect_
           exp_env = env }
       end
   | Pexp_record(lid_sexp_list, opt_sexp) ->
+    let saved_levels = save_levels () in
+    begin try
       assert (lid_sexp_list <> []);
       let opt_exp =
         match opt_sexp with
@@ -3095,6 +3097,19 @@ and type_expect_
         exp_type = instance ty_expected;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
+    with exn ->
+      raise_error exn;
+      set_levels saved_levels;
+      re {
+        exp_desc = Texp_record {
+            fields = [||]; representation = Record_regular;
+            extended_expression = None;
+          };
+        exp_loc = loc; exp_extra = [];
+        exp_type = instance ty_expected;
+        exp_attributes = merlin_recovery_attributes sexp.pexp_attributes;
+        exp_env = env }
+    end
   | Pexp_field(srecord, lid) ->
       let (record, label, _) = type_label_access env srecord lid in
       let (_, ty_arg, ty_res) = instance_label false label in

--- a/tests/test-dirs/completion/disambiguation.t/constr.ml
+++ b/tests/test-dirs/completion/disambiguation.t/constr.ml
@@ -1,0 +1,5 @@
+module T = struct
+  type t = Foobar
+end
+
+let _foobar = (Foo : T.t)

--- a/tests/test-dirs/completion/disambiguation.t/record.ml
+++ b/tests/test-dirs/completion/disambiguation.t/record.ml
@@ -1,0 +1,11 @@
+module T = struct
+  type t = { foobar : int; test_other : float; }
+end
+
+let _easy = { T.f }
+
+let _hard = ({ foo } : T.t)
+
+open T
+
+let _easier = { foobar = 5; tes }

--- a/tests/test-dirs/completion/disambiguation.t/run.t
+++ b/tests/test-dirs/completion/disambiguation.t/run.t
@@ -20,7 +20,15 @@ the type should be known):
   {
     "class": "return",
     "value": {
-      "entries": [],
+      "entries": [
+        {
+          "name": "foobar",
+          "kind": "Label",
+          "desc": "T.t -> int",
+          "info": "",
+          "deprecated": false
+        }
+      ],
       "context": null
     },
     "notifications": []
@@ -32,7 +40,15 @@ the type should be known):
   {
     "class": "return",
     "value": {
-      "entries": [],
+      "entries": [
+        {
+          "name": "foobar",
+          "kind": "Label",
+          "desc": "T.t -> int",
+          "info": "",
+          "deprecated": false
+        }
+      ],
       "context": null
     },
     "notifications": []
@@ -43,10 +59,16 @@ the type should be known):
   {
     "class": "return",
     "value": {
-      "entries": [],
+      "entries": [
+        {
+          "name": "test_other",
+          "kind": "Label",
+          "desc": "T.t -> float",
+          "info": "",
+          "deprecated": false
+        }
+      ],
       "context": null
     },
     "notifications": []
   }
-
-

--- a/tests/test-dirs/completion/disambiguation.t/run.t
+++ b/tests/test-dirs/completion/disambiguation.t/run.t
@@ -6,7 +6,15 @@ available:
   {
     "class": "return",
     "value": {
-      "entries": [],
+      "entries": [
+        {
+          "name": "Foobar",
+          "kind": "Constructor",
+          "desc": "T.t",
+          "info": "",
+          "deprecated": false
+        }
+      ],
       "context": null
     },
     "notifications": []

--- a/tests/test-dirs/completion/disambiguation.t/run.t
+++ b/tests/test-dirs/completion/disambiguation.t/run.t
@@ -1,0 +1,52 @@
+Completing out-of-scope constructor names when the type information is
+available:
+
+  $ $MERLIN single complete-prefix -position 5:18 -prefix Foo -doc n \
+  > -filename constr.ml < constr.ml
+  {
+    "class": "return",
+    "value": {
+      "entries": [],
+      "context": null
+    },
+    "notifications": []
+  }
+
+Try completing field names inside record expressions (where either the scope or
+the type should be known):
+
+  $ $MERLIN single complete-prefix -position 5:17 -prefix T.f -doc n \
+  > -filename record.ml < record.ml
+  {
+    "class": "return",
+    "value": {
+      "entries": [],
+      "context": null
+    },
+    "notifications": []
+  }
+
+
+  $ $MERLIN single complete-prefix -position 7:18 -prefix foo -doc n \
+  > -filename record.ml < record.ml
+  {
+    "class": "return",
+    "value": {
+      "entries": [],
+      "context": null
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single complete-prefix -position 11:31 -prefix tes -doc n \
+  > -filename record.ml < record.ml
+  {
+    "class": "return",
+    "value": {
+      "entries": [],
+      "context": null
+    },
+    "notifications": []
+  }
+
+


### PR DESCRIPTION
Type recovery on record degraded over the past few years, which in turns degraded completion results when inside a record expression.
I reintroduced a naïve recovery for record, but it needs to be reviewed (in particular: I am not calling `Msupport.erroneous_type_register`, should I?).

The other commit extends constructor completion candidates with the constructor from the expected type which matches the given prefix.