### PR TITLE
Improve prefixing of Destruct by removing opened modules

### DIFF
--- a/src/analysis/browse_misc.ml
+++ b/src/analysis/browse_misc.ml
@@ -44,6 +44,19 @@ let print_constructor c =
     in
     Printtyp.tree_of_type_scheme (dummy_type_scheme desc)
 
+let summary_prev = function
+  | Env.Env_empty -> None
+  | Env.Env_open (s,_)       | Env.Env_value (s,_,_)
+  | Env.Env_type (s,_,_)     | Env.Env_extension (s,_,_)
+  | Env.Env_module (s,_,_,_) | Env.Env_modtype (s,_,_)
+  | Env.Env_class (s,_,_)    | Env.Env_cltype (s,_,_)
+  | Env.Env_functor_arg (s,_)
+  | Env.Env_constraints (s,_)
+  | Env.Env_copy_types s
+  | Env.Env_persistent (s,_)
+  | Env.Env_value_unbound (s, _, _) | Env.Env_module_unbound (s, _, _) ->
+    Some s
+
 let signature_of_env ?(ignore_extensions=true) env =
   let signature_of_summary =
     let open Env in
@@ -69,19 +82,6 @@ let signature_of_env ?(ignore_extensions=true) env =
     | Env_open _ | Env_empty | Env_functor_arg _
     | Env_constraints _ | Env_copy_types _ | Env_persistent _
     | Env_value_unbound _ | Env_module_unbound _ -> None
-  in
-  let summary_prev = function
-    | Env.Env_empty -> None
-    | Env.Env_open (s,_)       | Env.Env_value (s,_,_)
-    | Env.Env_type (s,_,_)     | Env.Env_extension (s,_,_)
-    | Env.Env_module (s,_,_,_) | Env.Env_modtype (s,_,_)
-    | Env.Env_class (s,_,_)    | Env.Env_cltype (s,_,_)
-    | Env.Env_functor_arg (s,_)
-    | Env.Env_constraints (s,_)
-    | Env.Env_copy_types s
-    | Env.Env_persistent (s,_)
-    | Env.Env_value_unbound (s, _, _) | Env.Env_module_unbound (s, _, _) ->
-      Some s
   in
   let summary_module_ident_opt = function
     | Env.Env_module (_,i,_,_) -> Some i

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -44,6 +44,38 @@ let () =
     | _ -> None
   )
 
+module Path_utils : sig
+  val to_shortest_lid : env:Env.t -> Path.t -> Longident.t
+  val replace_name_by : name:string -> Longident.t -> Longident.t
+end = struct
+  let opens env =
+    let rec aux acc = function
+      | Env.Env_open (s, path) -> aux (path::acc) s
+      | s ->
+        Option.map ~f:(aux acc) (Browse_misc.summary_prev s)
+        |> Option.value ~default:acc
+    in
+    aux [] env
+
+  let rec to_shortest_lid ~(opens : Path.t list) =
+    function
+    | Path.Pdot (path, name) when List.exists ~f:(Path.same path) opens ->
+      Longident.Lident name
+    | Path.Pdot (path, name) -> Ldot (to_shortest_lid ~opens path, name)
+    | Pident ident -> Lident (Ident.name ident)
+    | _ -> assert false
+
+  let to_shortest_lid ~env =
+    let opens = opens (Env.summary env) in
+    to_shortest_lid ~opens
+
+  let replace_name_by ~name =
+    let open Longident in function
+    | Lident _ -> Lident name
+    | Ldot (lid, _) -> Ldot (lid, name)
+    | _ -> assert false
+end
+
 let mk_id s  = Location.mknoloc (Longident.Lident s)
 let mk_var s = Location.mknoloc s
 
@@ -109,12 +141,8 @@ let rec gen_patterns ?(recurse=true) env type_expr =
     | constructors, _ ->
       let prefix =
         let path = Printtyp.shorten_type_path env path in
-        let lid  = Untypeast.lident_of_path path in
-        fun name ->
-          match lid with
-          | Lident _ -> Longident.Lident name
-          | Ldot (lid, _) -> Ldot (lid, name)
-          | _ -> assert false
+        let lid  = Path_utils.to_shortest_lid ~env path in
+        fun name -> Path_utils.replace_name_by ~name lid
       in
       let are_types_unifiable typ =
         let snap = Btype.snapshot () in
@@ -408,7 +436,7 @@ let rec qualify_constructors ~unmangling_tables f pat  =
           begin match (Btype.repr pat.pat_type).Types.desc with
           | Types.Tconstr (path, _, _) ->
             let path = f pat.pat_env path in
-            begin match Untypeast.lident_of_path path with
+            begin match Path_utils.to_shortest_lid ~env:pat.pat_env path with
             | Lident _ -> { lid with Asttypes.txt = Longident.Lident name }
             | Ldot (path, _) -> { lid with Asttypes.txt = Ldot (path, name) }
             | _ -> assert false

--- a/src/analysis/destruct.mli
+++ b/src/analysis/destruct.mli
@@ -76,8 +76,22 @@ exception Nothing_to_do
 exception Wrong_parent of string
 
 module Path_utils : sig
-  val to_shortest_lid : env:Env.t -> Path.t -> Longident.t
-  val replace_name_by : name:string -> Longident.t -> Longident.t
+  (** [to_shortest_lid ~env ~env_check path] will make a [Longident.t] from the
+  provided [Path.t] and attempt to use the shortest prefix possible given the
+  currently opened modules. The result is checked by looking it up in the
+  environnement using the [env_check : Longident.t -> Env.t -> 'a] function.
+
+  The check is needed because shadowing can cause subtle issues. A typical check
+  function would be [Env.find_constructor_by_name]. WHen the check fails the
+  function will return [Untypeast.lident_of_path path] instead of clever
+  prefix-less constructions.
+
+  Optionnaly a [name] can be provided that will be used as the last ident of the
+  path. *)
+  val to_shortest_lid :
+    env:Env.t ->
+    ?name:string ->
+    env_check:(Longident.t -> Env.t -> 'a) -> Path.t -> Longident.t
 end
 
 val node :

--- a/src/analysis/destruct.mli
+++ b/src/analysis/destruct.mli
@@ -75,6 +75,11 @@ exception Useless_refine
 exception Nothing_to_do
 exception Wrong_parent of string
 
+module Path_utils : sig
+  val to_shortest_lid : env:Env.t -> Path.t -> Longident.t
+  val replace_name_by : name:string -> Longident.t -> Longident.t
+end
+
 val node :
   Mconfig.t -> Msource.t -> Browse_raw.node ->
   Browse_raw.node list -> Location.t * string

--- a/tests/test-dirs/destruct/dune
+++ b/tests/test-dirs/destruct/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to :whole_subtree)
+ (alias all-destruct-tests))

--- a/tests/test-dirs/destruct/prefixing.t
+++ b/tests/test-dirs/destruct/prefixing.t
@@ -1,0 +1,108 @@
+#################
+### FROM EXPR ###
+#################
+Test 1.1
+  $ $MERLIN single case-analysis -start 3:2 -end 3:3 -filename typ.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct type my_list = Atom | Elt of string * my_list end
+  > let f x : A.my_list =
+  >   x
+  > EOF
+  "match (x : A.my_list) with | A.Atom -> (??) | A.Elt (_, _) -> (??)"
+
+Test 1.2
+  $ $MERLIN single case-analysis -start 4:2 -end 4:3 -filename typ.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct type my_list = Atom | Elt of string * my_list end
+  > open A
+  > let f x : my_list =
+  >   x
+  > EOF
+  "match (x : my_list) with | Atom -> (??) | Elt (_, _) -> (??)"
+
+Test 1.3
+  $ $MERLIN single case-analysis -start 6:2 -end 6:3 -filename typ.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct type t = A | B | C end
+  > module B = struct type t = A | B end
+  > open A
+  > open B
+  > let f x : A.t =
+  >   x
+  > EOF
+  "match (x : A.t) with | A -> (??) | B -> (??) | C -> (??)"
+
+Test 1.4
+  $ $MERLIN single case-analysis -start 5:2 -end 5:3 -filename typ.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct module B = struct type t = C end end
+  > open A
+  > module B = struct type t = D end
+  > let f x : A.B.t =
+  >   x
+  > EOF
+  "match (x : A.B.t) with | A.B.C -> (??)"
+
+################
+### COMPLETE ###
+################
+
+Test 2.1
+  $ cat >typ21.ml <<EOF
+  > module A = struct type t = B | C end
+  > let f (x : A.t) =
+  >   match x with
+  >   | A.B -> ()
+  > open A
+  > let f (x : t) =
+  >   match x with
+  >   | B -> ()
+  > EOF
+
+Test 2.2
+  $ $MERLIN single case-analysis -start 4:4 -end 4:4 -filename typ21.ml <typ21.ml | \
+  > tr -d '\n' | jq '.value[1]'
+  "| A.C -> (??)"
+
+Test 2.3
+  $ $MERLIN single case-analysis -start 8:4 -end 8:4 -filename typ21.ml <typ21.ml | \
+  > tr -d '\n' | jq '.value[1]'
+  "| C -> (??)"
+
+Test 2.4
+  $ $MERLIN single case-analysis -start 5:4 -end 5:4 -filename typ.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct module B = struct type t = C | F end end
+  > open A
+  > module B = struct type t = D end
+  > let f x = match (x : A.B.t) with
+  >   | A.B.C -> ()
+  > EOF
+  "| A.B.F -> (??)"
+
+################
+### REFINING ###
+################
+
+Test 3.1
+  $ $MERLIN single case-analysis -start 5:9 -end 5:10 -filename refine_pattern.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct type t = B | C end
+  > let _ =
+  >   match (None : A.t option) with
+  >   | None -> ()
+  >   | Some _ -> ()
+  > EOF
+  "Some (A.B) |Some (A.C)"
+
+Test 3.2
+  $ $MERLIN single case-analysis -start 6:9 -end 6:10 -filename refine_pattern.ml <<EOF | \
+  > tr -d '\n' | jq '.value[1]'
+  > module A = struct type t = B | C end
+  > open A
+  > let _ =
+  >   match (None : t option) with
+  >   | None -> ()
+  >   | Some _ -> ()
+  > EOF
+  "Some (B) |Some (C)"


### PR DESCRIPTION
(this PR targets branch 411)

This is an attempt to improve prefixing on Destruct and it will be reused by Construct.

We scan the environment to gather opened modules paths and then we use that information to drop prefixes in paths that are in the list of opened paths.

As suggested by @def, because over-shortening of the prefix can happen is some shadowing cases, we always check that the resulting lid can be found in the environment. If not we fallback on the non-shortened lid.

I made the function looking up in the environment a parameter of `Destruct.Path_utils.to_shortest_lid` in anticipation of Construct usages. For Destruct the lookup function if always `Env.find_constructor_by_name` but Construct will need more flexibility as it handles more diverse types of objects.