### PR TITLE
Constify argv parameter in _spawnvp

### DIFF
--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -649,7 +649,7 @@ int main(int argc, char **argv)
   {
     argv[0] = ocamlmerlin_server;
 #ifdef _WIN32
-    int err = _spawnvp(_P_WAIT, merlin_path, argv);
+    int err = _spawnvp(_P_WAIT, merlin_path, (const char *const *)argv);
     if (err < 0)
       failwith_perror("spawnvp(ocamlmerlin-server)");
     else


### PR DESCRIPTION
This suppresses a warning in mingw-w64.