### PR TITLE
CI fix attempt

### DIFF
--- a/merlin.opam
+++ b/merlin.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
-  "ocaml" {> "4.11.1" }
+  "ocaml" {>= "4.12.0" }
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}

--- a/merlin.opam
+++ b/merlin.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.12.0" }
+  "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}


### PR DESCRIPTION
Ocaml CI was running one 4.11 build because the constraint was `>4.11.1` and not `4.11.2`.
This PR sets the constraint to `>= 4.12.0`.