### PR TITLE
Fix test breakage

### DIFF
--- a/tests/test-dirs/completion/infix.t/run.t
+++ b/tests/test-dirs/completion/infix.t/run.t
@@ -2,13 +2,6 @@
   > -filename infix.ml < infix.ml | jq ".value.entries | sort_by(.name)"
   [
     {
-      "name": "(())",
-      "kind": "Constructor",
-      "desc": "unit",
-      "info": "",
-      "deprecated": false
-    },
-    {
       "name": "(>>)",
       "kind": "Value",
       "desc": "int",

--- a/tests/test-dirs/completion/infix.t/run.t
+++ b/tests/test-dirs/completion/infix.t/run.t
@@ -2,6 +2,13 @@
   > -filename infix.ml < infix.ml | jq ".value.entries | sort_by(.name)"
   [
     {
+      "name": "(())",
+      "kind": "Constructor",
+      "desc": "unit",
+      "info": "",
+      "deprecated": false
+    },
+    {
       "name": "(>>)",
       "kind": "Value",
       "desc": "int",

--- a/tests/test-dirs/locate/ambiguity/not-in-env.t
+++ b/tests/test-dirs/locate/ambiguity/not-in-env.t
@@ -1,3 +1,13 @@
+FIXME!
+
+We would like this to say "Not in the environment b", because no label
+declaration named b exists.
+For this to work, we would need to know that the cursor is on a label name,
+which we can't right now when looking on the recovered typedtree. We only know
+we're in an expression.
+If we switch our context analysis to work on the grammar, this might get better.
+Until then ...
+
   $ $MERLIN single locate -look-for ml -position 2:10 -filename test.ml <<EOF
   > let b = 10
   > let x = { b = 9 }

--- a/tests/test-dirs/locate/ambiguity/not-in-env.t
+++ b/tests/test-dirs/locate/ambiguity/not-in-env.t
@@ -4,6 +4,12 @@
   > EOF
   {
     "class": "return",
-    "value": "Not in environment 'b'",
+    "value": {
+      "file": "test.ml",
+      "pos": {
+        "line": 1,
+        "col": 4
+      }
+    },
     "notifications": []
   }


### PR DESCRIPTION
#1276 broke two tests (and I didn't notice! :scream: ):
- one is due to me not considering the prefix when proposing disambiguated constructors as completion candidates. This PR fixes this
- the other is actually a very reasonable limitation of our current context detection, which is explained in the last commit. This became apparent because the typing recovery got slightly better. Before that the guessed context was "module path" which was definitely not correct. I didn't investigate why that was the case. The present result is more correct.

This PR should fix the CI! :pray: 