### PR TITLE
[deconstruct][vim] Add next/previous hole commands

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -321,6 +321,16 @@ def command_occurrences(pos):
     except MerlinExc as e:
         try_print_error(e)
 
+def command_holes():
+    try:
+        lst_or_err = command("holes")
+        if not isinstance(lst_or_err, list):
+            print(lst_or_err)
+        else:
+            return lst_or_err
+    except MerlinExc as e:
+        try_print_error(e)
+
 ######## VIM FRONTEND
 
 def vim_complete_prepare(str):
@@ -557,7 +567,7 @@ def vim_type_reset():
     enclosing_types = [] # reset
     current_enclosing = -1
 
-def replace_buffer_portion(start, end, txt):
+def replace_buffer_portion_and_jump_to_hole(start, end, txt):
     (encode,decode) = vim_codec()
 
     start_line = start['line'] - 1
@@ -581,7 +591,10 @@ def replace_buffer_portion(start, end, txt):
 
     # Properly reindent the modified lines
     vim.current.window.cursor = (start['line'], 0)
-    vim.command("call feedkeys('%d==', 'n')" % nb_lines)
+    vim.command('normal %d==' % nb_lines)
+
+    # We look for a hole to move the cursor to in the range we replaced
+    vim_next_hole(start_line, start_line + nb_lines)
 
 def vim_case_analysis():
     global enclosing_types
@@ -607,11 +620,35 @@ def vim_case_analysis():
                                           "-end", fmtpos(tmp['end']))
         tmp = result[0]
         txt = result[1]
-        replace_buffer_portion(tmp['start'], tmp['end'], txt)
+        replace_buffer_portion_and_jump_to_hole(tmp['start'], tmp['end'], txt)
+
     except MerlinExc as e:
         try_print_error(e)
 
     vim_type_reset()
+
+def vim_previous_hole():
+    line, col = vim.current.window.cursor
+    holes = command_holes()
+    holes.reverse()
+    for hole in holes:
+      hline = hole['start']['line']
+      hcol = hole['start']['col']
+      if (hline, hcol) < (line, col):
+        vim.current.window.cursor = (hline, hcol)
+        print(hole['type'])
+        break
+
+def vim_next_hole(min = 0, max = sys.maxint):
+    line, col = vim.current.window.cursor
+    holes = command_holes()
+    for hole in holes:
+      hline = hole['start']['line']
+      hcol = hole['start']['col']
+      if hline >= min and (hline, hcol) > (line, col) and hline <= max:
+        vim.current.window.cursor = (hline, hcol)
+        print(hole['type'])
+        break
 
 def vim_type_enclosing():
     global enclosing_types

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -265,7 +265,7 @@ function! merlin#PolaritySearch(debug,query)
   let s:search_result = []
   MerlinPy merlin.vim_polarity_search(vim.eval("a:query"), "s:search_result")
   if a:debug != 1 && s:search_result != []
-    call feedkeys("i=merlin#PolarityComplete()","n")
+    call feedkeys("i=merlin#PolarityComplete()\<CR>","n")
   endif
 endfunction
 
@@ -510,6 +510,14 @@ function! merlin#Destruct()
   MerlinPy merlin.vim_case_analysis()
 endfunction
 
+function! merlin#PreviousHole()
+  MerlinPy merlin.vim_previous_hole()
+endfunction
+
+function! merlin#NextHole()
+  MerlinPy merlin.vim_next_hole()
+endfunction
+
 function! merlin#Restart()
   MerlinPy merlin.vim_restart()
 endfunction
@@ -581,6 +589,10 @@ function! merlin#Register()
 
   """ Destruct  ----------------------------------------------------------------
   command! -buffer -nargs=0 MerlinDestruct call merlin#Destruct()
+
+  """ Holes  ---------------------------------------------------------------
+  command! -buffer -nargs=0 MerlinNextHole call merlin#NextHole()
+  command! -buffer -nargs=0 MerlinPreviousHole call merlin#PreviousHole()
 
   """ Locate  ------------------------------------------------------------------
   command! -buffer -complete=customlist,merlin#ExpandPrefix -nargs=? MerlinLocate call merlin#Locate(<q-args>)


### PR DESCRIPTION
This PR add two new commands to the vim plugin : `MerlinNextHole` et `MerlinPreviousHole`
It also automatically jump to the first hole when destruct is called. This should allow nice chaining with Construct. 