### PR TITLE
Holes with types

### DIFF
--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -383,7 +383,7 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     `List [ assoc ; `String str ]
   | Holes, locations ->
     `List (List.map locations
-              ~f:(fun loc -> with_location loc []))
+              ~f:(fun (loc, typ) -> with_location loc ["type", `String typ]))
   | Outline, outlines ->
     `List (json_of_outline outlines)
   | Shape _, shapes ->

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -164,7 +164,7 @@ type _ t =
   | Case_analysis(* *)
     : Msource.position * Msource.position -> (Location.t * string) t
   | Holes(* *)
-    : Location.t list t
+    : (Location.t * string) list t
   | Outline(* *)
     :  outline t
   | Shape(* *)

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -897,7 +897,13 @@ let node_of_binary_part env part =
 let all_holes (env, node) =
   let rec aux acc (env, node) =
     let f env node acc = match node with
-      | Expression { exp_desc = Texp_hole; exp_loc; _}  -> exp_loc :: acc
+      | Expression {
+          exp_desc = Texp_hole;
+          exp_loc;
+          exp_type;
+          exp_env;
+          _
+        } -> (exp_loc, exp_env, exp_type) :: acc
       | _ -> aux acc (env, node)
     in
     fold_node f env node acc

--- a/src/ocaml/merlin_specific/browse_raw.mli
+++ b/src/ocaml/merlin_specific/browse_raw.mli
@@ -116,4 +116,4 @@ val node_is_constructor : node ->
 
 val node_of_binary_part : Env.t -> Cmt_format.binary_part -> node
 
-val all_holes : Env.t * node -> Location.t list
+val all_holes : Env.t * node -> (Location.t * Env.t * Types.type_expr) list

--- a/tests/test-dirs/construct/holes.t
+++ b/tests/test-dirs/construct/holes.t
@@ -8,6 +8,7 @@
 
   $ cat >h2.ml <<EOF
   > let x : int option = _
+  > let g x y = x * y
   > let f x y = g _ _
   > EOF
 
@@ -22,26 +23,29 @@
       "end": {
         "line": 1,
         "col": 22
-      }
+      },
+      "type": "int option"
     },
     {
       "start": {
-        "line": 2,
+        "line": 3,
         "col": 14
       },
       "end": {
-        "line": 2,
+        "line": 3,
         "col": 15
-      }
+      },
+      "type": "int"
     },
     {
       "start": {
-        "line": 2,
+        "line": 3,
         "col": 16
       },
       "end": {
-        "line": 2,
+        "line": 3,
         "col": 17
-      }
+      },
+      "type": "int"
     }
   ]


### PR DESCRIPTION
This PR updates the `holes` command to add the type of each hole to the returned value.
This can prevent supernumerary calls to Merlin from editors plugins. 

(see https://github.com/ocaml/merlin/pull/1287)