### PR TITLE
Remove result dependency

### DIFF
--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -15,7 +15,6 @@ depends: [
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
   "csexp" {>= "1.2.3"}
-  "result" {>= "1.5"}
 ]
 description:
   "Helper process: reads .merlin files and gives the normalized content to merlin"

--- a/dune-project
+++ b/dune-project
@@ -4,4 +4,3 @@
 
 (cram enable)
 (formatting disabled)
-(implicit_transitive_deps false)

--- a/merlin.opam
+++ b/merlin.opam
@@ -16,7 +16,6 @@ depends: [
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
-  "result" {>= "1.5"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/src/dot-merlin/dot-protocol/dune
+++ b/src/dot-merlin/dot-protocol/dune
@@ -1,4 +1,4 @@
 (library
  (name merlin_dot_protocol)
  (wrapped false)
- (libraries merlin_utils csexp result))
+ (libraries merlin_utils csexp))

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -2,5 +2,5 @@
 
 (library
  (name merlin_utils)
- (libraries str yojson unix result)
+ (libraries str yojson unix)
  (foreign_stubs (language c) (names platform_misc)))

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -338,7 +338,7 @@ module Option = struct
 end
 
 module Result = struct
-  type ('a, 'e) t = ('a, 'e) Result.result =
+  type ('a, 'e) t = ('a, 'e) result =
   | Ok of 'a
   | Error of 'e
 end


### PR DESCRIPTION
* It's no longer necessary because merlin doesn't support 4.02.
* This requires us to drop (implicit_transitive_deps false) temporarily.
The reason is that Csexp is still using result.