### PR TITLE
Clarify .merlin requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ External contributors have implemented modes for more editors:
 Next steps
 ==========
 
-To use Merlin with a multi-file project, it is necessary to have a [.merlin](https://github.com/ocaml/merlin/wiki/project-configuration) file.
+To use Merlin with a multi-file project, it is necessary to have a [.merlin](https://github.com/ocaml/merlin/wiki/project-configuration) file
+unless your project is built using dune.
 
 Read more in the [wiki](https://github.com/ocaml/merlin/wiki) to learn how to make full use of Merlin in your projects.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Next steps
 
 To use Merlin with a multi-file project, it is necessary to have a [.merlin](https://github.com/ocaml/merlin/wiki/project-configuration) file
 unless your project is built using dune.
+Note that, in a project using Dune, user-created `.merlin` files will take precedence over the configuration provided by Dune to Merlin. 
 
 Read more in the [wiki](https://github.com/ocaml/merlin/wiki) to learn how to make full use of Merlin in your projects.
 


### PR DESCRIPTION
Per the recent announcement (https://tarides.com/blog/2021-01-26-recent-and-upcoming-changes-to-merlin), .merlin files are not needed when using Dune.