### PR TITLE
Make GH Actions use release mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,6 @@ jobs:
           # Version of the OCaml compiler to initialise
           ocaml-version: ${{ matrix.ocaml-version }}
 
-      - run: opam pin add . --no-action
-      - run: opam depext conf-jq --yes # merlin --yes --with-test # opam depext bug
+      - run: opam depext conf-jq --yes # opam depext bug
       - run: opam install . --deps-only --with-test
-      - run: opam install menhir
-      - run: opam exec -- dune build -p merlin,dot-merlin-reader
-      - run: opam exec -- dune runtest
+      - run: opam exec -- dune runtest -p merlin,dot-merlin-reader


### PR DESCRIPTION
This way both release and non-release modes are tested by the CI.
(OCaml-CI builds and test in non-release mode)