### PR TITLE
Disable failing tests on Windows

### DIFF
--- a/tests/test-dirs/config/check/dune
+++ b/tests/test-dirs/config/check/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to check-config)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/config/dot-merlin-reader/dune
+++ b/tests/test-dirs/config/dot-merlin-reader/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to erroneous-config quoting)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/config/dune
+++ b/tests/test-dirs/config/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to symlinks path-expansion workdir)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/config/flags/dune
+++ b/tests/test-dirs/config/flags/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to invalid)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/dune
+++ b/tests/test-dirs/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to no-escape type-expr environment_on_open locate-type
+   polarity-search typer-cache)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/ambiguity/dune
+++ b/tests/test-dirs/locate/ambiguity/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to rebinding)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/context-detection/dune
+++ b/tests/test-dirs/locate/context-detection/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to cd-field cd-from_a_pattern cd-label cd-mod_constr cd-test)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/dune
+++ b/tests/test-dirs/locate/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to looping-substitution mutually-recursive partial-cmt includes
+   issue802 issue845 issue1199 sig-substs)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/functors/dune
+++ b/tests/test-dirs/locate/functors/dune
@@ -1,0 +1,5 @@
+(cram
+ (applies_to f-all_local f-from_application f-generative f-included
+   f-missed_shadowing f-nested_applications)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/local-definitions/dune
+++ b/tests/test-dirs/locate/local-definitions/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to issue798 issue806)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/non-local/dune
+++ b/tests/test-dirs/locate/non-local/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to ignore-kept-locs preference)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/reconstruct-identifier/dune
+++ b/tests/test-dirs/locate/reconstruct-identifier/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to newlines off_by_one)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/pp/dune
+++ b/tests/test-dirs/pp/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to dot-pp-dot-ml simple-pp)
+ (enabled_if
+  (<> %{os_type} Win32)))


### PR DESCRIPTION
This ensures that `dune runtest` works on Windows: if Windows runners are added to ocaml-ci, this will not break the build, and failures can be fixed incrementally.