### PR TITLE
Prepare for 4.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,45 @@
+merlin 4.2
+==========
+Tue Apr 12 11:44:22 AM CET 2021
+
+  + merlin binary
+    - external configuration reading:
+      + use relative paths to communicate with Dune when possible. This solves
+        issues related to symlinks on Unix and improve Windows support (#1271,
+        fixes #1288)
+      + make the `workdir` configuration value when using the
+        `dune ocaml-merlin` configuration provider the same as when using
+        `dot-merlin-reader` so that ppxes behaves in the same way as before
+        (#1284, fixes ocaml/dune#4479, discussion in #1292)
+    - destruct:
+      + improve prefixing of generated constructors in Destruct by filtering
+        opened modules (#1277)
+      + make the destruct command more resilient to ill-typed expressions and
+        when called without nodes (#1304, fixes #1300)
+    - reintroduce some record recovery and improve completion (#1276)
+    - introduce a new AST node for holes (`_`), allow correct typing of these
+      holes and add a new `holes` command that returns the locations of all
+      holes in the current file along with their types (#1242, #1289)
+    - Mppx: don't restore cookies after invocation. Ppx are invoked only once
+      so there is no need to manage cookies. This small change should increase
+      performance and should not change any other behavior (#1309)
+    - Windows: system command variant: do not open a window console when
+      launching a ppx (#1270, fixes #714)
+    - fix same file documentation bug (#1265 by @ulugbekna, fixes #1261)
+  + editor modes
+    - vim: Add `MerlinNextHole` and `MerlinPreviousHole` commands to navigate
+      between holes. Jump to the first hole after destruct (#1287, #1303)
+    - emacs: Add `merlin-next-hole` and `merlin-previous-hole` commands to
+      navigate holes. Jump to the first hole after calling destruct. (#1291)
+    - emacs: modernization of the elisp code and conformance with coding
+      guidelines (#1247, #1310 by Steve Purcell )
+    - vim & emacs : new client-side "merlin use package" commands, restoring
+      previous behavior (#1272, fixes #1191)
+  + test suite
+    - cover constructor disambiguation and record fields (#1276)
+    - cover the new `holes` command and AST node (#1242, #1289)
+    - cover the document fix (#1265, #1315)
+
 merlin 4.1
 ==========
 Tue Feb 16 10:33:11 AM CET 2021


### PR DESCRIPTION
This is the draft changelog for release 4.2-412 and the scheduled backports.

## Try to merge before the release (not yet in changelog)
- [x] Constify argv parameter in _spawnvp #1279
- [x] vim & emacs : implement MerlinUse/merlin-use/-package in editor modes #1272
- [x] system command variant: do not open a window console when launching a ppx #1270 
- [x] Use infinity instead of maxint. Loop holes like in emacs. #1303
- [x] Do not fail when destructing no-nodes or recovered nodes #1304
- [x] Modernisation of elisp code and conformance with coding guidelines #1247
- [x] Mppx: don't restore cookies after invocation #1309
- [x] Update Emacs usage docs where applicable #1310
- [x] fix same file documentation bug #1265
- [x] Add more doc-related tests #1315

## Backport to 3.4
- [x] Use relative paths to communicate with dune ocaml-merlin #1271
- [x] Fix workdir detection #1284 
- [x] Constify argv parameter in _spawnvp #1279
- [x] vim & emacs : implement MerlinUse/merlin-use/-package in editor modes #1272
- [x] system command variant: do not open a window console when launching a ppx #1270 
- [x] Do not fail when destructing no-nodes or recovered nodes #1304
- [x] Modernisation of elisp code and conformance with coding guidelines #1247
- [x] Emacs: Fixes #1234 #1250 (already in 411)
- [x] Emacs: Use opam var instead of opam config var #1249 (already in 411)
- [x] Mppx: don't restore cookies after invocation #1309
- [x] Update Emacs usage docs where applicable #1310
- [x] fix same file documentation bug #1265
- [x] Add more doc-related tests #1315

## Backport to 411
- [x] All that is backported to 3.4
- [x] Completion: use type information #1276 (and Fix test breakage #1285)
- [x] Improve prefixing of Destruct by filtering opened modules #1277
- [x] Remove left-over destruct file #1282
- [x] [Construct] Part 0 - add AST holes, fix typing of holes and add a new holes command #1242
- [x] Holes with types #1289 
- [x] [deconstruct][vim] Add next/previous hole commands #1287 
- [x] New holes command for Emacs + Destruct jump #1291 
- [x] Use infinity instead of maxint. Loop holes like in emacs. #1303