### PR TITLE
Tentative fix for iedit.

### DIFF
--- a/emacs/merlin-iedit.el
+++ b/emacs/merlin-iedit.el
@@ -32,8 +32,7 @@
                     iedit-read-only-occurrences-overlays)
             (push (iedit-make-occurrence-overlay beginning ending)
                   iedit-occurrences-overlays))))
-      (when (and occurrences iedit-unmatched-lines-invisible)
-        (iedit-hide-unmatched-lines iedit-occurrence-context-lines))))
+      ))
   (length occurrences))
 
 (defun merlin-iedit-occurrences ()


### PR DESCRIPTION
the iedit emacs mode is broken with the last version of iedit. This is a tentative fix. It seems to work like that but don't ask me why. :)