### PR TITLE
Use infinity instead of maxint. Loop holes like in emacs.

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -638,6 +638,8 @@ def vim_previous_hole():
         vim.current.window.cursor = (hline, hcol)
         print(hole['type'])
         return
+    # If no hole was found before the cursor we jump
+    # to the last hole of the file if any.
     if len(holes) > 0:
       hline = holes[0]['start']['line']
       hcol = holes[0]['start']['col']
@@ -654,6 +656,8 @@ def vim_next_hole(min = 0, max = float('inf')):
         vim.current.window.cursor = (hline, hcol)
         print(hole['type'])
         return
+    # If no hole was found after the cursor we jump
+    # to the first hole of the file if any.
     if max == float('inf') and len(holes) > 0:
       hline = holes[0]['start']['line']
       hcol = holes[0]['start']['col']

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -637,9 +637,14 @@ def vim_previous_hole():
       if (hline, hcol) < (line, col):
         vim.current.window.cursor = (hline, hcol)
         print(hole['type'])
-        break
+        return
+    if len(holes) > 0:
+      hline = holes[0]['start']['line']
+      hcol = holes[0]['start']['col']
+      vim.current.window.cursor = (hline, hcol)
+      print(holes[0]['type'])
 
-def vim_next_hole(min = 0, max = sys.maxint):
+def vim_next_hole(min = 0, max = float('inf')):
     line, col = vim.current.window.cursor
     holes = command_holes()
     for hole in holes:
@@ -648,7 +653,12 @@ def vim_next_hole(min = 0, max = sys.maxint):
       if hline >= min and (hline, hcol) > (line, col) and hline <= max:
         vim.current.window.cursor = (hline, hcol)
         print(hole['type'])
-        break
+        return
+    if max == float('inf') and len(holes) > 0:
+      hline = holes[0]['start']['line']
+      hcol = holes[0]['start']['col']
+      vim.current.window.cursor = (hline, hcol)
+      print(holes[0]['type'])
 
 def vim_type_enclosing():
     global enclosing_types


### PR DESCRIPTION
Fixes #1302 

`sys.maxint` does not exists in Python 3 where ints do not have a maximum value.
It is used in the code to represent an value hypothetically higher than every over one so infinity (`float('inf')`) is correct value fir that. 

This PR also add the same "looping" behaviour as in the emacs plugin: if there is no next hole the first hole is returned (and vice et versa for "previous hole".

(There is some code duplication but I am not sure that it would be worth it to abstract like we did in the Emacs equivalent.)