### PR TITLE
Do not fail when destructing no-nodes or recovered nodes

### DIFF
--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -32,6 +32,7 @@ open Browse_raw
 exception Not_allowed of string
 exception Useless_refine
 exception Nothing_to_do
+exception Ill_typed
 exception Wrong_parent of string
 
 let {Logger. log} = Logger.for_section "destruct"
@@ -41,6 +42,9 @@ let () =
     | Not_allowed s  -> Some (Location.error ("Destruct not allowed on " ^ s))
     | Useless_refine -> Some (Location.error "Cannot refine an useless branch")
     | Nothing_to_do  -> Some (Location.error "Nothing to do")
+    | Ill_typed  -> Some (
+        Location.error "The node on which destruct was called is ill-typed"
+      )
     | _ -> None
   )
 
@@ -276,6 +280,9 @@ let rec get_every_pattern = function
     | Pattern _ ->
       (* We are still in the same branch, going up. *)
       get_every_pattern parents
+    | Expression { exp_desc = Typedtree.Texp_ident (Path.Pident id, _, _) ; _}
+      when Ident.name id = "*type-error*" ->
+        raise (Ill_typed)
     | Expression _ ->
       (* We are on the right node *)
       let patterns : Typedtree.pattern list =

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -610,7 +610,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     Destruct.log ~title:"nodes after" "%a"
       Logger.json (fun () -> `List (List.map nodes ~f:dump_node));
     begin match nodes with
-      | [] -> raise No_nodes
+      | [] -> raise Destruct.Nothing_to_do
       | (env,node) :: parents ->
         let source = Mpipeline.input_source pipeline in
         let config = Mpipeline.final_config pipeline in

--- a/tests/test-dirs/destruct/errors.t
+++ b/tests/test-dirs/destruct/errors.t
@@ -9,13 +9,16 @@ Test 1
 
 Test 2
 
-  $ $MERLIN single case-analysis -start 4:2 -end 4:1 -filename nonode.ml <<EOF | grep -B 1 Query_commands.No_nodes
+  $ $MERLIN single case-analysis -start 4:2 -end 4:1 -filename nonode.ml <<EOF
   > let f (x : int option) =
   >   match w with
   >  | _ -> ()
   > EOF
-    "class": "exception",
-    "value": "Query_commands.No_nodes
+  {
+    "class": "error",
+    "value": "Nothing to do",
+    "notifications": []
+  }
 
 Test 3
 

--- a/tests/test-dirs/destruct/issue1300.t
+++ b/tests/test-dirs/destruct/issue1300.t
@@ -1,0 +1,52 @@
+From issue 1300:
+https://github.com/ocaml/merlin/issues/1300
+  $ $MERLIN single case-analysis -start 6:5 -end 6:5 -filename i1300.ml <<EOF
+  > type t =
+  > | A of int
+  > | B of int
+  > 
+  > let f = function
+  > | A x (* <<< here *)
+  > | B -> 0
+  > EOF
+  {
+    "class": "error",
+    "value": "The node on which destruct was called is ill-typed",
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 6:5 -end 6:5 -filename i1300.ml <<EOF
+  > type t =
+  > | A of int
+  > | B of int
+  > 
+  > let f = function
+  > | A x (* <<< here *)
+  > | B x -> 0
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 6,
+          "col": 2
+        },
+        "end": {
+          "line": 7,
+          "col": 5
+        }
+      },
+      "A 0 |B x |A _"
+    ],
+    "notifications": []
+  }
+
+Fixed: Another stacktrace when "no nodes"
+  $ $MERLIN single case-analysis -start 7:25 -end 7:25 -filename i1300.ml <<EOF
+  > EOF
+  {
+    "class": "error",
+    "value": "Nothing to do",
+    "notifications": []
+  }


### PR DESCRIPTION
Fixes #1300 

This PR adds graceful error handling for two cases:
- Recovered AST (#1300)
- No nodes

Future work: #1300 could be solved in a more satisfying way by improving the recovery