### PR TITLE
Mppx: don't restore cookies after invocation

### DIFF
--- a/src/kernel/mppx.ml
+++ b/src/kernel/mppx.ml
@@ -39,7 +39,9 @@ let rewrite cfg parsetree =
   in
   (* add include path attribute to the parsetree *)
   with_include_dir (Mconfig.build_path cfg) @@ fun () ->
-  match Pparse.apply_rewriters ~ppx ~tool_name:"merlin" parsetree with
+  match
+    Pparse.apply_rewriters ~restore:false ~ppx ~tool_name:"merlin" parsetree
+  with
   | parsetree ->
     restore ();
     cfg, parsetree


### PR DESCRIPTION
Ppx are invoked only once so there is no need to manage cookies.
@lpw25 observed that restoring cookies cause the load path to be rescanned.
This doubles the number of uncached calls to stat which can be expensive on large projects.

This small change should increase performance and should not change any other behavior.