### PR TITLE
refactor-open qualify uses short-paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ git version
     - add new module holes that can replace module expressions (#1333)
     - add a new command `construct` that builds a list of possible terms when
       called on a typed hole (#1318)
+    - `refactor-open qualify` improvements (#1313)
+      - do not make paths absolute, simply prefix with the identifier under the cursor
+        ```ocaml
+        open Foo (* calling refactor-open qualify on this open *)
+        let _ = Foo.bar (* previously could result in [Dune__exe.Foo.bar] *)
+        ```
+      - does not return identical (duplicate) edits
   + editor modes
     - vim: add a simple interface to the new `construct` command:
       `MerlinConstruct`. When several results are suggested, `<c-i>` and `<c-u>`

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -508,7 +508,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
               with Not_found -> None
             else None
           )
-        |> List.sort
+        |> List.sort_uniq
           ~cmp:(fun (_,l1) (_,l2) ->
               Lexing.compare_pos l1.Location.loc_start l2.Location.loc_start)
     end

--- a/src/kernel/mbrowse.ml
+++ b/src/kernel/mbrowse.ml
@@ -176,26 +176,26 @@ let rec select_open_node =
   function[@warning "-9"]
   | (_, ( Structure_item ({str_desc =
                              Tstr_open { open_expr =
-                                           { mod_desc = Tmod_ident (p, _) }}},
+                                           { mod_desc = Tmod_ident (p, {txt = longident}) }}},
                           _)))
     :: ancestors ->
-    Some (p, ancestors)
+    Some (p, longident, ancestors)
   | (_, ( Signature_item ({sig_desc = Tsig_open op}, _))) :: ancestors ->
-    Some (fst op.open_expr, ancestors)
+    let (p, { Asttypes.txt = longident; }) = op.open_expr in
+    Some (p, longident, ancestors)
+  | (_, Expression { exp_desc =
+          Texp_open ({ open_expr =
+                        { mod_desc = Tmod_ident (p, {txt = longident})}}, _); _})
+    :: _ as ancestors ->
+      Some (p, longident, ancestors)
   | (_, Pattern {pat_extra; _}) :: ancestors
     when List.exists pat_extra
-        ~f:(function (Tpat_open _, _ ,_) -> true | _ -> false) ->
-    let p = List.find_map pat_extra
-        ~f:(function | Tpat_open (p,_,_), _ ,_ -> Some p
+          ~f:(function (Tpat_open _, _ ,_) -> true | _ -> false) ->
+    let (p, longident) = List.find_map pat_extra
+        ~f:(function | Tpat_open (p,{ txt = longident; },_), _ ,_ -> Some (p, longident)
                      | _ -> None)
     in
-    Some (p, ancestors)
-  | (_, Expression { exp_desc =
-                       Texp_open ({ open_expr =
-                                      { mod_desc = Tmod_ident (p, _)}}, _);
-                     _
-                   }) :: _ as ancestors ->
-    Some (p, ancestors)
+    Some (p, longident, ancestors)
   | [] -> None
   | _ :: ancestors -> select_open_node ancestors
 

--- a/src/kernel/mbrowse.mli
+++ b/src/kernel/mbrowse.mli
@@ -47,7 +47,7 @@ val drop_leaf : t -> t option
 val deepest_before : Lexing.position -> t list -> t
 
 
-val select_open_node : t -> (Path.t * t) option
+val select_open_node : t -> (Path.t * Longident.t * t) option
 
 val enclosing : Lexing.position -> t list -> t
 

--- a/tests/test-dirs/refactor-open/qualify.t
+++ b/tests/test-dirs/refactor-open/qualify.t
@@ -1,4 +1,4 @@
-Works for in-file modules
+Can qualify module located in the same file
   $ $MERLIN single refactor-open -action qualify -position 4:6 <<EOF
   > module M = struct
   >   let u = ()
@@ -24,7 +24,7 @@ Works for in-file modules
     "notifications": []
   }
 
-Works for in-file nested modules
+Can qualify nested modules located in the same file
 
   $ $MERLIN single refactor-open -action qualify -position 6:6 <<EOF
   > module M = struct
@@ -53,8 +53,7 @@ Works for in-file nested modules
     "notifications": []
   }
 
-Works for stdlib modules (stdlib modules differ from other in-file modules because their
-full path is different)
+Can qualify a module from an external library
 
   $ $MERLIN single refactor-open -action qualify -position 1:6 <<EOF
   > open Unix
@@ -78,7 +77,8 @@ full path is different)
     "notifications": []
   }
 
-refactor open qualify use short paths - 2
+Can qualify nested modules from the same file, including open statements, and 
+does not return duplicate edits
 
   $ $MERLIN single refactor-open -action qualify -position 8:6 <<EOF
   > module L = struct

--- a/tests/test-dirs/refactor-open/qualify.t
+++ b/tests/test-dirs/refactor-open/qualify.t
@@ -1,0 +1,80 @@
+Works for in-file modules
+  $ $MERLIN single refactor-open -action qualify -position 4:6 <<EOF
+  > module M = struct
+  >   let u = ()
+  > end
+  > open M
+  > let u = u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 5,
+          "col": 8
+        },
+        "end": {
+          "line": 5,
+          "col": 9
+        },
+        "content": "M.u"
+      }
+    ],
+    "notifications": []
+  }
+
+Works for in-file nested modules
+
+  $ $MERLIN single refactor-open -action qualify -position 6:6 <<EOF
+  > module M = struct
+  >   module N = struct
+  >     let u = ()
+  >   end
+  > end
+  > open M.N
+  > let u = u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 7,
+          "col": 8
+        },
+        "end": {
+          "line": 7,
+          "col": 9
+        },
+        "content": "M.N.u"
+      }
+    ],
+    "notifications": []
+  }
+
+Works for stdlib modules (stdlib modules differ from other in-file modules because their
+full path is different)
+
+  $ $MERLIN single refactor-open -action qualify -position 1:6 <<EOF
+  > open Unix
+  > let times = times ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 12
+        },
+        "end": {
+          "line": 2,
+          "col": 17
+        },
+        "content": "Unix.times"
+      }
+    ],
+    "notifications": []
+  }
+

--- a/tests/test-dirs/refactor-open/qualify.t
+++ b/tests/test-dirs/refactor-open/qualify.t
@@ -78,7 +78,7 @@ full path is different)
     "notifications": []
   }
 
-refactor open qualiafy use short paths - 2
+refactor open qualify use short paths - 2
 
   $ $MERLIN single refactor-open -action qualify -position 8:6 <<EOF
   > module L = struct
@@ -88,24 +88,13 @@ refactor open qualiafy use short paths - 2
   >     end
   >   end
   > end
-  > open L (* <- refactor open qualify causes this output:*)
-  > open M.N (* open L.L.M.N *)
+  > open L 
+  > open M.N
   > let () = u
   > EOF
   {
     "class": "return",
     "value": [
-      {
-        "start": {
-          "line": 9,
-          "col": 5
-        },
-        "end": {
-          "line": 9,
-          "col": 8
-        },
-        "content": "L.M.N"
-      },
       {
         "start": {
           "line": 9,

--- a/tests/test-dirs/refactor-open/qualify.t
+++ b/tests/test-dirs/refactor-open/qualify.t
@@ -78,3 +78,57 @@ full path is different)
     "notifications": []
   }
 
+refactor open qualiafy use short paths - 2
+
+  $ $MERLIN single refactor-open -action qualify -position 8:6 <<EOF
+  > module L = struct
+  >   module M = struct
+  >     module N = struct
+  >       let u = ()
+  >     end
+  >   end
+  > end
+  > open L (* <- refactor open qualify causes this output:*)
+  > open M.N (* open L.L.M.N *)
+  > let () = u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 9,
+          "col": 5
+        },
+        "end": {
+          "line": 9,
+          "col": 8
+        },
+        "content": "L.M.N"
+      },
+      {
+        "start": {
+          "line": 9,
+          "col": 5
+        },
+        "end": {
+          "line": 9,
+          "col": 8
+        },
+        "content": "L.M.N"
+      },
+      {
+        "start": {
+          "line": 10,
+          "col": 9
+        },
+        "end": {
+          "line": 10,
+          "col": 10
+        },
+        "content": "L.M.N.u"
+      }
+    ],
+    "notifications": []
+  }
+

--- a/tests/test-dirs/refactor-open/qualify_short_paths.t
+++ b/tests/test-dirs/refactor-open/qualify_short_paths.t
@@ -1,0 +1,29 @@
+FIXME refactor open qualify should use short paths
+
+  $ $MERLIN single refactor-open -action qualify -position 7:6 <<EOF
+  > module Dune__exe = struct
+  >   module M = struct
+  >     let u = ()
+  >   end
+  > end
+  > open Dune__exe
+  > open M
+  > let u = u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 8,
+          "col": 8
+        },
+        "end": {
+          "line": 8,
+          "col": 9
+        },
+        "content": "Dune__exe.M.u"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/refactor-open/qualify_short_paths.t
+++ b/tests/test-dirs/refactor-open/qualify_short_paths.t
@@ -1,4 +1,4 @@
-FIXME refactor open qualify should use short paths
+refactor open qualify should use short paths
 
   $ $MERLIN single refactor-open -action qualify -position 7:6 <<EOF
   > module Dune__exe = struct
@@ -22,7 +22,7 @@ FIXME refactor open qualify should use short paths
           "line": 8,
           "col": 9
         },
-        "content": "Dune__exe.M.u"
+        "content": "M.u"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/refactor-open/record_field.t
+++ b/tests/test-dirs/refactor-open/record_field.t
@@ -23,3 +23,38 @@ FIXME refactor open rewriting the whole record instead of a field label
     ],
     "notifications": []
   }
+
+Refactor open for record disambiguation
+
+  $ $MERLIN single refactor-open -action qualify -position 1:6 <<EOF
+  > open Unix
+  > let f x = x.tms_stime, x.tms_utime
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 12
+        },
+        "end": {
+          "line": 2,
+          "col": 21
+        },
+        "content": "Unix.tms_stime"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 25
+        },
+        "end": {
+          "line": 2,
+          "col": 34
+        },
+        "content": "Unix.tms_utime"
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
`refactor-open qualify` uses a "full path" to qualify modules, e.g., 

```ocaml
open Import (* calling refactor open qualify on this open does the following qualification, which is undesirable *)

let path = Dune__exe.Import.Option.value_exn (Dune__exe.Import.Unix_env.get Dune__exe.Import.Unix_env.initial "PATH")
```

I think this is not what a user wants when they use this command. 

This PR makes the command to qualify paths up to the leftmost ident in the open expression, e.g., up to `Import` in the above example despite the full path being `Dune__exe.Import.Option.value_exn`. 

Notes: 
- based on #1312 branch
- added before- and after-PR tests
- the tests concern only refactor-open qualify because the changes concern only refactor-open qualify 
- made minimal changes to keep PR easy to review; otherwise, there were some bits that could be improved