### PR TITLE
refactor-open: don't return useless edits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@ git version
         open Foo (* calling refactor-open qualify on this open *)
         let _ = Foo.bar (* previously could result in [Dune__exe.Foo.bar] *)
         ```
-      - does not return identical (duplicate) edits
+      - do not return identical (duplicate) edits
+      - do not return unnecessary edits that when applied do not change the document
   + editor modes
     - vim: add a simple interface to the new `construct` command:
       `MerlinConstruct`. When several results are suggested, `<c-i>` and `<c-u>`

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -522,9 +522,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
               | exception Not_found -> None
             else None
           )
-        |> List.sort_uniq
-          ~cmp:(fun (_,l1) (_,l2) ->
-              Lexing.compare_pos l1.Location.loc_start l2.Location.loc_start)
+        |> List.sort_uniq ~cmp:(fun (_,l1) (_,l2) -> Location_aux.compare l1 l2)
     end
 
   | Document (patho, pos) ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -487,7 +487,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
           Browse_tree.all_occurrences_of_prefix ~strict_prefix:true path node in
         let paths = List.concat_map ~f:snd paths in
         let leftmost_ident = Longident.flatten longident |> List.hd in
-        let path_to_string p =
+        let qual_or_unqual_path p =
           let rec aux acc (p : Path.t) =
             match p with
             | Pident ident ->
@@ -507,7 +507,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
         List.filter_map paths ~f:(fun {Location. txt = path; loc} ->
             if not loc.Location.loc_ghost &&
                Location_aux.compare_pos pos loc <= 0 then
-              try Some (path_to_string path, loc)
+              try Some (qual_or_unqual_path path, loc)
               with Not_found -> None
             else None
           )

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -487,24 +487,27 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
           Browse_tree.all_occurrences_of_prefix ~strict_prefix:true path node in
         let paths = List.concat_map ~f:snd paths in
         let leftmost_ident = Longident.flatten longident |> List.hd in
-        let rec path_to_string acc (p : Path.t) =
-          match p with
-          | Pident ident ->
-            String.concat ~sep:"." (Ident.name ident :: acc)
-          | Pdot (path', s) when
-              mode = `Unqualify && Path.same path path' ->
-            String.concat ~sep:"." (s :: acc)
-          | Pdot (path', s) when
-              mode = `Qualify && s = leftmost_ident ->
-            String.concat ~sep:"." (s :: acc)
-          | Pdot (path', s) ->
-            path_to_string (s :: acc) path'
-          | _ -> raise Not_found
+        let path_to_string p =
+          let rec aux acc (p : Path.t) =
+            match p with
+            | Pident ident ->
+              Ident.name ident :: acc
+            | Pdot (path', s) when
+                mode = `Unqualify && Path.same path path' ->
+              s :: acc
+            | Pdot (path', s) when
+                mode = `Qualify && s = leftmost_ident ->
+              s :: acc
+            | Pdot (path', s) ->
+              aux (s :: acc) path'
+            | _ -> raise Not_found
+          in
+          aux [] p |> String.concat ~sep:"."
         in
         List.filter_map paths ~f:(fun {Location. txt = path; loc} ->
             if not loc.Location.loc_ghost &&
                Location_aux.compare_pos pos loc <= 0 then
-              try Some (path_to_string [] path, loc)
+              try Some (path_to_string path, loc)
               with Not_found -> None
             else None
           )

--- a/src/ocaml/parsing/location_aux.ml
+++ b/src/ocaml/parsing/location_aux.ml
@@ -32,6 +32,12 @@ type t
   = Location.t
   = { loc_start: Lexing.position; loc_end: Lexing.position; loc_ghost: bool }
 
+let compare (l1: t) (l2: t) =
+  match Lexing.compare_pos l1.loc_start l2.loc_start with
+  | (-1 | 1) as r -> r
+  | 0 -> Lexing.compare_pos l1.loc_end l2.loc_end
+  | _ -> assert false
+
 let compare_pos pos loc =
   if Lexing.compare_pos pos loc.Location.loc_start < 0 then
     -1

--- a/src/ocaml/parsing/location_aux.mli
+++ b/src/ocaml/parsing/location_aux.mli
@@ -30,6 +30,9 @@ type t
   = Location.t
   = { loc_start: Lexing.position; loc_end: Lexing.position; loc_ghost: bool }
 
+(** [compare l1 l2] compares start positions, if equal compares end positions *)
+val compare : t -> t -> int
+
 val compare_pos: Lexing.position -> t -> int
 
 (** Return the smallest location covered by both arguments,

--- a/tests/test-dirs/refactor-open/unqualify.t
+++ b/tests/test-dirs/refactor-open/unqualify.t
@@ -1,0 +1,160 @@
+Works for in-file modules
+  $ $MERLIN single refactor-open -action unqualify -position 4:6 <<EOF
+  > module M = struct
+  >   let u = ()
+  > end
+  > open M
+  > let u = M.u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 5,
+          "col": 8
+        },
+        "end": {
+          "line": 5,
+          "col": 11
+        },
+        "content": "u"
+      }
+    ],
+    "notifications": []
+  }
+
+Works for in-file nested modules
+
+  $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
+  > module M = struct
+  >   module N = struct
+  >     let u = ()
+  >   end
+  > end
+  > open M.N
+  > let u = M.N.u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 7,
+          "col": 8
+        },
+        "end": {
+          "line": 7,
+          "col": 13
+        },
+        "content": "u"
+      }
+    ],
+    "notifications": []
+  }
+
+Works for stdlib modules (stdlib modules differ from other in-file modules because their
+full path is different)
+
+  $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
+  > open Unix
+  > let times = Unix.times ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 12
+        },
+        "end": {
+          "line": 2,
+          "col": 22
+        },
+        "content": "times"
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME shouldn't return anything, as nothing to unqualify
+
+  $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
+  > open Unix
+  > let times = times ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 12
+        },
+        "end": {
+          "line": 2,
+          "col": 17
+        },
+        "content": "times"
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME shouldn't return anything, as nothing to unqualify for multiline paths
+
+  $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
+  > open Unix
+  > let f x = x.
+  >             tms_stime
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 12
+        },
+        "end": {
+          "line": 3,
+          "col": 21
+        },
+        "content": "tms_stime"
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME shouldn't return anything, as nothing to unqualify for multiline paths
+
+  $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
+  > module M = struct
+  >   module N = struct
+  >     let u = ()
+  >   end
+  > end
+  > open M
+  > let u = N.
+  > u
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 7,
+          "col": 8
+        },
+        "end": {
+          "line": 8,
+          "col": 1
+        },
+        "content": "N.u"
+      }
+    ],
+    "notifications": []
+  }
+
+

--- a/tests/test-dirs/refactor-open/unqualify.t
+++ b/tests/test-dirs/refactor-open/unqualify.t
@@ -78,7 +78,7 @@ full path is different)
     "notifications": []
   }
 
-FIXME shouldn't return anything, as nothing to unqualify
+Shouldn't return anything, as nothing to unqualify
 
   $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
   > open Unix
@@ -86,23 +86,11 @@ FIXME shouldn't return anything, as nothing to unqualify
   > EOF
   {
     "class": "return",
-    "value": [
-      {
-        "start": {
-          "line": 2,
-          "col": 12
-        },
-        "end": {
-          "line": 2,
-          "col": 17
-        },
-        "content": "times"
-      }
-    ],
+    "value": [],
     "notifications": []
   }
 
-FIXME shouldn't return anything, as nothing to unqualify for multiline paths
+Shouldn't return anything, as nothing to unqualify for multiline paths
 
   $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
   > open Unix
@@ -111,23 +99,11 @@ FIXME shouldn't return anything, as nothing to unqualify for multiline paths
   > EOF
   {
     "class": "return",
-    "value": [
-      {
-        "start": {
-          "line": 3,
-          "col": 12
-        },
-        "end": {
-          "line": 3,
-          "col": 21
-        },
-        "content": "tms_stime"
-      }
-    ],
+    "value": [],
     "notifications": []
   }
 
-FIXME shouldn't return anything, as nothing to unqualify for multiline paths
+FIXME shouldn't return anything, as nothing to unqualify (for multi-line identifiers)
 
   $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
   > module M = struct

--- a/tests/test-dirs/refactor-open/unqualify.t
+++ b/tests/test-dirs/refactor-open/unqualify.t
@@ -1,4 +1,4 @@
-Works for in-file modules
+Can unqualify module located in the same file
   $ $MERLIN single refactor-open -action unqualify -position 4:6 <<EOF
   > module M = struct
   >   let u = ()
@@ -24,7 +24,7 @@ Works for in-file modules
     "notifications": []
   }
 
-Works for in-file nested modules
+Can unqualify nested modules located in the same file
 
   $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
   > module M = struct
@@ -53,44 +53,7 @@ Works for in-file nested modules
     "notifications": []
   }
 
-Works for stdlib modules (stdlib modules differ from other in-file modules because their
-full path is different)
-
-  $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
-  > open Unix
-  > let times = Unix.times ()
-  > EOF
-  {
-    "class": "return",
-    "value": [
-      {
-        "start": {
-          "line": 2,
-          "col": 12
-        },
-        "end": {
-          "line": 2,
-          "col": 22
-        },
-        "content": "times"
-      }
-    ],
-    "notifications": []
-  }
-
-Shouldn't return anything, as nothing to unqualify
-
-  $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
-  > open Unix
-  > let times = times ()
-  > EOF
-  {
-    "class": "return",
-    "value": [],
-    "notifications": []
-  }
-
-Shouldn't return anything, as nothing to unqualify for multiline paths
+Shouldn't return anything, as nothing to unqualify (for multiline identifiers)
 
   $ $MERLIN single refactor-open -action unqualify -position 1:6 <<EOF
   > open Unix


### PR DESCRIPTION
Before this PR `refactor-open` returns edits that when applied do not change the document, e.g, 

Calling `unqualify` on this:

```ocaml
open Unix 

let f = times () 
```

returned 

```ts
{
  "class": "return",
  "value": [
    {
      "start": {
        "line": 2,
        "col": 16
      },
      "end": {
        "line": 2,
        "col": 21
      },
      "content": "times"
    }
  ],
...
}
```

This is a hacky solution though, which doesn't work for multi-line identifiers (which are rare in OCaml, I guess). A proper solution would involve changing `Mbrowse.node_paths` to return `longident`s along with paths. I would appreciate input on which way to go. 

Notes:
- Based on #1313 
- I'm sending these PRs separately since their goals are not interconnected (the commits are but that can be fixed easily)