### PR TITLE
[Construct] Part I 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,14 @@ git version
     - fix location of module definitions done via functors (#1329, fixes #1199)
     - fix -cmt-path dirs mistakenly added to build path (#1330)
     - add new module holes that can replace module expressions (#1333)
+    - add a new command `construct` that builds a list of possible terms when
+      called on a typed hole (#1318)
+  + editor modes
+    - vim: add a simple interface to the new `construct` command:
+      `MerlinConstruct`. When several results are suggested, `<c-i>` and `<c-u>`
+      to show more or less deep results. (#1318)
+  + test suite
+    - cover the new `construct` command (#1318)
 
 merlin 4.2
 ==========

--- a/doc/dev/PROTOCOL.md
+++ b/doc/dev/PROTOCOL.md
@@ -223,6 +223,17 @@ Entries is the list of possible completion. Each entry is made of:
 - a description, most of the time a type or a definition line, to be put next to the name in completion box
 - optional information which might not fit in the completion box, like signatures for modules or documentation string.
 
+### `construct -position <position> [ -with-values <none|local> -depth <int> ]`
+
+    -position <position>      Position where construct should happen
+    -with-values <none|local> Use values from the environment (defaults to none)
+    -depth <int>              Depth of the search (defaults to 1)
+
+When the position determined by `-position` is a hole (`_`), this command
+  returns a list of possible terms that could replace it given its type.
+When `-with-values` is set to local, values in the current environment will be
+  used in the constructed terms.
+
 ### `document -position <position> [ -identifier <string> ]`
 
     -position <position>  Position to complete
@@ -295,6 +306,11 @@ Returns all known findlib packages as a list of string.
 
 
 Returns supported compiler flags.The purpose of this command is to implement interactive completion of compiler settings in an IDE.
+
+### `holes`
+
+This command will return the ordered list of the positions and types of all
+holes in the current document.
 
 ### `jump -target <string> -position <position>`
 

--- a/src/analysis/construct.ml
+++ b/src/analysis/construct.ml
@@ -1,0 +1,522 @@
+open Std
+open Typedtree
+
+let {Logger. log} = Logger.for_section "construct"
+
+type values_scope = Null | Local
+type what = Modtype | Mod
+
+exception Not_allowed of string
+exception Not_a_hole
+exception Modtype_not_found of what * string
+
+let () =
+  Location.register_error_of_exn (function
+    | Not_a_hole ->
+      Some (Location.error "Construct only works on holes.")
+    | Modtype_not_found (Modtype, s) ->
+      let txt = Format.sprintf "Module type not found: %s" s in
+      Some (Location.error txt)
+      | Modtype_not_found (Mod, s) ->
+        let txt = Format.sprintf "Module not found: %s" s in
+        Some (Location.error txt)
+    | _ -> None
+  )
+module Util = struct
+  open Types
+
+  let predef_types =
+    let tbl = Hashtbl.create 14 in
+    let () =
+      let constant c =
+        Ast_helper.Exp.constant c
+      in
+      let construct s =
+        Ast_helper.Exp.construct (Location.mknoloc (Longident.Lident s)) None
+      in
+      let ident s =
+        Ast_helper.Exp.ident (Location.mknoloc (Longident.Lident s))
+      in
+      List.iter ~f:(fun (k, v) -> Hashtbl.add tbl k v)
+        Parsetree.[
+          Predef.path_int, constant (Pconst_integer("0", None)) ;
+          Predef.path_float, constant (Pconst_float("0.0", None)) ;
+          Predef.path_char, constant (Pconst_char 'c') ;
+          Predef.path_string,
+            constant (Pconst_string("", Location.none, None)) ;
+          Predef.path_bool, construct "true" ;
+          Predef.path_unit, construct "()" ;
+          Predef.path_exn, ident "exn" ;
+          Predef.path_array, Ast_helper.Exp.array [] ;
+          Predef.path_nativeint, constant (Pconst_integer("0", Some 'n')) ;
+          Predef.path_int32, constant (Pconst_integer("0", Some 'l')) ;
+          Predef.path_int64, constant (Pconst_integer("0", Some 'L')) ;
+          Predef.path_lazy_t, Ast_helper.Exp.lazy_ (construct "()")
+        ]
+    in
+    tbl
+
+  let prefix env ~env_check path name =
+    Destruct.Path_utils.to_shortest_lid ~env ~env_check ~name path
+
+  let var_of_id id = Location.mknoloc @@ Ident.name id
+
+  let type_to_string t =
+    Printtyp.type_expr (Format.str_formatter) t;
+    Format.flush_str_formatter ()
+
+  let unifiable env type_expr type_expected = 
+    let snap = Btype.snapshot () in
+    try
+      Ctype.unify_gadt
+        ~equations_level:0
+        ~allow_recursive:true
+        (ref env) type_expected type_expr
+      |> ignore; 
+      Some snap
+    with Ctype.Unify _  -> 
+      (* Unification failure *) 
+      Btype.backtrack snap;
+      None
+
+
+  (** [find_values_for_type env typ] searches the environment [env] for
+  {i values} with a return type compatible with [typ] *)
+  let find_values_for_type env typ =
+    let aux name path descr acc =
+      (* [check_type| checks return type compatibility and lists parameters *)
+      let rec check_type type_expr params =
+        let type_expr = Btype.repr type_expr in
+        (* TODO is this test general enough ? *)
+        match unifiable env type_expr typ with
+        | Some snap ->
+          (* This will be called multiple times so we need to backtrack
+              See c-simple, test 6.2b for an example *)
+          Btype.backtrack snap;
+          Some params
+        | None -> 
+          begin match type_expr.desc with
+          | Tarrow (arg_label, _, te, _) -> check_type te (arg_label::params)
+          | _ -> None
+      end
+      in
+      (* TODO we should probably sort the results better *)
+      (* Also the Path filter is too restrictive. *)
+      match path, check_type descr.val_type [] with
+      | Path.Pident _, Some params ->
+        (name, path, descr, params) :: acc
+      | _, _ -> acc
+    in
+    Env.fold_values aux None env []
+
+  (** The idents_table is used to keep track of already used names when
+  generating function arguments in the same expression *)
+  let idents_table ~keywords =
+    let table = Hashtbl.create 50 in
+    (* we add keyworss to the table so they are always numbered *)
+    List.iter keywords ~f:(fun k -> Hashtbl.add table k (-1));
+    table
+
+  (* Given a list [l] of n elements which are lists of choices,
+    [combination l] is a list of all possible combinations of
+    these choices (cartesian product). For example:
+
+    let l = [["a";"b"];["1";"2"]; ["x"]];;
+    combinations l;;
+    - : string list list =
+    [["a"; "1"; "x"]; ["b"; "1"; "x"];
+     ["a"; "2"; "x"]; ["b"; "2"; "x"]]
+
+    If the input is the empty list, the result is
+    the empty list singleton list.
+    *)
+  let combinations l =
+    List.fold_left l
+      ~init:[[]]
+      ~f:(fun acc_l choices_for_arg_i ->
+        List.fold_left choices_for_arg_i
+          ~init:[]
+          ~f:(fun acc choice_arg_i ->
+            let choices = List.map acc_l
+              ~f:(fun l -> List.rev (choice_arg_i :: l))
+            in
+            List.rev_append acc choices))
+
+  (** [panache2 l1 l2] returns a new list containing an interleaving of the
+  values in [l1] and [l2] *)
+  let panache2 l1 l2 =
+    let rec aux acc l1 l2 =
+      match l1, l2 with
+      | [], [] -> List.rev acc
+      | tl, [] | [], tl -> List.rev_append acc tl
+      | a::tl1, b::tl2 -> aux (a::b::acc) tl1 tl2
+  in aux [] l1 l2
+
+  (* Given a list [l] of n lists, [panache l] flattens the list
+    by starting with the first element of each, then the second one etc. *)
+  let panache l =
+    List.fold_left ~init:[] ~f:panache2 l
+end
+
+module Gen = struct
+  open Types
+
+  let hole = Ast_helper.Exp.hole ()
+
+  (* [make_value] generates the PAST repr of a value applied to holes *)
+  let make_value env (name, path, value_description, params) =
+    let open Ast_helper in
+    let env_check = Env.find_value_by_name in
+    let lid = Location.mknoloc (Util.prefix env ~env_check path name) in
+    let params = List.map params
+      ~f:(fun label -> label, Exp.hole ())
+    in
+    if List.length params > 0 then
+      Exp.(apply (ident lid) params)
+    else Exp.ident lid
+
+  (* We never perform deep search when constructing modules *)
+  let rec module_ env =
+    let open Ast_helper in function
+    | Mty_ident path -> begin
+      try
+        let m = Env.find_modtype path env in
+        match m.mtd_type with
+        | Some t -> module_ env t
+        | None -> raise Not_found
+      with Not_found ->
+        let name = Ident.name (Path.head path) in
+        raise (Modtype_not_found (Modtype, name))
+      end
+    | Mty_signature sig_items ->
+      let env = Env.add_signature sig_items env in
+      Mod.structure @@ structure env sig_items
+    | Mty_functor (param, out) ->
+      let param = match param with
+        | Unit -> Parsetree.Unit
+        | Named (id, in_) ->
+          Parsetree.Named (
+            Location.mknoloc (Option.map ~f:Ident.name id),
+            Ptyp_of_type.module_type in_)
+      in
+      Mod.functor_ param @@ module_ env out
+    | Mty_alias path ->
+      begin try let m = Env.find_module path env in
+        module_ env m.md_type
+        with Not_found ->
+          let name = Ident.name (Path.head path) in
+          raise (Modtype_not_found (Mod, name))
+      end
+    | Mty_for_hole -> Mod.mk Pmod_hole
+  and structure_item env =
+    let open Ast_helper in
+    function
+    | Sig_value (id, vd, _visibility) ->
+      let vb = Vb.mk (Pat.var (Util.var_of_id id)) (Exp.hole ()) in
+      Str.value Nonrecursive [ vb ]
+    | Sig_type (id, type_declaration, rec_flag, _visibility) ->
+      let td = Ptyp_of_type.type_declaration id type_declaration in
+      let rec_flag = match rec_flag with
+        | Trec_first | Trec_next -> Asttypes.Recursive
+        | Trec_not -> Nonrecursive
+      in (* mutually recursive types are really handled by [structure] *)
+      Str.type_ rec_flag [td]
+    | Sig_modtype (id, { mtd_type; _ }, _visibility) ->
+      let mtd = Ast_helper.Mtd.mk
+        ?typ:(Option.map ~f:Ptyp_of_type.module_type mtd_type)
+        @@ Util.var_of_id id
+      in
+      Ast_helper.Str.modtype mtd
+    | Sig_module (id, _, mod_decl, _, _) ->
+      let module_binding =
+        Ast_helper.Mb.mk
+          (Location.mknoloc (Some (Ident.name id)))
+          @@ module_ env mod_decl.md_type
+      in
+      Str.module_ module_binding
+    | Sig_typext (id, ext_constructor, _, _) ->
+      let lid =
+        Untypeast.lident_of_path ext_constructor.ext_type_path
+        |> Location.mknoloc
+      in
+      Str.type_extension @@ Ast_helper.Te.mk
+        ~attrs:ext_constructor.ext_attributes
+        ~params:[]
+        ~priv:ext_constructor.ext_private
+        lid
+        [Ptyp_of_type.extension_constructor id ext_constructor]
+    | Sig_class_type (id, class_type_decl, _, _) ->
+      let str = Format.asprintf "Construct does not handle class types yet. \
+      Please replace this comment by [%s]'s definition." (Ident.name id) in
+      Str.text [ Docstrings.docstring str Location.none ] |> List.hd
+    | Sig_class (id, class_decl, _, _) ->
+      let str = Format.asprintf "Construct does not handle classes yet. \
+      Please replace this comment by [%s]'s definition." (Ident.name id) in
+      Str.text [ Docstrings.docstring str Location.none ] |> List.hd
+  and structure env (items : Types.signature_item list) =
+    List.map (Ptyp_of_type.group_items items) ~f:(function
+      | Ptyp_of_type.Item item -> structure_item env item
+      | Ptyp_of_type.Type (rec_flag, type_decls) ->
+        Ast_helper.Str.type_ rec_flag type_decls)
+
+  (* [expression values_scope ~depth env ty] generates a list of PAST
+    expressions that could fill a hole of type [ty] in the environment [env].
+    [depth] regulates the deep construction of recursive values. If
+    [values_scope] is set to [Local] the returned list will also contains
+    local values to choose from *)
+  let rec expression ~idents_table values_scope ~depth =
+    let exp_or_hole env typ =
+      if depth > 1 then
+        (* If max_depth has not been reached we recurse *)
+        expression ~idents_table values_scope ~depth:(depth - 1) env typ
+      else
+        (* else we return a hole *)
+        [ Ast_helper.Exp.hole () ]
+    in
+
+    (* [make_arg] tries to provide a nice default name for function args *)
+    let make_arg =
+      let make_i n i =
+        Hashtbl.replace idents_table n i;
+        Printf.sprintf "%s_%i" n i
+      in
+      let uniq_name env id =
+        let n = Ident.name id in
+        try
+          let i = Hashtbl.find idents_table n + 1 in
+          make_i n i
+        with Not_found ->
+          try
+            let _ = Env.find_value (Path.Pident id) env in
+            make_i n 0
+          with Not_found -> Hashtbl.add idents_table n 0; n
+      in
+      fun env label ty ->
+        let open Asttypes in
+        match label with
+        | Labelled s | Optional s ->
+            (* Pun for labelled arguments *)
+            Ast_helper.Pat.var ( Location.mknoloc s), s
+        | Nolabel -> begin match ty.desc with
+          | Tconstr (path, _, _) ->
+            let name = uniq_name env (Path.head path) in
+            Ast_helper.Pat.var (Location.mknoloc name), name
+          | _ -> Ast_helper.Pat.any (), "_" end
+    in
+
+    let constructor env type_expr path constrs =
+      log ~title:"constructors" "[%s]"
+        (String.concat ~sep:"; "
+          (List.map constrs ~f:(fun c -> c.Types.cstr_name)));
+      (* [make_constr] builds the PAST repr of a type constructor applied
+      to holes *)
+      let make_constr env path type_expr cstr_descr =
+        let ty_args, ty_res = Ctype.instance_constructor cstr_descr in
+        match Util.unifiable env type_expr ty_res with
+        | Some snap ->
+          let lid =
+            Util.prefix env ~env_check:Env.find_constructor_by_name
+              path cstr_descr.cstr_name
+            |> Location.mknoloc
+          in
+          let args = List.map ty_args ~f:(exp_or_hole env) in
+          let args_combinations = Util.combinations args in
+          let exps = List.map args_combinations
+            ~f:(function
+              | [] -> None
+              | [e] -> Some e
+              | l -> Some (Ast_helper.Exp.tuple l))
+          in
+          Btype.backtrack snap;
+          List.filter_map exps
+            ~f:(fun exp ->
+              let exp = Ast_helper.Exp.construct lid exp in
+              (* For gadts not all combinations will be valid.
+                See Test 6.1b in c-simple.t for an example.
+
+                We therefore check that constructed expressions
+                can be typed. *)
+              try
+                Typecore.type_expression env exp |> ignore;
+                Some exp
+              with _ -> None)
+        | None -> []
+      in
+      List.map constrs ~f:(make_constr env path type_expr)
+      |> Util.panache
+    in
+
+    let variant env typ row_desc =
+      let fields =
+        List.filter
+          ~f:(fun (lbl, row_field) -> match row_field with
+            | Rpresent _
+            | Reither (true, [], _, _)
+            | Reither (false, [_], _, _) -> true
+            | _ -> false)
+          row_desc.row_fields
+      in
+      match fields with
+      | [] -> raise (Not_allowed "empty variant type")
+      | row_descrs ->
+        List.map row_descrs ~f:(fun (lbl, row_field) ->
+          (match row_field with
+            | Reither (false, [ty], _, _) | Rpresent (Some ty) ->
+              List.map ~f:(fun s -> Some s) (exp_or_hole env ty)
+            | _ -> [None])
+            |> List.map ~f:(fun e ->
+              Ast_helper.Exp.variant lbl e)
+            )
+        |> List.flatten
+    in
+
+    let record env typ path labels =
+      log ~title:"record labels" "[%s]"
+        (String.concat ~sep:"; "
+          (List.map labels ~f:(fun l -> l.Types.lbl_name)));
+
+      let labels = List.map labels ~f:(fun ({ lbl_name; _ } as lbl) ->
+        let _, arg, res = Ctype.instance_label true lbl in
+        Ctype.unify env res typ ;
+        let lid =
+          Util.prefix env ~env_check:Env.find_label_by_name path lbl_name
+          |> Location.mknoloc
+        in
+        let exprs = exp_or_hole env arg in
+        lid, exprs)
+      in
+
+      let lbl_lids, lbl_exprs = List.split labels in
+      Util.combinations lbl_exprs
+      |> List.map
+          ~f:(fun lbl_exprs ->
+            let labels = List.map2 lbl_lids lbl_exprs
+              ~f:(fun lid exp -> (lid, exp))
+            in
+            Ast_helper.Exp.record labels None)
+    in
+
+    (* Given a typed hole, there is two possible forms of constructions:
+      - Use the type's definition to propose the correct type constructors,
+      - Look for values in the environnement with compatible return type. *)
+    fun env typ ->
+      log ~title:"construct expr" "Looking for expressions of type %s"
+        (Util.type_to_string typ);
+      let rtyp = Ctype.full_expand env typ |> Btype.repr in
+      let constructed_from_type = match rtyp.desc with
+        | Tlink _ | Tsubst _ ->
+          assert false
+        | Tpoly (texp, _)  ->
+          (* We are not going "deeper" so we don't call [exp_or_hole] here *)
+          expression ~idents_table values_scope ~depth env texp
+        | Tunivar _ | Tvar _ ->
+          [ ]
+        | Tconstr (path, [texp], _) when path = Predef.path_lazy_t ->
+          (* Special case for lazy *)
+          let exps = exp_or_hole env texp in
+          List.map exps ~f:Ast_helper.Exp.lazy_
+        | Tconstr (path, params, _) ->
+          (* If this is a "basic" type we propose a default value *)
+          begin try
+            [ Hashtbl.find Util.predef_types path ]
+          with Not_found ->
+            let def = Env.find_type_descrs path env in
+            match def with
+            | constrs, [] -> constructor env rtyp path constrs
+            | [], labels -> record env rtyp path labels
+            | _ -> []
+          end
+        | Tarrow (label, tyleft, tyright, _) ->
+          let argument, name = make_arg env label tyleft in
+          let value_description = {
+              val_type = tyleft;
+              val_kind = Val_reg;
+              val_loc = Location.none;
+              val_attributes = [];
+              val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
+            }
+          in
+          let env = Env.add_value (Ident.create_local name) value_description env in
+          let exps = exp_or_hole env tyright in
+          List.map exps ~f:(Ast_helper.Exp.fun_ label None argument)
+        | Ttuple types ->
+          let choices = List.map types ~f:(exp_or_hole env)
+            |> Util.combinations
+          in
+          List.map choices  ~f:Ast_helper.Exp.tuple
+        | Tvariant row_desc -> variant env rtyp row_desc
+        | Tpackage (path, lids, args) -> begin
+          let open Ast_helper in
+          try
+            let ty =
+              Typemod.modtype_of_package env Location.none path lids args
+            in
+            let ast =
+              Exp.constraint_
+                (Exp.pack (module_ env ty))
+                (Ptyp_of_type.core_type typ)
+            in
+            [ ast ]
+          with Typemod.Error _ ->
+            let name = Ident.name (Path.head path) in
+            raise (Modtype_not_found (Modtype, name)) end
+        | Tobject (fields, _) ->
+          let rec aux acc fields =
+            match fields.desc with
+            | Tnil -> acc
+            | Tvar _ | Tunivar _ -> acc
+            | Tfield ("*dummy method*", _, _, fields) -> aux acc fields
+            | Tfield (name, _, type_expr, fields) ->
+              let exprs = exp_or_hole env type_expr
+                |> List.map ~f:(fun expr ->
+                  let open Ast_helper in
+                  Cf.method_ (Location.mknoloc name) Asttypes.Public
+                  @@ Ast_helper.Cf.concrete Asttypes.Fresh expr)
+              in
+              aux (exprs :: acc) fields
+            | _ ->
+              failwith @@ Format.asprintf
+                "Unexpected type constructor in fields list: %a"
+                Printtyp.type_expr fields
+          in
+          let all_fields = aux [] fields |> Util.combinations in
+          List.map all_fields ~f:(fun fields ->
+            let open Ast_helper in
+            Exp.object_ @@ Ast_helper.Cstr.mk (Pat.any ()) fields)
+        | Tfield _ | Tnil -> failwith "Found a field type outside an object"
+      in
+      let matching_values =
+        if values_scope = Local then
+          List.map (Util.find_values_for_type env typ)
+            ~f:(make_value env) |> List.rev
+        else []
+      in
+      List.append constructed_from_type matching_values
+end
+
+let needs_parentheses e = match e.Parsetree.pexp_desc with
+  | Pexp_fun _
+  | Pexp_lazy _
+  | Pexp_apply _
+  | Pexp_variant (_, Some _)
+  | Pexp_construct (_, Some _)
+  -> true
+  | _ -> false
+
+let to_string_with_parentheses exp = 
+  let f : _ format6 = 
+    if needs_parentheses exp then "(%a)"
+    else "%a"
+  in
+  Format.asprintf f Pprintast.expression exp
+
+let node ?(depth = 1) ~keywords ~values_scope node =
+  match node with
+  | Browse_raw.Expression { exp_type; exp_env; _ } ->
+      let idents_table = Util.idents_table ~keywords in
+      Gen.expression ~idents_table values_scope ~depth exp_env exp_type
+      |> List.map ~f:to_string_with_parentheses
+  | Browse_raw.Module_expr { mod_type; mod_env; _ } ->
+      let m = Gen.module_ mod_env mod_type in
+      [ Format.asprintf "%a" Pprintast.module_ m ]
+  | _ -> raise Not_a_hole

--- a/src/analysis/construct.mli
+++ b/src/analysis/construct.mli
@@ -1,0 +1,11 @@
+exception Not_allowed of string
+exception Not_a_hole
+
+type values_scope = Null | Local
+
+val node
+  : ?depth : int
+  -> keywords : string list
+  -> values_scope : values_scope
+  -> Browse_raw.node
+  -> string list

--- a/src/analysis/ptyp_of_type.ml
+++ b/src/analysis/ptyp_of_type.ml
@@ -1,0 +1,240 @@
+open Std
+open Typedtree
+open Types
+let {Logger. log} = Logger.for_section "ptyp of type"
+
+let var_of_id id = Location.mknoloc @@ Ident.name id
+
+type signature_elt =
+  | Item of Types.signature_item
+  | Type of Asttypes.rec_flag * Parsetree.type_declaration list
+
+let rec module_type =
+  let open Ast_helper in function
+  | Mty_for_hole -> failwith "Holes are not allowed in module types"
+  | Mty_signature signature_items ->
+    Mty.signature @@ signature signature_items
+  | Mty_ident path ->
+    Ast_helper.Mty.ident (Location.mknoloc (Untypeast.lident_of_path path))
+  | Mty_alias path ->
+    Ast_helper.Mty.alias (Location.mknoloc (Untypeast.lident_of_path path))
+  | Mty_functor (param, type_out) ->
+    let param = match param with
+      | Unit -> Parsetree.Unit
+      | Named (id, type_in) ->
+        Parsetree.Named (
+          Location.mknoloc (Option.map ~f:Ident.name id),
+          module_type type_in)
+    in
+    let out = module_type type_out in
+    Mty.functor_ param out
+and core_type type_expr =
+  let open Ast_helper in
+  let open Parsetree in
+  let type_expr = Btype.repr type_expr in
+  match type_expr.desc with
+  | Tvar None | Tunivar None -> Typ.any ()
+  | Tvar (Some s) | Tunivar (Some s) -> Typ.var s
+  | Tarrow (label, type_expr, type_expr_out, _commutable) ->
+    Typ.arrow label
+      (core_type type_expr)
+      (core_type type_expr_out)
+  | Ttuple type_exprs -> Typ.tuple @@ List.map ~f:core_type type_exprs
+  | Tconstr (path, type_exprs, _abbrev) ->
+    let loc = Untypeast.lident_of_path path |> Location.mknoloc in
+    Typ.constr loc @@ List.map ~f:core_type type_exprs
+  | Tobject (type_expr, class_) ->
+    let type_expr = Btype.repr type_expr in
+    let rec aux acc type_expr = match type_expr.desc with
+      | Tnil -> acc, Asttypes.Closed
+      | Tvar None -> acc, Asttypes.Open
+      | Tfield ("*dummy method*", _, _, fields) -> aux acc fields
+      | Tfield (name, _, type_expr, fields) ->
+        let open Ast_helper in
+        let core_type = core_type type_expr in
+        let core_type = Of.tag (Location.mknoloc name) core_type in
+
+        aux (core_type :: acc) fields
+      | _ ->
+        failwith @@ Format.asprintf
+          "Unexpected type constructor in fields list: %a"
+          Printtyp.type_expr type_expr
+    in
+    let fields, closed = aux [] type_expr in
+    Typ.object_ fields closed
+  | Tfield _ ->  failwith "Found object field outside of object."
+  | Tnil -> Typ.object_ [] Closed
+  | Tlink type_expr | Tsubst type_expr -> core_type type_expr
+  | Tvariant { row_fields; row_closed; row_name; _ } ->
+    let field (label, row_field) =
+      let label = Location.mknoloc label in
+      match row_field with
+      | Rpresent None | Reither (true, _, _, _) ->
+        Rf.tag label true []
+      | Rpresent (Some type_expr) ->
+        let core_type = core_type type_expr in
+        Rf.tag label false [ core_type ]
+      | Reither (false, type_exprs, _, _) ->
+        Rf.tag label false @@ List.map ~f:core_type type_exprs
+      | Rabsent -> assert false
+    in
+    let closed = if row_closed then Asttypes.Closed else Asttypes.Open in
+    let fields = List.map ~f:field row_fields in
+    (* TODO NOT ALWAYS NONE *)
+    Typ.variant fields closed None
+  | Tpoly (type_expr, type_exprs) ->
+    let names = List.map (fun v -> match v.desc with
+      | Tunivar (Some name) | Tvar (Some name) -> mknoloc name
+      | _ -> failwith "poly: not a var")
+      type_exprs
+    in
+    Typ.poly names @@ core_type type_expr
+  | Tpackage (path, lids, type_exprs) ->
+    let loc = mknoloc (Untypeast.lident_of_path path) in
+    let args = List.map2 lids type_exprs
+      ~f:(fun id t -> mknoloc id, core_type t)
+    in
+    Typ.package loc args
+and modtype_declaration id { mtd_type; mtd_attributes; _ } =
+  Ast_helper.Mtd.mk
+    ~attrs:mtd_attributes
+    ?typ:(Option.map ~f:module_type mtd_type)
+    (var_of_id id)
+and module_declaration id { md_type; md_attributes; _ } =
+ let name = Location.mknoloc (Some (Ident.name id)) in
+ Ast_helper.Md.mk
+  ~attrs:md_attributes
+  name
+  @@ module_type md_type
+and extension_constructor id {
+  ext_args;
+  ext_ret_type;
+  ext_attributes;
+  _
+} =
+  Ast_helper.Te.decl
+    ~attrs:ext_attributes
+    ~args:(constructor_arguments ext_args)
+    ?res:(Option.map ~f:core_type ext_ret_type)
+    (var_of_id id)
+and value_description id { val_type; val_kind; val_loc; val_attributes; _ } =
+  let type_ = core_type val_type in
+  {
+    Parsetree.pval_name = var_of_id id;
+    pval_type = type_;
+    pval_prim = [];
+    pval_attributes = val_attributes;
+    pval_loc = val_loc
+  }
+and label_declaration { ld_id; ld_mutable; ld_type; ld_attributes; _ } =
+  Ast_helper.Type.field
+    ~attrs:ld_attributes
+    ~mut:ld_mutable
+    (var_of_id ld_id)
+    (core_type ld_type)
+and constructor_arguments = function
+  | Cstr_tuple type_exprs ->
+    Parsetree.Pcstr_tuple (List.map ~f:core_type type_exprs)
+  | Cstr_record label_decls ->
+    Parsetree.Pcstr_record (List.map ~f:label_declaration label_decls)
+and constructor_declaration { cd_id; cd_args; cd_res; cd_attributes; _} =
+  Ast_helper.Type.constructor
+    ~attrs:cd_attributes
+    ~args:(constructor_arguments cd_args)
+    ?res:(Option.map ~f:core_type cd_res)
+    @@ var_of_id cd_id
+and type_declaration id {
+  type_params;
+  type_variance;
+  type_manifest;
+  type_kind;
+  type_attributes;
+  type_private;
+  _ }
+  =
+  let params = List.map2 type_params type_variance ~f:(fun type_ variance ->
+    let core_type = core_type type_ in
+    let pos, neg, inv, inj = Types.Variance.get_lower variance in
+    let v = if pos then  Asttypes.Covariant
+      else (if neg then Contravariant
+      else NoVariance)
+    in
+    let i = if inj then Asttypes.Injective else NoInjectivity in
+    core_type, (v, i))
+  in
+  let kind = match type_kind with
+    | Type_abstract -> Parsetree.Ptype_abstract
+    | Type_open -> Ptype_open
+    | Type_variant constrs ->
+      Ptype_variant (List.map ~f:constructor_declaration constrs)
+    | Type_record (labels, _repr) ->
+      Ptype_record (List.map ~f:label_declaration labels)
+  in
+  let manifest = Option.map ~f:core_type type_manifest in
+  Ast_helper.Type.mk
+    ~attrs:type_attributes
+    ~params
+    ~kind
+    ~priv:type_private
+    ?manifest
+    (var_of_id id)
+and signature_item (str_item : Types.signature_item) =
+  let open Ast_helper in
+  match str_item with
+  | Sig_value (id, vd, _visibility) ->
+    let vd = value_description id vd in
+    Sig.value  vd
+  | Sig_type (id, type_decl, rec_flag, _visibility) ->
+    let rec_flag = match rec_flag with
+      | Trec_first -> Asttypes.Recursive
+      | Trec_next -> Asttypes.Recursive
+      | Trec_not -> Nonrecursive
+    in (* mutually recursive types are really handled by [signature] *)
+    Sig.type_ rec_flag [type_declaration id type_decl]
+  | Sig_modtype (id, modtype_decl, _visibility) ->
+    Sig.modtype @@ modtype_declaration id modtype_decl
+  | Sig_module (id, _, mod_decl, _, _) ->
+    Sig.module_ @@ module_declaration id mod_decl
+  | Sig_typext (id, ext_constructor, _, _) ->
+    let ext = Te.mk
+      (Location.mknoloc @@ Longident.Lident (Ident.name id))
+      [ extension_constructor id ext_constructor]
+    in
+    Sig.type_extension ext
+  | Sig_class_type (id, _, _, _) ->
+    let str = Format.asprintf "Construct does not handle class types yet. \
+    Please replace this comment by [%s]'s definition." (Ident.name id) in
+    Sig.text [ Docstrings.docstring str Location.none ] |> List.hd
+  | Sig_class (id, _, _, _) ->
+    let str = Format.asprintf "Construct does not handle classes yet. \
+    Please replace this comment by [%s]'s definition." (Ident.name id) in
+    Sig.text [ Docstrings.docstring str Location.none ] |> List.hd
+and signature  (items : Types.signature_item list) =
+  List.map (group_items items)
+    ~f:(function
+    | Item item -> signature_item item
+    | Type (rec_flag, type_decls) -> Ast_helper.Sig.type_  rec_flag type_decls)
+and group_items (items : Types.signature_item list) =
+  let rec read_type type_acc items =
+    match items with
+    | Sig_type (id, type_decl, Trec_next, _) :: rest ->
+      let td = type_declaration id type_decl in
+      read_type (td :: type_acc) rest
+    | _ -> List.rev type_acc, items
+  in
+  let rec group acc items =
+    match items with
+    | Sig_type (id, type_decl, Trec_first, _) :: rest ->
+      let type_, rest = read_type [type_declaration id type_decl] rest in
+      group (Type (Asttypes.Recursive, type_) :: acc) rest
+    | Sig_type (id, type_decl, Trec_not, _) :: rest ->
+      let type_, rest = read_type [type_declaration id type_decl] rest in
+      group (Type (Asttypes.Nonrecursive, type_) :: acc) rest
+    | Sig_class _ as item :: _ :: _ :: _ :: rest ->
+      group (Item item :: acc) rest
+    | Sig_class_type _ as item :: _ :: _ :: rest ->
+      group (Item item :: acc) rest
+    | item :: rest -> group (Item item :: acc) rest
+    | [] -> List.rev acc
+  in
+  group [] items

--- a/src/analysis/ptyp_of_type.ml
+++ b/src/analysis/ptyp_of_type.ml
@@ -47,7 +47,7 @@ and core_type type_expr =
     let type_expr = Btype.repr type_expr in
     let rec aux acc type_expr = match type_expr.desc with
       | Tnil -> acc, Asttypes.Closed
-      | Tvar None -> acc, Asttypes.Open
+      | Tvar None | Tunivar None -> acc, Asttypes.Open
       | Tfield ("*dummy method*", _, _, fields) -> aux acc fields
       | Tfield (name, _, type_expr, fields) ->
         let open Ast_helper in

--- a/src/analysis/ptyp_of_type.mli
+++ b/src/analysis/ptyp_of_type.mli
@@ -1,0 +1,41 @@
+type signature_elt =
+| Item of Types.signature_item
+| Type of Asttypes.rec_flag * Parsetree.type_declaration list
+
+val module_type : Types.module_type -> Parsetree.module_type
+
+val core_type : Types.type_expr -> Parsetree.core_type
+
+val modtype_declaration :
+  Ident.t ->
+  Types.modtype_declaration ->
+  Parsetree.module_type_declaration
+
+val module_declaration :
+  Ident.t -> Types.module_declaration -> Parsetree.module_declaration
+
+val signature_item : Types.signature_item -> Parsetree.signature_item
+
+val extension_constructor :
+  Ident.t -> Types.extension_constructor -> Parsetree.extension_constructor
+
+val value_description :
+  Ident.t -> Types.value_description -> Parsetree.value_description
+
+val label_declaration : Types.label_declaration -> Parsetree.label_declaration
+
+val constructor_arguments :
+  Types.constructor_arguments -> Parsetree.constructor_arguments
+
+val constructor_declaration :
+  Types.constructor_declaration -> Parsetree.constructor_declaration
+
+val type_declaration :
+  Ident.t -> Types.type_declaration -> Parsetree.type_declaration
+
+val signature : Types.signature ->  Parsetree.signature
+
+(** [group_items sig_items] groups items from a signature in a more meaningful
+  way: type declaration of the same recursive type are group together and items
+  following a class or class_type items are discarded *)
+val group_items : Types.signature_item list -> signature_elt list

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -644,6 +644,23 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     in
     List.concat_map ~f:loc_and_types_of_holes nodes
 
+  | Construct (pos, with_values, depth) ->
+    let typer = Mpipeline.typer_result pipeline in
+    let typedtree = Mtyper.get_typedtree typer in
+    let pos = Mpipeline.get_lexing_pos pipeline pos in
+    let structures = Mbrowse.enclosing pos
+      [Mbrowse.of_typedtree typedtree] in
+    begin match structures with
+    | [] -> failwith "No node at given range"
+    | (_env, node) :: parents ->
+      let loc = Mbrowse.node_loc node in
+      let values_scope = match with_values with
+        | Some `None | None -> Construct.Null
+        | Some `Local -> Construct.Local
+      in
+      (loc, Construct.node ?depth ~values_scope node)
+    end
+
   | Outline ->
     let typer = Mpipeline.typer_result pipeline in
     let browse = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -645,20 +645,27 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     List.concat_map ~f:loc_and_types_of_holes nodes
 
   | Construct (pos, with_values, depth) ->
+    let values_scope = match with_values with
+      | Some `None | None -> Construct.Null
+      | Some `Local -> Construct.Local
+    in
+    let keywords = Mpipeline.reader_lexer_keywords pipeline in
     let typer = Mpipeline.typer_result pipeline in
     let typedtree = Mtyper.get_typedtree typer in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let structures = Mbrowse.enclosing pos
       [Mbrowse.of_typedtree typedtree] in
     begin match structures with
-    | [] -> failwith "No node at given range"
-    | (_env, node) :: parents ->
+    | (_, (Browse_raw.Module_expr { mod_desc = Tmod_hole; _ } as node_for_loc))
+      :: (_, node) :: parents ->
+        let loc = Mbrowse.node_loc node_for_loc in
+        (loc, Construct.node ~keywords ?depth ~values_scope node)
+    | (_,  (Browse_raw.Expression { exp_desc = Texp_hole; _ } as node))
+      :: parents ->
       let loc = Mbrowse.node_loc node in
-      let values_scope = match with_values with
-        | Some `None | None -> Construct.Null
-        | Some `Local -> Construct.Local
-      in
-      (loc, Construct.node ?depth ~values_scope node)
+      (loc, Construct.node ~keywords ?depth ~values_scope node)
+    | (_, node) :: _ -> raise Construct.Not_a_hole
+    | [] -> raise No_nodes
     end
 
   | Outline ->

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -165,6 +165,9 @@ type _ t =
     : Msource.position * Msource.position -> (Location.t * string) t
   | Holes(* *)
     : (Location.t * string) list t
+  | Construct
+    : Msource.position * [`None | `Local] option * int option
+    -> (Location.t * string list) t
   | Outline(* *)
     :  outline t
   | Shape(* *)

--- a/src/ocaml/parsing/pprintast.ml
+++ b/src/ocaml/parsing/pprintast.ml
@@ -416,7 +416,7 @@ and pattern_or ctxt f x =
   match left_associative x [] with
   | [] -> assert false
   | [x] -> pattern1 ctxt f x
-  | orpats -> 
+  | orpats ->
       pp f "@[<hov0>%a@]" (list ~sep:"@ |" (pattern1 ctxt)) orpats
 
 and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
@@ -1671,6 +1671,7 @@ let pattern = pattern reset_ctxt
 let signature = signature reset_ctxt
 let structure = structure reset_ctxt
 let case_list = case_list reset_ctxt
+let module_ = module_expr reset_ctxt
 
 let prepare_error err =
   let source = Location.Parser in

--- a/src/ocaml/parsing/pprintast.mli
+++ b/src/ocaml/parsing/pprintast.mli
@@ -34,6 +34,7 @@ val core_type: Format.formatter -> Parsetree.core_type -> unit
 val signature: Format.formatter -> Parsetree.signature -> unit
 val structure: Format.formatter -> Parsetree.structure -> unit
 val string_of_structure: Parsetree.structure -> string
+val module_: Format.formatter -> Parsetree.module_expr -> unit
 
 val toplevel_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
 val top_phrase: Format.formatter -> Parsetree.toplevel_phrase -> unit

--- a/tests/dune
+++ b/tests/dune
@@ -1,28 +1,12 @@
-; (rule
-;  (targets merlin-wrapper)
-;  (deps    merlin-wrapper-template)
-;  (action
-;    (progn
-;      (with-stdout-to %{targets}
-;        (run sed -e "s#%%OCAMLMERLIN_PATH%%#ocamlmerlin#"
-;                 -e "s#%%DOT_MERLIN_READER%%#dot-merlin-reader#"
-;             merlin-wrapper-template))
-;      (bash "chmod +x %{targets}"))))
-
-
 (env (_
  (binaries merlin-wrapper)
  (env-vars
   (MERLIN merlin-wrapper)
   (OCAMLC ocamlc))))
 
-(alias
- (name test-deps)
+(cram
+ (applies_to :whole_subtree)
  (deps
   %{bin:merlin-wrapper}
   (package merlin)
   (package dot-merlin-reader)))
-
-(cram
- (applies_to :whole_subtree)
- (deps (alias test-deps)))

--- a/tests/test-dirs/construct/c-depth.t
+++ b/tests/test-dirs/construct/c-depth.t
@@ -1,0 +1,99 @@
+  $ cat >d1.ml <<EOF
+  > let x : int option option = _
+  > EOF
+
+Test 1.1
+  $ $MERLIN single construct -depth 1 -position 1:28 -filename d1.ml <d1.ml |
+  >  jq ".value[1]"
+  [
+    "(Some _)",
+    "None"
+  ]
+
+Test 1.2
+  $ $MERLIN single construct -depth 2 -position 1:28 -filename d1.ml <d1.ml |
+  >  jq ".value[1]"
+  [
+    "(Some (Some _))",
+    "None",
+    "(Some None)"
+  ]
+
+Test 1.3
+  $ $MERLIN single construct -depth 3 -position 1:28 -filename d1.ml <d1.ml |
+  >  jq ".value[1]"
+  [
+    "(Some (Some 0))",
+    "None",
+    "(Some None)"
+  ]
+
+Test 1.4
+  $ $MERLIN single construct -depth 4 -position 1:28 -filename d1.ml <d1.ml |
+  >  jq ".value[1]"
+  [
+    "(Some (Some 0))",
+    "None",
+    "(Some None)"
+  ]
+
+  $ cat >d2.ml <<EOF
+  > type t = { a : int option option; b : float option }
+  > let x : t = _
+  > EOF
+
+Test 2.1
+  $ $MERLIN single construct -depth 1 -position 2:12 -filename d2.ml <d2.ml |
+  >  jq ".value[1]"
+  [
+    "{ a = _; b = _ }"
+  ]
+
+Test 2.2
+  $ $MERLIN single construct -depth 2 -position 2:12 -filename d2.ml <d2.ml |
+  >  jq ".value[1]"
+  [
+    "{ a = None; b = (Some _) }",
+    "{ a = (Some _); b = (Some _) }",
+    "{ a = (Some _); b = None }",
+    "{ a = None; b = None }"
+  ]
+
+Test 2.3
+  $ $MERLIN single construct -depth 3 -position 2:12 -filename d2.ml <d2.ml |
+  >  jq ".value[1]"
+  [
+    "{ a = (Some None); b = (Some 0.0) }",
+    "{ a = (Some (Some _)); b = (Some 0.0) }",
+    "{ a = None; b = (Some 0.0) }",
+    "{ a = None; b = None }",
+    "{ a = (Some (Some _)); b = None }",
+    "{ a = (Some None); b = None }"
+  ]
+
+Test 2.4
+  $ $MERLIN single construct -depth 4 -position 2:12 -filename d2.ml <d2.ml |
+  >  jq ".value[1]"
+  [
+    "{ a = (Some None); b = (Some 0.0) }",
+    "{ a = (Some (Some 0)); b = (Some 0.0) }",
+    "{ a = None; b = (Some 0.0) }",
+    "{ a = None; b = None }",
+    "{ a = (Some (Some 0)); b = None }",
+    "{ a = (Some None); b = None }"
+  ]
+
+  $ cat >d3.ml <<EOF
+  > type t = int option option * float option
+  > let x : t = _
+  > EOF
+
+Test 3.1
+  $ $MERLIN single construct -depth 2 -position 2:12 -filename d3.ml <d3.ml |
+  >  jq ".value[1]"
+  [
+    "(None, (Some _))",
+    "((Some _), (Some _))",
+    "((Some _), None)",
+    "(None, None)"
+  ]

--- a/tests/test-dirs/construct/c-errors.t
+++ b/tests/test-dirs/construct/c-errors.t
@@ -1,0 +1,59 @@
+  $ $MERLIN single construct -position 2:25 \
+  > -filename e1.ml <<EOF
+  > EOF
+  {
+    "class": "error",
+    "value": "Construct only works on holes.",
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 1:15 \
+  > -filename e1.ml <<EOF
+  > let x : int =
+  > EOF
+  {
+    "class": "error",
+    "value": "Construct only works on holes.",
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 1:5 \
+  > -filename e1.ml <<EOF
+  > let _ = 3
+  > EOF
+  {
+    "class": "error",
+    "value": "Construct only works on holes.",
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 2:16 \
+  > -filename e1.ml <<EOF
+  > module M = N module type S = module type of M
+  > module M : S = _
+  > EOF
+  {
+    "class": "error",
+    "value": "Module not found: N",
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 1:15 \
+  > -filename e1.ml <<EOF
+  > module M : S = _
+  > EOF
+  {
+    "class": "error",
+    "value": "Could not find a module type to construct from. Check that you used a correct constraint.",
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 1:12 \
+  > -filename e1.ml <<EOF
+  > module M = _
+  > EOF
+  {
+    "class": "error",
+    "value": "Could not find a module type to construct from. Check that you used a correct constraint.",
+    "notifications": []
+  }

--- a/tests/test-dirs/construct/c-modules.t/functor_app.ml
+++ b/tests/test-dirs/construct/c-modules.t/functor_app.ml
@@ -1,0 +1,7 @@
+module type X_int = sig val x : int end
+
+module Increment (M : X_int) = struct
+  let x = M.x + 1
+end
+
+module X = Increment(_);;

--- a/tests/test-dirs/construct/c-modules.t/module.ml
+++ b/tests/test-dirs/construct/c-modules.t/module.ml
@@ -1,0 +1,44 @@
+module type S = sig
+  type t = private b and b = A | B of t
+  type (-'a, +'b) t' = T of ('a -> 'b)
+  type t2 = A | B of string | C of t
+  type nonrec r = { lbl1 : t; lbl2 : float list}
+  type nonrec n = r and m = float
+  type t_ext = ..
+  type t_ext += Str of string | A
+  type v = [`A of t_ext]
+
+  val i : int
+  val f : t -> int
+
+  module Sub : sig
+    val y : int
+  end
+
+  class type room = object
+    val mutable gene : unit
+
+    method scientific : unit -> int
+  end
+  class croom : room
+  module type Another = sig val i : int end
+
+  module type Sig = sig
+    type t and b
+    val f : int -> float
+    module type STyp = sig end
+    module D : Another
+  end
+
+  module Submod : Sig
+
+  module SubFunc (M : Sig) : sig val g : unit end
+end
+
+module type Small = sig type t = int end
+
+module M : S = _
+
+let m : (module Small) = _
+
+let m = (module _ : Small)

--- a/tests/test-dirs/construct/c-modules.t/run.t
+++ b/tests/test-dirs/construct/c-modules.t/run.t
@@ -1,0 +1,135 @@
+Simple module construction
+  $ $MERLIN single construct -position 40:16 \
+  > -filename module.ml <module.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 40,
+          "col": 15
+        },
+        "end": {
+          "line": 40,
+          "col": 16
+        }
+      },
+      [
+        "struct
+    type t = private b
+    and b =
+      | A 
+      | B of t 
+    type (-!'a, +!'b) t' =
+      | T of ('a -> 'b) 
+    type t2 =
+      | A 
+      | B of string 
+      | C of t 
+    type nonrec r = {
+      lbl1: t ;
+      lbl2: float list }
+    type nonrec n = r
+    and m = float
+    type t_ext = ..
+    type t_ext +=  
+      | Str of string 
+    type t_ext +=  
+      | A 
+    type v = [ `A of t_ext ]
+    let i = _
+    let f = _
+    module Sub = struct let y = _ end
+    [@@@ocaml.text
+      \"Construct does not handle class types yet. Please replace this comment by [room]'s definition.\"]
+    [@@@ocaml.text
+      \"Construct does not handle classes yet. Please replace this comment by [croom]'s definition.\"]
+    module type Another  = sig val i : int end
+    module type Sig  =
+      sig
+        type t
+        and b
+        val f : int -> float
+        module type STyp  = sig  end
+        module D : Another
+      end
+    module Submod =
+      struct
+        type t
+        and b
+        let f = _
+        module type STyp  = sig  end
+        module D = struct let i = _ end
+      end
+    module SubFunc(M:Sig) = struct let g = _ end
+  end"
+      ]
+    ],
+    "notifications": []
+  }
+
+First class modules
+
+  $ $MERLIN single construct -position 42:26 \
+  > -filename module.ml <module.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 42,
+          "col": 25
+        },
+        "end": {
+          "line": 42,
+          "col": 26
+        }
+      },
+      [
+        "((module struct type t = int end) : (module Small))"
+      ]
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single construct -position 44:17 \
+  > -filename module.ml <module.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 44,
+          "col": 16
+        },
+        "end": {
+          "line": 44,
+          "col": 17
+        }
+      },
+      [
+        "struct type t = int end"
+      ]
+    ],
+    "notifications": []
+  }
+
+
+Construction in functor application
+  $ $MERLIN single construct -position 7:22 \
+  > -filename functor_app.ml <functor_app.ml | jq '.value'
+  [
+    {
+      "start": {
+        "line": 7,
+        "col": 21
+      },
+      "end": {
+        "line": 7,
+        "col": 22
+      }
+    },
+    [
+      "struct let x = _ end"
+    ]
+  ]

--- a/tests/test-dirs/construct/c-objects.t
+++ b/tests/test-dirs/construct/c-objects.t
@@ -1,0 +1,64 @@
+  $ cat >obj1.ml <<EOF
+  > let o : < a : string; get : int -> int option >
+  >   = _
+  > EOF
+
+  $ $MERLIN single construct -position 2:4 \
+  > -filename obj1.ml <obj1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 2,
+        "col": 4
+      },
+      "end": {
+        "line": 2,
+        "col": 5
+      }
+    },
+    [
+      "object method get = _ method a = _ end"
+    ]
+  ]
+
+  $ $MERLIN single construct -depth 2 -position 2:4 \
+  > -filename obj1.ml <obj1.ml | jq ".value[1]"
+  [
+    "object method get int = _ method a = \"\" end"
+  ]
+
+  $ $MERLIN single construct -depth 3 -position 2:4 \
+  > -filename obj1.ml <obj1.ml | jq ".value[1]"
+  [
+    "object method get int = Some _ method a = \"\" end",
+    "object method get int = None method a = \"\" end"
+  ]
+
+More cases
+  $ cat >obj2.ml <<EOF
+  > let a : < x : int >
+  >   = _
+  > let b : < x : int; .. >
+  >   = _
+  > type o = < x : int >
+  > let x : < y: char; o >
+  >   = _
+  > EOF
+
+  $ $MERLIN single construct -position 2:5 \
+  > -filename obj2.ml <obj2.ml | jq ".value[1]"
+  [
+    "object method x = _ end"
+  ]
+
+  $ $MERLIN single construct -position 4:5 \
+  > -filename obj2.ml <obj2.ml | jq ".value[1]"
+  [
+    "object method x = _ end"
+  ]
+
+  $ $MERLIN single construct -position 7:5 \
+  > -filename obj2.ml <obj2.ml | jq ".value[1]"
+  [
+    "object method y = _ method x = _ end"
+  ]

--- a/tests/test-dirs/construct/c-parenthesis.t
+++ b/tests/test-dirs/construct/c-parenthesis.t
@@ -1,0 +1,28 @@
+###############
+## SUM TYPES ##
+###############
+
+Test 1.1 :
+
+  $ cat >c1.ml <<EOF
+  > let x : int option option = Some (_)
+  > EOF
+
+  $ $MERLIN single construct -position 1:34 \
+  > -filename c1.ml <c1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 33
+      },
+      "end": {
+        "line": 1,
+        "col": 36
+      }
+    },
+    [
+      "(Some _)",
+      "None"
+    ]
+  ]

--- a/tests/test-dirs/construct/c-prefix.t
+++ b/tests/test-dirs/construct/c-prefix.t
@@ -1,0 +1,101 @@
+###############
+## PREFIXING ##
+###############
+
+Test 1.1 :
+
+  $ cat >c1.ml <<EOF
+  > module Prefix = struct
+  >   type t = A of int | B
+  > end
+  > let x : Prefix.t = _
+  > EOF
+
+  $ $MERLIN single construct -position 4:20 -filename c1.ml <c1.ml |
+  >  jq ".value"
+  [
+    {
+      "start": {
+        "line": 4,
+        "col": 19
+      },
+      "end": {
+        "line": 4,
+        "col": 20
+      }
+    },
+    [
+      "Prefix.B",
+      "(Prefix.A _)"
+    ]
+  ]
+
+Test 1.2 :
+
+  $ cat >c12.ml <<EOF
+  > module Prefix = struct
+  >   type t = A of int | B
+  > end
+  > open Prefix
+  > let x : t = _
+  > EOF
+
+  $ $MERLIN single construct -position 5:13 -filename c12.ml <c12.ml |
+  >  jq ".value"
+  [
+    {
+      "start": {
+        "line": 5,
+        "col": 12
+      },
+      "end": {
+        "line": 5,
+        "col": 13
+      }
+    },
+    [
+      "B",
+      "(A _)"
+    ]
+  ]
+
+Test 1.3 :
+
+  $ cat >c13.ml <<EOF
+  > module Prefix = struct
+  >   type t = A of int | B
+  >   type r = { a : t }
+  > end
+  > let x : Prefix.t = _
+  > let x : Prefix.r = _
+  > open Prefix
+  > let x : t = _
+  > let x : r = _
+  > EOF
+
+  $ $MERLIN single construct -position 5:20 -filename c13.ml <c13.ml |
+  >  jq ".value[1]"
+  [
+    "Prefix.B",
+    "(Prefix.A _)"
+  ]
+
+  $ $MERLIN single construct -position 6:20 -filename c13.ml <c13.ml |
+  >  jq ".value[1]"
+  [
+    "{ Prefix.a = _ }"
+  ]
+
+  $ $MERLIN single construct -position 8:13 -filename c13.ml <c13.ml |
+  >  jq ".value[1]"
+  [
+    "B",
+    "(A _)"
+  ]
+
+  $ $MERLIN single construct -position 9:13 -filename c13.ml <c13.ml |
+  >  jq ".value[1]"
+  [
+    "{ a = _ }"
+  ]
+

--- a/tests/test-dirs/construct/c-simple.t
+++ b/tests/test-dirs/construct/c-simple.t
@@ -1,0 +1,543 @@
+###############
+## SUM TYPES ##
+###############
+
+Test 1.1 :
+
+  $ cat >c1.ml <<EOF
+  > let nice_candidate = Some 3
+  > let nice_candidate_with_arg x = Some x
+  > let nice_candidate_with_labeled_arg ~x = Some x
+  > let y = 4
+  > let x : int option = _
+  > EOF
+
+  $ $MERLIN single construct -position 5:22 \
+  > -filename c1.ml <c1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 5,
+        "col": 21
+      },
+      "end": {
+        "line": 5,
+        "col": 22
+      }
+    },
+    [
+      "(Some _)",
+      "None"
+    ]
+  ]
+
+With depth 2:
+
+  $ $MERLIN single construct -depth 2 -position 5:22 \
+  > -filename c1.ml <c1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 5,
+        "col": 21
+      },
+      "end": {
+        "line": 5,
+        "col": 22
+      }
+    },
+    [
+      "(Some 0)",
+      "None"
+    ]
+  ]
+
+With values:
+
+  $ $MERLIN single construct -with-values local -position 5:22 \
+  > -filename c1.ml <c1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 5,
+        "col": 21
+      },
+      "end": {
+        "line": 5,
+        "col": 22
+      }
+    },
+    [
+      "(Some _)",
+      "None",
+      "(nice_candidate_with_arg _)",
+      "(nice_candidate_with_labeled_arg ~x:_)",
+      "nice_candidate"
+    ]
+  ]
+
+With depth 2 and values:
+
+  $ $MERLIN single construct -depth 2 -with-values local \
+  > -position 5:22 -filename c1.ml <c1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 5,
+        "col": 21
+      },
+      "end": {
+        "line": 5,
+        "col": 22
+      }
+    },
+    [
+      "(Some 0)",
+      "None",
+      "(Some y)",
+      "(nice_candidate_with_arg _)",
+      "(nice_candidate_with_labeled_arg ~x:_)",
+      "nice_candidate"
+    ]
+  ]
+
+Test 1.2
+
+  $ cat >c2.ml <<EOF
+  > let x : int list = _
+  > EOF
+
+  $ $MERLIN single construct -position 1:20 \
+  > -filename c2.ml <c2.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 19
+      },
+      "end": {
+        "line": 1,
+        "col": 20
+      }
+    },
+    [
+      "(_ :: _)",
+      "[]"
+    ]
+  ]
+
+Test 1.3
+
+  $ cat >c3.ml <<EOF
+  > let x : 'a list = _
+  > EOF
+
+  $ $MERLIN single construct -position 1:19 \
+  > -filename c3.ml <c3.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 18
+      },
+      "end": {
+        "line": 1,
+        "col": 19
+      }
+    },
+    [
+      "(_ :: _)",
+      "[]"
+    ]
+  ]
+
+
+Test lazy
+
+  $ cat >lazy.ml <<EOF
+  > let x : int lazy = _
+  > EOF
+
+  $ $MERLIN single construct -position 1:20 \
+  > -filename lazy.ml <lazy.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 19
+      },
+      "end": {
+        "line": 1,
+        "col": 20
+      }
+    },
+    [
+      "(lazy _)"
+    ]
+  ]
+
+#############
+## RECORDS ##
+#############
+
+Test 2.1
+
+  $ cat >c2.ml <<EOF
+  > type r = { a : string; b : int option }
+  > let nice_candidate = {a = "a"; b = None }
+  > let x : r = _
+  > EOF
+
+  $ $MERLIN single construct -position 3:13 \
+  > -filename c2.ml <c2.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 3,
+        "col": 12
+      },
+      "end": {
+        "line": 3,
+        "col": 13
+      }
+    },
+    [
+      "{ a = _; b = _ }"
+    ]
+  ]
+
+#################
+## ARROW TYPES ##
+#################
+
+Test 3.1
+
+  $ cat >c31.ml <<EOF
+  > let nice_candidate s = int_of_string s
+  > let x : string -> int = _
+  > EOF
+
+  $ $MERLIN single construct -position 2:25 \
+  > -filename c31.ml <c31.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 2,
+        "col": 24
+      },
+      "end": {
+        "line": 2,
+        "col": 25
+      }
+    },
+    [
+      "(fun string -> _)"
+    ]
+  ]
+
+Test 3.2
+
+  $ cat >c32.ml <<EOF
+  > let type mytype = float
+  > let x : v:string -> float -> mytype -> mytype -> int = _
+  > EOF
+
+  $ $MERLIN single construct -depth 4 -position 2:55 \
+  > -filename c32.ml <c32.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 2,
+        "col": 55
+      },
+      "end": {
+        "line": 2,
+        "col": 56
+      }
+    },
+    [
+      "(fun ~v -> fun float -> fun mytype -> fun mytype_1 -> _)"
+    ]
+  ]
+
+############
+## TUPLES ##
+############
+
+Test 4.1
+
+  $ cat >c41.ml <<EOF
+  > type tup = int * float * (string option)
+  > let some_float = 4.2
+  > let x : tup = _
+  > EOF
+
+  $ $MERLIN single construct -position 3:14 \
+  >  -filename c41.ml <c41.ml | jq '.value[1]'
+  [
+    "(_, _, _)"
+  ]
+
+####################
+## POLY. VARIANTS ##
+####################
+
+TODO we need more tests here
+
+Test 5.1
+
+  $ cat >c51.ml <<EOF
+  > type v = [ \`A | \`B of string ]
+  > let some_v = \`B "totoro"
+  > let x : v = _
+  > EOF
+
+  $ $MERLIN single construct -position 3:13 \
+  >  -filename c51.ml <c51.ml | jq '.value[1]'
+  [
+    "(`B _)",
+    "`A"
+  ]
+
+  $ $MERLIN single construct -with-values local -position 3:13 \
+  >  -filename c51.ml <c51.ml | jq '.value[1]'
+  [
+    "(`B _)",
+    "`A",
+    "some_v"
+  ]
+
+###########
+## GADTs ##
+###########
+
+Test 6.1
+
+  $ cat >c61.ml <<EOF
+  > type _ term =
+  >  | Int : int -> int term
+  >  | Float : float -> float term
+  >  | Eq : 'a term * 'a term -> 'a term
+  > 
+  > let x : 'a term =
+  >   _
+  > let x : int term =
+  >   _
+  > EOF
+
+  $ $MERLIN single construct -position 7:3 \
+  > -filename c61.ml <c61.ml | jq '.value[1]'
+  [
+    "(Eq (_, _))",
+    "(Float _)",
+    "(Int _)"
+  ]
+
+Test 6.1b
+Eq (Int _, Float) is wrong and should not appear (fixed)
+  $ $MERLIN single construct -depth 2 -position 7:3 \
+  > -filename c61.ml <c61.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 7,
+          "col": 2
+        },
+        "end": {
+          "line": 7,
+          "col": 3
+        }
+      },
+      [
+        "(Eq ((Eq (_, _)), (Float _)))",
+        "(Float 0.0)",
+        "(Eq ((Float _), (Float _)))",
+        "(Int 0)",
+        "(Eq ((Float _), (Eq (_, _))))",
+        "(Eq ((Eq (_, _)), (Eq (_, _))))",
+        "(Eq ((Int _), (Eq (_, _))))",
+        "(Eq ((Eq (_, _)), (Int _)))",
+        "(Eq ((Int _), (Int _)))"
+      ]
+    ],
+    "notifications": []
+  }
+
+Test 6.1c
+  $ $MERLIN single construct -position 9:3 \
+  > -filename c61.ml <c61.ml | jq '.value[1]'
+  [
+    "(Eq (_, _))",
+    "(Int _)"
+  ]
+
+Test 6.2
+
+  $ cat >c62.ml <<EOF
+  > type _ term =
+  >  | Int : int -> int term
+  >  | Float : float -> float term
+  >  | Add : (int -> int -> int) term
+  >  | App : ('b -> 'a) term * 'b term -> 'a term
+  > let v1 = Int 42
+  > let v2 = Float 3.5
+  > let x : 'a term =
+  >   _
+  > let x : int term =
+  >   _
+  > EOF
+
+Test 6.2b
+Fixed: v2 should appear
+  $ $MERLIN single construct -with-values local -position 9:3 \
+  > -filename c62.ml <c62.ml | jq '.value[1]'
+  [
+    "(App (_, _))",
+    "Add",
+    "(Float _)",
+    "(Int _)",
+    "v1",
+    "v2"
+  ]
+
+Test 6.2c
+only v1 should appear
+  $ $MERLIN single construct -with-values local -position 11:3 \
+  > -filename c62.ml <c62.ml | jq '.value[1]'
+  [
+    "(App (_, _))",
+    "(Int _)",
+    "x",
+    "v1"
+  ]
+
+###################
+## MISCELLANEOUS ##
+###################
+
+Test M.1 : Type vars
+
+  $ cat >cM1.ml <<EOF
+  > type 'a t = A of 'a
+  > let x = A _
+  > EOF
+
+  $ $MERLIN single construct -position 2:11 \
+  >  -filename cM1.ml <cM1.ml | jq '.value[1]'
+  []
+
+Test M.2 : FIXME wrong position
+
+  $ cat >M2.ml <<EOF
+  > let x : type a . a list = _
+  > EOF
+
+  $ $MERLIN single construct -position 1:27 \
+  > -filename M2.ml <M2.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 4
+      },
+      "end": {
+        "line": 1,
+        "col": 27
+      }
+    },
+    [
+      "(_ :: _)",
+      "[]"
+    ]
+  ]
+
+Test M.3 : Predef types
+
+  $ cat >M3.ml <<EOF
+  > let x : int =         _
+  > let x : nativeint =   _
+  > let x : int32 =       _
+  > let x : int64 =       _
+  > let x : float =       _
+  > let x : char =        _
+  > let x : string =      _
+  > let x : bool =        _
+  > let x : unit =        _
+  > let x : exn =         _
+  > let x : 'a array =    _
+  > let x : 'a lazy_t =   _
+  > EOF
+
+  $ $MERLIN single construct -position 1:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "0"
+  ]
+
+  $ $MERLIN single construct -position 2:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "0n"
+  ]
+
+  $ $MERLIN single construct -position 3:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "0l"
+  ]
+
+  $ $MERLIN single construct -position 4:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "0L"
+  ]
+
+  $ $MERLIN single construct -position 5:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "0.0"
+  ]
+
+  $ $MERLIN single construct -position 6:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "'c'"
+  ]
+
+  $ $MERLIN single construct -position 7:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "\"\""
+  ]
+
+  $ $MERLIN single construct -position 8:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "true"
+  ]
+
+  $ $MERLIN single construct -position 9:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "()"
+  ]
+
+  $ $MERLIN single construct -position 10:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "exn"
+  ]
+
+  $ $MERLIN single construct -position 11:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "[||]"
+  ]
+
+  $ $MERLIN single construct -position 12:22 \
+  > -filename M3.ml <M3.ml | jq ".value[1]"
+  [
+    "(lazy _)"
+  ]

--- a/tests/test-dirs/construct/dune
+++ b/tests/test-dirs/construct/dune
@@ -1,0 +1,3 @@
+(cram
+ (applies_to :whole_subtree)
+ (alias construct))

--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -111,6 +111,13 @@ Add these bindings to rename interactively: >
 
 See https://ocaml.github.io/merlin/destruct.ogv
 
+:MerlinConstruct                                            *:MerlinConstruct*
+
+When called from a hole "_", attempts to construct terms matching the hole's
+type. If only one result is found the hole is replaced immediately. If multiple
+results are found a list will appear. It is possible to ask for more or less
+deep results in that list using the shortcuts  "<c-i>" and "<c-u>".
+
 :MerlinOutline                                                *:MerlinOutline*
 
 Gives an "outline" of the current buffer, i.e. lists all the "definitions"
@@ -120,6 +127,16 @@ definition.
 
 The rendering (and interactivity) is provided by
 [ctrl-p](https://github.com/ctrlpvim/ctrlp.vim).
+
+:MerlinNextHole                                              *:MerlinNextHole*
+
+Moves the cursor forward to the closest hole "_". If there is no hole after the
+cursor the search will restart at the beginning of the buffer.
+
+:MerlinPreviousHole                                      *:MerlinPreviousHole*
+
+Moves the cursor backwards to the closest hole "_". If there is no hole before
+the cursor the search will restart at the end of the buffer.
 
 :MerlinILocate                                                *:MerlinILocate*
 


### PR DESCRIPTION
This PR adds:

- a new command `construct` that given the position of a hole will return a list of possible expressions to fill this hole
- a handful of tests for that command
- the VIM plugin support for that feature:
  + `MerlinConstruct` on a hole `_` will open a completion dialog with the alternatives or replace the hole is only one construction is possible
  + One can ask to increase (or decrease) search depth with `c-i` (`c-u`) while choosing a completion
  + Once a completion is chosen it replaces the hole and the cursor jump to the next hole

Todo:
- [x] Polish the VIM plugin (for example we should only jump to holes in the constructed expression, not further)
- [x] Treat the various todo in `construct.ml`
- [x] Add documentation (and a changelog entry)
- [x] Maybe improve the test suite
