### PR TITLE
Emacs: fix 2 erroneous calls to merlin-locate

### DIFF
--- a/emacs/merlin-ac.el
+++ b/emacs/merlin-ac.el
@@ -139,7 +139,7 @@ wrong then recompute it."
     (when (popup-hidden-p ac-menu)
       (ac-show-menu))
     (let ((merlin-locate-in-new-window 'always))
-      (merlin-locate (ac-selected-candidate)))
+      (merlin-call-locate (ac-selected-candidate)))
     (ac-show-menu)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/emacs/merlin-company.el
+++ b/emacs/merlin-company.el
@@ -109,7 +109,7 @@
       (doc-buffer (merlin-company--doc-buffer arg))
       (location
        (ignore-errors
-         (let ((data (merlin-locate arg)))
+         (let ((data (merlin-call-locate arg)))
            (when (listp data)
              (let ((filename (merlin-lookup 'file data (buffer-file-name)))
                    (linum (cdr (assoc 'line (assoc 'pos data)))))


### PR DESCRIPTION
Emacs byte compile says:
```
In ac-merlin-locate:
merlin-ac.el:142:8:Warning: merlin-locate called with 1 argument, but accepts
    only 0

In merlin-company-backend:
merlin-company.el:112:23:Warning: merlin-locate called with 1 argument, but
    accepts only 0
```

I think these should be calls to `merlin-call-locate`; i.e., the former `merlin/locate`.