### PR TITLE
Improve load path performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ git version
 
   + merlin binary
     - filter dups in source paths (#1218)
+    - improve load path performance (#1323)
 
 merlin 4.4
 ==========

--- a/src/kernel/mocaml.ml
+++ b/src/kernel/mocaml.ml
@@ -25,12 +25,11 @@ let is_current_state state = match !current_state with
 
 (* Build settings *)
 
-let setup_config config = (
+let setup_reader_config config = (
   assert Local_store.(is_bound ());
   let open Mconfig in
   let open Clflags in
   let ocaml = config.ocaml in
-  Load_path.init (Mconfig.build_path config);
   Env.set_unit_name (Mconfig.unitname config);
   Location.input_name  := config.query.filename;
   fast                 := ocaml.unsafe ;
@@ -44,6 +43,11 @@ let setup_config config = (
   nopervasives         := ocaml.nopervasives ;
   strict_formats       := ocaml.strict_formats ;
   open_modules         := ocaml.open_modules ;
+)
+
+let setup_typer_config config = (
+  setup_reader_config config;
+  Load_path.init (Mconfig.build_path config);
 )
 
 (** Switchable implementation of Oprint *)

--- a/src/kernel/mocaml.mli
+++ b/src/kernel/mocaml.mli
@@ -6,7 +6,8 @@ val with_state : typer_state -> (unit -> 'a) -> 'a
 val is_current_state : typer_state -> bool
 
 (* Build settings *)
-val setup_config : Mconfig.t -> unit
+val setup_reader_config : Mconfig.t -> unit
+val setup_typer_config : Mconfig.t -> unit
 
 (* Replace Outcome printer *)
 val default_printer :

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -157,17 +157,16 @@ let process
     )) in
   let reader = timed_lazy reader_time (lazy (
       let lazy source = source in
-      let result = Mreader.parse ?for_completion config source in
-      let config = result.Mreader.config in
-      let config = Mreader.apply_directives config result.Mreader.parsetree in
       let config = Mconfig.normalize config in
+      Mocaml.setup_config config;
+      let result = Mreader.parse ?for_completion config source in
       result, config
     )) in
   let ppx = timed_lazy ppx_time (lazy (
       let lazy ({Mreader.parsetree; _}, config) = reader in
       let caught = ref [] in
       Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught @@ fun () ->
-      let config, parsetree = Mppx.rewrite config parsetree in
+      let parsetree = Mppx.rewrite config parsetree in
       { Ppx. config; parsetree; errors = !caught }
     )) in
   let typer = timed_lazy typer_time (lazy (

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -158,7 +158,7 @@ let process
   let reader = timed_lazy reader_time (lazy (
       let lazy source = source in
       let config = Mconfig.normalize config in
-      Mocaml.setup_config config;
+      Mocaml.setup_reader_config config;
       let result = Mreader.parse ?for_completion config source in
       result, config
     )) in
@@ -171,6 +171,7 @@ let process
     )) in
   let typer = timed_lazy typer_time (lazy (
       let lazy { Ppx. config; parsetree; _ } = ppx in
+      Mocaml.setup_typer_config config;
       let result = Mtyper.run config parsetree in
       let errors = timed_lazy error_time (lazy (Mtyper.get_errors result)) in
       { Typer. errors; result }

--- a/src/kernel/mppx.ml
+++ b/src/kernel/mppx.ml
@@ -44,7 +44,7 @@ let rewrite cfg parsetree =
   with
   | parsetree ->
     restore ();
-    cfg, parsetree
+    parsetree
   | exception exn ->
     log ~title:"rewrite" "failed with %a" Logger.fmt (fun fmt ->
       match Location.error_of_exn exn with
@@ -55,4 +55,4 @@ let rewrite cfg parsetree =
     );
     Msupport.raise_error exn;
     restore ();
-    cfg, parsetree
+    parsetree

--- a/src/kernel/mppx.mli
+++ b/src/kernel/mppx.mli
@@ -1,1 +1,1 @@
-val rewrite : Mconfig.t -> Mreader.parsetree -> Mconfig.t * Mreader.parsetree
+val rewrite : Mconfig.t -> Mreader.parsetree -> Mreader.parsetree

--- a/src/kernel/mreader.ml
+++ b/src/kernel/mreader.ml
@@ -8,7 +8,6 @@ type parsetree = [
 type comment = (string * Location.t)
 
 type result = {
-  config        : Mconfig.t;
   lexer_keywords: string list;
   lexer_errors  : exn list;
   parser_errors : exn list;
@@ -34,7 +33,6 @@ let normal_parse ?for_completion config source =
     then Mreader_parser.MLI
     else Mreader_parser.ML
   in
-  Mocaml.setup_config config;
   let lexer =
     let keywords = Extension.keywords Mconfig.(config.merlin.extensions) in
     Mreader_lexer.make Mconfig.(config.ocaml.warnings) keywords config source
@@ -54,7 +52,7 @@ let normal_parse ?for_completion config source =
   and parsetree = Mreader_parser.result parser
   and comments = Mreader_lexer.comments lexer
   in
-  { config; lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
+  { lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
     no_labels_for_completion; }
 
 (* Pretty-printing *)
@@ -171,42 +169,12 @@ let parse ?for_completion config = function
       | Some (`No_labels no_labels_for_completion, parsetree) ->
         let (lexer_errors, parser_errors, comments) = ([], [], []) in
         let lexer_keywords = [] (* TODO? *) in
-        { config; lexer_keywords; lexer_errors; parser_errors; comments;
+        { lexer_keywords; lexer_errors; parser_errors; comments;
           parsetree; no_labels_for_completion; }
       | None -> normal_parse ?for_completion config source
     end
   | (_, Some parsetree) ->
     let (lexer_errors, parser_errors, comments) = ([], [], []) in
     let lexer_keywords = [] in
-    { config; lexer_keywords; lexer_errors; parser_errors; comments;
-      parsetree; no_labels_for_completion = false; }
-
-(* Update config after parse *)
-
-(*
-let apply_directives config tree =
-  let config = ref config in
-  let attribute _ attr =
-    let ({Location. txt = name; _}, payload) = Ast_helper.Attr.as_tuple attr in
-    match name with
-    | "merlin.directive.require" ->
-      begin match Ast_helper.extract_str_payload payload with
-        | None -> ()
-        | Some (package, _) ->
-          let open Mconfig in
-          let merlin = !config.merlin in
-          let merlin = {merlin with packages_to_load =
-                                      package :: merlin.packages_to_load} in
-          config := {!config with merlin}
-      end
-    | _ -> ()
-  in
-  let open Ast_iterator in
-  let iterator = {default_iterator with attribute} in
-  begin match tree with
-    | `Interface sg -> iterator.signature iterator sg
-    | `Implementation str -> iterator.structure iterator str
-  end;
-  !config
-*)
-let apply_directives config _tree = config
+    { lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
+      no_labels_for_completion = false; }

--- a/src/kernel/mreader.mli
+++ b/src/kernel/mreader.mli
@@ -6,7 +6,6 @@ type parsetree = [
 type comment = (string * Location.t)
 
 type result = {
-  config        : Mconfig.t;
   lexer_keywords: string list;
   lexer_errors  : exn list;
   parser_errors : exn list;
@@ -42,7 +41,3 @@ val print_batch_outcome :
 
 val reconstruct_identifier:
   Mconfig.t -> Msource.t -> Lexing.position -> string Location.loc list
-
-(* Update config after parse *)
-
-val apply_directives: Mconfig.t -> parsetree -> Mconfig.t

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -136,8 +136,13 @@ let type_interface config caught parsetree =
 
 let run config parsetree =
   if not (Env.check_state_consistency ()) then (
+    (* Resetting the local store will clear the load_path cache.
+       Save it now, reset the store and then restore the path. *)
+    let load_path = Load_path.get_paths () in
     Mocaml.flush_caches ();
     Local_store.reset ();
+    Load_path.reset ();
+    Load_path.init load_path;
   );
   let caught = ref [] in
   Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught @@ fun () ->

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -139,7 +139,6 @@ let run config parsetree =
     Mocaml.flush_caches ();
     Local_store.reset ();
   );
-  Mocaml.setup_config config;
   let caught = ref [] in
   Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught @@ fun () ->
   Typecore.reset_delayed_checks ();

--- a/src/ocaml/utils/load_path.ml
+++ b/src/ocaml/utils/load_path.ml
@@ -31,17 +31,8 @@ module Dir = struct
   let path t = t.path
   let files t = t.files
 
-  (* For backward compatibility reason, simulate the behavior of
-     [Misc.find_in_path]: silently ignore directories that don't exist
-     + treat [""] as the current directory. *)
-  let readdir_compat dir =
-    try
-      Sys.readdir (if dir = "" then Filename.current_dir_name else dir)
-    with Sys_error _ ->
-      [||]
-
   let create path =
-    { path; files = Array.to_list (readdir_compat path) }
+    { path; files = Array.to_list (Directory_content_cache.read path) }
 end
 
 let dirs = s_ref []

--- a/src/ocaml/utils/load_path.ml
+++ b/src/ocaml/utils/load_path.ml
@@ -33,6 +33,9 @@ module Dir = struct
 
   let create path =
     { path; files = Array.to_list (Directory_content_cache.read path) }
+
+  let check t = Directory_content_cache.check t.path
+
 end
 
 let dirs = s_ref []
@@ -58,9 +61,35 @@ let prepend_add dir =
     ) dir.Dir.files
 
 let init l =
-  reset ();
-  dirs := List.rev_map Dir.create l;
-  List.iter prepend_add !dirs
+  assert (not Config.merlin || Local_store.is_bound ());
+  let rec loop_changed acc = function
+    | [] -> Some acc
+    | new_path :: new_rest ->
+      loop_changed (Dir.create new_path :: acc) new_rest
+  in
+  let rec loop_unchanged acc new_paths old_dirs =
+    match new_paths, old_dirs with
+    | [], [] -> None
+    | new_path :: new_rest, [] ->
+      loop_changed (Dir.create new_path :: acc) new_rest
+    | [], _ :: _ -> Some acc
+    | new_path :: new_rest, old_dir :: old_rest ->
+      if String.equal new_path (Dir.path old_dir) then begin
+        if Dir.check old_dir then begin
+          loop_unchanged (old_dir :: acc) new_rest old_rest
+        end else begin
+          loop_changed (Dir.create new_path :: acc) new_rest
+        end
+      end else begin
+        loop_changed (Dir.create new_path :: acc) new_rest
+      end
+  in
+  match loop_unchanged [] l (List.rev !dirs) with
+  | None -> ()
+  | Some new_dirs ->
+    reset ();
+    dirs := new_dirs;
+    List.iter prepend_add new_dirs
 
 let remove_dir dir =
   assert (not Config.merlin || Local_store.is_bound ());

--- a/src/ocaml/utils/load_path.ml
+++ b/src/ocaml/utils/load_path.ml
@@ -18,7 +18,7 @@ module STbl = Misc.String.Tbl
 
 (* Mapping from basenames to full filenames *)
 type registry = string STbl.t
-  
+
 let files : registry ref = s_table STbl.create 42
 let files_uncap : registry ref = s_table STbl.create 42
 

--- a/src/utils/file_cache.ml
+++ b/src/utils/file_cache.ml
@@ -63,6 +63,18 @@ end) = struct
       Hashtbl.remove cache filename;
       raise exn
 
+  let check filename =
+    let fid = File_id.get filename in
+    match Hashtbl.find cache filename with
+    | exception Not_found -> false
+    | (fid', latest_use, _) ->
+      if File_id.check fid fid' then begin
+        latest_use := Unix.time ();
+        true
+      end else begin
+        false
+      end
+
   let get_cached_entry filename =
     let fid = File_id.get filename in
     let title = "get_cached_entry" in

--- a/src/utils/file_cache.mli
+++ b/src/utils/file_cache.mli
@@ -34,6 +34,7 @@ end) : sig
   val read  : string -> Input.t
   val flush : ?older_than:float -> unit -> unit
   val clear : unit -> unit
+  val check : string -> bool
 
   val get_cached_entry : string -> Input.t
   (** @raises Not_found if the file is not in cache. *)


### PR DESCRIPTION
This PR makes 4 changes to speed up the handling of the load path:
1. It restores the use of Directory_content_cache for the load path -- which seems to have been removed by accident in the switch to 4.12.
2. It changes where 'Mocaml.setup_config` is called to ensure that it is only called once per command.
3. It uses a hash table for the load path instead of a reference to a map.
4. It reuses the previous hash table when the load path hasn't changed and none of it's directories' contents have changed.

On a randomly chosen command in a library with a large load path, each of these changes is worth around 0.1s. #1309 is also worth about 0.1s. Between them these changes take that command's runtime from 0.7s to 0.25s. (This is for the second call to the command, the initial call to the command is more like 1.9s vs 1.7s).

I also have [a version of this branch for 4.11](https://github.com/lpw25/merlin/tree/fast-load-path-411), which is the one I actually tested.