### PR TITLE
Fix location of patterns in Occurrences

### DIFF
--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -746,7 +746,7 @@ let pattern_paths (type k) { Typedtree. pat_desc; pat_extra; pat_loc } =
     match (pat_desc : k pattern_desc) with
     | Tpat_construct ({Location. loc},{Types. cstr_name; cstr_res; _},_) ->
       fake_path cstr_res cstr_name loc
-    | Tpat_var (id,_) -> [mkloc (Path.Pident id) pat_loc]
+    | Tpat_var (id, {Location. loc}) -> [mkloc (Path.Pident id) loc]
     | Tpat_alias (_,id,loc) -> [reloc (Path.Pident id) loc]
     | _ -> []
   in

--- a/tests/test-dirs/occurrences/pattern.t
+++ b/tests/test-dirs/occurrences/pattern.t
@@ -1,0 +1,36 @@
+This test demonstrates the handling of location of patterns. For a pattern like
+(x), the occurence location should reflect only the identifier.
+
+  $ cat >pat.ml <<EOF
+  > let f x =
+  >   match x with
+  >   | Some (yyy) -> yyy
+  >   | None -> assert false
+  > EOF
+  $ $MERLIN single occurrences -identifier-at 3:10 -filename ./pat.ml < ./pat.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 9
+        },
+        "end": {
+          "line": 3,
+          "col": 14
+        }
+      },
+      {
+        "start": {
+          "line": 3,
+          "col": 18
+        },
+        "end": {
+          "line": 3,
+          "col": 21
+        }
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/occurrences/pattern.t
+++ b/tests/test-dirs/occurrences/pattern.t
@@ -14,11 +14,11 @@ This test demonstrates the handling of location of patterns. For a pattern like
       {
         "start": {
           "line": 3,
-          "col": 9
+          "col": 10
         },
         "end": {
           "line": 3,
-          "col": 14
+          "col": 13
         }
       },
       {


### PR DESCRIPTION
For a pattern like `(x)`, merlin will include the parens in the locations. This
PR fixes changes the location to only include the identifier.