### PR TITLE
Fixes random documentation fetched on hover

### DIFF
--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -831,13 +831,6 @@ let get_doc ~config ~env ~local_defs ~comments ~pos =
   | `Found (_, Some doc) ->
     `Found doc
   | `Found (loc, None) ->
-    let comments =
-      match File_switching.where_am_i () with
-      | None -> comments
-      | Some cmt_path ->
-        let {Cmt_cache. cmt_infos; _ } = Cmt_cache.read cmt_path in
-        cmt_infos.Cmt_format.cmt_comments
-    in
     log ~title:"get_doc" "%a" Logger.fmt (fun fmt ->
         Format.fprintf fmt "looking around %a inside: [\n"
           Location.print_loc !last_location;

--- a/tests/test-dirs/random-doc-issue.t
+++ b/tests/test-dirs/random-doc-issue.t
@@ -1,0 +1,78 @@
+Reproduce [ocaml-lsp #344](https://github.com/ocaml/ocaml-lsp/issues/344): a symbol's
+documentation is some other random documentation from a library that was last pulled for
+completion. See the issue for details. The space is necessary for the position of
+documentation to be fetch-able.
+
+  $ cat >lib_doc.ml <<EOF
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > 
+  > let k = ()
+  > let m = List.map
+  > EOF
+
+we need merlin to keep state between requests, so using server
+
+  $ $MERLIN server stop-server
+
+see that there is no doc for k
+
+  $ $MERLIN server document -position 23:5 < lib_doc.ml | jq '.value'
+  "No documentation available"
+
+we trigger the bug
+
+  $ $MERLIN server document -position 24:15 -filename lib_doc < lib_doc.ml
+  {
+    "class": "return",
+    "value": " [map f [a1; ...; an]] applies function [f] to [a1, ..., an],
+     and builds the list [[f a1; ...; f an]]
+     with the results returned by [f]. Not tail-recursive.
+   ",
+    "notifications": []
+  }
+
+random documentation is fetched for the same `document` request as before
+
+  $ $MERLIN server document -position 23:5 < lib_doc.ml
+  {
+    "class": "return",
+    "value": "List operations.
+  
+     Some functions are flagged as not tail-recursive.  A tail-recursive
+     function uses constant stack space, while a non-tail-recursive function
+     uses stack space proportional to the length of its list argument, which
+     can be a problem with very long lists.  When the function takes several
+     list arguments, an approximate formula giving stack usage (in some
+     unspecified constant unit) is shown in parentheses.
+  
+     The above considerations can usually be ignored if your lists are not
+     longer than about 10000 elements.
+  
+     The labeled version of this module can be used as described in the
+     {!StdLabels} module.",
+    "notifications": []
+  }
+
+stop server
+
+  $ $MERLIN server stop-server

--- a/tests/test-dirs/random-doc-issue.t
+++ b/tests/test-dirs/random-doc-issue.t
@@ -56,20 +56,7 @@ random documentation is fetched for the same `document` request as before
   $ $MERLIN server document -position 23:5 < lib_doc.ml
   {
     "class": "return",
-    "value": "List operations.
-  
-     Some functions are flagged as not tail-recursive.  A tail-recursive
-     function uses constant stack space, while a non-tail-recursive function
-     uses stack space proportional to the length of its list argument, which
-     can be a problem with very long lists.  When the function takes several
-     list arguments, an approximate formula giving stack usage (in some
-     unspecified constant unit) is shown in parentheses.
-  
-     The above considerations can usually be ignored if your lists are not
-     longer than about 10000 elements.
-  
-     The labeled version of this module can be used as described in the
-     {!StdLabels} module.",
+    "value": "No documentation available",
     "notifications": []
   }
 


### PR DESCRIPTION
Fixes the issue reported in https://github.com/ocaml/ocaml-lsp/issues/344 (the link contains the reported issue and some investigation work 🕵️ ), where documentation for the last hovered or completed file is shown for the current file. 

The reported issue:

> On hover, I sometimes get documentation for a completely different thing than the identifier I hover over. The "different thing" is usually something that comes from stdlib such as `>` operator or as in the screenshot, where I hover over `err_pos_range` and get correct type but not doc.
>
> ![image](https://user-images.githubusercontent.com/16353531/101482455-94c92100-3978-11eb-896c-51c3304f7f9b.png)

Re: fix

The fix removes code that looked for documentation in "last visited" file (a "visit" to a file is made by completion or type-enclosing request, for example). Maybe I'm missing where this behavior is necessary, but so far doc-on-hover behavior works well for me, and no tests are failing.