### PR TITLE
Replace spaces in socketname with '_'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ git version
       - handle multi-line paths
     - Handle `Persistent_env.Error` in `Typemod.initial_env` (#1355)
     - locate: reset global state from all entry points (#1364)
+    - Windows: replace user names by their SID in socketnames (#1345, @ttamttam)
   + editor modes
     - vim: add a simple interface to the new `construct` command:
       `MerlinConstruct`. When several results are suggested, `<c-i>` and `<c-u>`
@@ -31,8 +32,8 @@ git version
     - emacs: add a simple interface to the new `construct` command:
       `merlin-construct`. (#1352)
     - emacs: add support for the `merlin-locate-type` command. (#1359)
-  - emacs: fix issue with `merlin--highlight` and  various minor improvements
-      (#1367, @mattiase) 
+    - emacs: fix issue with `merlin--highlight` and  various minor improvements
+        (#1367, @mattiase) 
   + test suite
     - cover the new `construct` command (#1318)
 

--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -537,6 +537,11 @@ static void compute_socketname(char socketname[PATHSZ], struct stat *st)
 
   if (!GetUserName(user, &dwBufSize))
     user[0] = '\0';
+   
+  for (int i = 0; user[i] != '\0' && i <= UNLEN; i++)
+     if (isspace(user[i]))
+        user[i] = '_';
+   
   // @@DRA Need to use Windows API functions to get meaningful values for st_dev and st_ino
   snprintf(eventname, PATHSZ,
       "ocamlmerlin_%s_%lx_%llx",

--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -9,6 +9,7 @@
 #include <windows.h>
 #include <Lmcons.h>
 #include <process.h>
+#include <sddl.h>       // ConvertSidToStringSid
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif
@@ -521,35 +522,74 @@ static void compute_merlinpath(char merlin_path[PATHSZ], const char *argv0, stru
 }
 
 #ifdef _WIN32
+
+/* May return NULL */
+LPSTR retrieve_user_sid_string()
+{
+  LPSTR usidstr;
+  HANDLE process_token;
+  if ( ! OpenProcessToken( GetCurrentProcess(), TOKEN_QUERY, &process_token ) )
+    return NULL;
+
+  DWORD sid_buffer_size;
+  if ( ! GetTokenInformation(process_token, TokenUser, NULL, 0, &sid_buffer_size ) &&
+        ( GetLastError() != ERROR_INSUFFICIENT_BUFFER ) )
+  {
+    CloseHandle(process_token);
+    return NULL;
+  }
+
+  TOKEN_USER * token_user_ptr = (PTOKEN_USER) malloc(sid_buffer_size);
+  if ( ! token_user_ptr )
+  {
+    CloseHandle( process_token);
+    return NULL;
+  }
+
+  if ( ! GetTokenInformation(process_token, TokenUser, token_user_ptr,
+                             sid_buffer_size, &sid_buffer_size))
+  {
+    free(token_user_ptr);
+    CloseHandle(process_token);
+    return NULL;
+  }
+
+  if (! ConvertSidToStringSid(token_user_ptr->User.Sid, &usidstr))
+    usidstr = NULL;
+
+  free(token_user_ptr);
+  CloseHandle(process_token);
+
+  return usidstr;
+}
+
 static void compute_socketname(char socketname[PATHSZ], char eventname[PATHSZ], const char merlin_path[PATHSZ])
 #else
 static void compute_socketname(char socketname[PATHSZ], struct stat *st)
 #endif
 {
 #ifdef _WIN32
-  CHAR user[UNLEN + 1];
-  DWORD dwBufSize = UNLEN;
   BY_HANDLE_FILE_INFORMATION info;
+  LPSTR user_sid_string;
   HANDLE hFile = CreateFile(merlin_path, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
   if (hFile == INVALID_HANDLE_VALUE || !GetFileInformationByHandle(hFile, &info))
     failwith_perror("stat (cannot find ocamlmerlin binary)");
   CloseHandle(hFile);
 
-  if (!GetUserName(user, &dwBufSize))
-    user[0] = '\0';
-   
-  for (int i = 0; user[i] != '\0' && i <= UNLEN; i++)
-     if (isspace(user[i]))
-        user[i] = '_';
-   
+  user_sid_string = retrieve_user_sid_string() ;
+  if (! user_sid_string)
+    user_sid_string = LocalAlloc(LPTR, 1);
+
   // @@DRA Need to use Windows API functions to get meaningful values for st_dev and st_ino
   snprintf(eventname, PATHSZ,
       "ocamlmerlin_%s_%lx_%llx",
-      user,
+      user_sid_string,
       info.dwVolumeSerialNumber,
       ((__int64)info.nFileIndexHigh) << 32 | ((__int64)info.nFileIndexLow));
   snprintf(socketname, PATHSZ,
       "\\\\.\\pipe\\%s", eventname);
+
+  LocalFree(user_sid_string);
 #else
   snprintf(socketname, PATHSZ,
       "ocamlmerlin_%llu_%llu_%llu.socket",


### PR DESCRIPTION
On windows, if the username retrieved by `GetUserName` contain spaces, they end up in the socketname, and emacs fails when trying to open it.