### PR TITLE
Dune file new name: "dune-file"

### DIFF
--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -106,7 +106,7 @@ module Configurator = struct
   let of_string_opt = function
     | ".merlin" ->
       Some Dot_merlin
-    | "dune-project" | "dune" ->
+    | "dune-project" | "dune-workspace" ->
       Some Dune
     | _ -> None
 

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -309,8 +309,10 @@ let find_project_context start_dir =
     always use that starting folder as the workdir.  *)
   let map_workdir dir = function
     | Some dir -> Some dir
-    | None -> let fname = Filename.concat dir "dune" in
-      if Sys.file_exists fname && not (Sys.is_directory fname)
+    | None -> 
+      let fnames = List.map ~f:(Filename.concat dir) ["dune"; "dune-file"] in
+      if List.exists ~f:(fun fname -> 
+        Sys.file_exists fname && not (Sys.is_directory fname)) fnames
       then Some dir else None
   in
 


### PR DESCRIPTION
Starting with Dune 3.0 the name `dune-file` will be able to be used instead  of `dune` for build configuration files.

This PR anticipate this change, and also fix an issue when `dune-workspace` file is used instead of `dune-project`.