### PR TITLE
Handle `Persistent_env.Error` in `Typemod.initial_env`

### DIFF
--- a/src/ocaml/typing/typemod.ml
+++ b/src/ocaml/typing/typemod.ml
@@ -157,7 +157,7 @@ let initial_env ~loc ~safe_string ~initially_opened_module
     try
       snd (type_open_ Override env lid.loc lid)
     with
-    | (Typetexp.Error _ | Env.Error _ | Magic_numbers.Cmi.Error _) as exn ->
+    | (Typetexp.Error _ | Env.Error _ | Magic_numbers.Cmi.Error _ | Persistent_env.Error _) as exn ->
       Msupport.raise_error exn;
       env
     | exn ->


### PR DESCRIPTION
We have some users who are nondeterministically getting the error

```
error in process sentinel: merlin-mode failure: Uncaught exception Persistent_env.Error in initial_env.open_module: Persistent_env.Error(_)
```

We believe this to be due to a race with writing out `.cmi` files during the build process, and think it can be fixed by handling this exception in `Typemod.initial_env` in the same way other relevant errors are handled.

This change should probably be added to the "Backport to 3.4" and "Backport to 411" projects, but as I'm not a member of this repository I don't seem to be able to do that.