### PR TITLE
Use locks for server related tests :tada: (require Dune 2.9)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 2.9)
 (name merlin)
 (using menhir 2.0)
 

--- a/merlin.opam
+++ b/merlin.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.12" & < "4.13"}
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}

--- a/tests/test-dirs/dune
+++ b/tests/test-dirs/dune
@@ -3,3 +3,7 @@
    polarity-search typer-cache)
  (enabled_if
   (<> %{os_type} Win32)))
+
+(cram
+ (applies_to typer-cache warnings/backtrack)
+ (locks merlin-server))


### PR DESCRIPTION
This should fix random failures of the CI.