### PR TITLE
[Construct] fix generated argument names

### DIFF
--- a/src/analysis/construct.ml
+++ b/src/analysis/construct.ml
@@ -118,7 +118,7 @@ module Util = struct
   generating function arguments in the same expression *)
   let idents_table ~keywords =
     let table = Hashtbl.create 50 in
-    (* we add keyworss to the table so they are always numbered *)
+    (* We add keywords to the table so they are always numbered *)
     List.iter keywords ~f:(fun k -> Hashtbl.add table k (-1));
     table
 
@@ -290,8 +290,8 @@ module Gen = struct
         Hashtbl.replace idents_table n i;
         Printf.sprintf "%s_%i" n i
       in
-      let uniq_name env id =
-        let n = Ident.name id in
+      let uniq_name env n =
+        let id = Ident.create_local n in
         try
           let i = Hashtbl.find idents_table n + 1 in
           make_i n i
@@ -309,7 +309,7 @@ module Gen = struct
             Ast_helper.Pat.var ( Location.mknoloc s), s
         | Nolabel -> begin match ty.desc with
           | Tconstr (path, _, _) ->
-            let name = uniq_name env (Path.head path) in
+            let name = uniq_name env (Path.last path) in
             Ast_helper.Pat.var (Location.mknoloc name), name
           | _ -> Ast_helper.Pat.any (), "_" end
     in

--- a/tests/test-dirs/construct/c-fun.t
+++ b/tests/test-dirs/construct/c-fun.t
@@ -1,0 +1,49 @@
+  $ cat >fun1.ml <<EOF
+  > module Mymod = struct type the_type = int end
+  > type the_type = float
+  > let x : Mymod.the_type -> the_type -> unit =
+  >   _
+  > EOF
+
+  $ $MERLIN single construct -position 4:2 \
+  > -filename fun1.ml <fun1.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 4,
+        "col": 2
+      },
+      "end": {
+        "line": 4,
+        "col": 3
+      }
+    },
+    [
+      "(fun the_type the_type_1 -> _)"
+    ]
+  ]
+
+  $ cat >fun2.ml <<EOF
+  > module Mymod = struct type int = string end
+  > type int = float
+  > let x : Mymod.int -> int -> unit =
+  >   _
+  > EOF
+
+  $ $MERLIN single construct -position 4:2 \
+  > -filename fun2.ml <fun2.ml | jq ".value"
+  [
+    {
+      "start": {
+        "line": 4,
+        "col": 2
+      },
+      "end": {
+        "line": 4,
+        "col": 3
+      }
+    },
+    [
+      "(fun int int_1 -> _)"
+    ]
+  ]


### PR DESCRIPTION
Thanks @ulugbekna for signaling that issue.

Construct's argument name generation was a bit broken:

```
  $ cat >fun1.ml <<EOF
  > module Mymod = struct type the_type = int end
  > let x : Mymod.the_type -> unit =
  >   _
  > EOF

  $ $MERLIN single construct -position 3:2 \
  > -filename fun1.ml <fun1.ml | jq ".value"
...
    [
      "(fun Mymod -> _)"
    ]       ^^^^^
  ]
  ```

This PR fixes this by using the last component of the path instead of the first.