### PR TITLE
[Construct] fix suggested values

### DIFF
--- a/doc/dev/PROTOCOL.md
+++ b/doc/dev/PROTOCOL.md
@@ -226,13 +226,14 @@ Entries is the list of possible completion. Each entry is made of:
 ### `construct -position <position> [ -with-values <none|local> -depth <int> ]`
 
     -position <position>      Position where construct should happen
-    -with-values <none|local> Use values from the environment (defaults to none)
+    -with-values <none|local> Use values from the environment 
+                              (experimental, defaults to none)
     -depth <int>              Depth of the search (defaults to 1)
 
 When the position determined by `-position` is a hole (`_`), this command
   returns a list of possible terms that could replace it given its type.
 When `-with-values` is set to local, values in the current environment will be
-  used in the constructed terms.
+  used in the constructed terms. This feature is still under development.
 
 ### `document -position <position> [ -identifier <string> ]`
 

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -49,6 +49,8 @@ let () =
   )
 
 module Path_utils : sig
+  val is_opened : Env.t -> Path.t -> bool 
+
   val to_shortest_lid :
     env:Env.t ->
     ?name:string ->
@@ -62,6 +64,8 @@ end = struct
         |> Option.value ~default:acc
     in
     aux [] env
+
+  let is_opened env path = List.mem path ~set:(opens (Env.summary env))
 
   let rec to_shortest_lid ~(opens : Path.t list) = function
     | Path.Pdot (path, name) when List.exists ~f:(Path.same path) opens ->

--- a/src/analysis/destruct.mli
+++ b/src/analysis/destruct.mli
@@ -92,6 +92,9 @@ module Path_utils : sig
     env:Env.t ->
     ?name:string ->
     env_check:(Longident.t -> Env.t -> 'a) -> Path.t -> Longident.t
+
+  (* Return wheter the given path is opened in the given environment *)
+  val is_opened : Env.t -> Path.t -> bool 
 end
 
 val node :

--- a/tests/test-dirs/construct/c-fun.t
+++ b/tests/test-dirs/construct/c-fun.t
@@ -1,3 +1,4 @@
+Test 1
   $ cat >fun1.ml <<EOF
   > module Mymod = struct type the_type = int end
   > type the_type = float
@@ -23,6 +24,7 @@
     ]
   ]
 
+Test 2
   $ cat >fun2.ml <<EOF
   > module Mymod = struct type int = string end
   > type int = float
@@ -46,4 +48,44 @@
     [
       "(fun int int_1 -> _)"
     ]
+  ]
+
+Test 3
+  $ cat >fun3.ml <<EOF
+  > module Mymod : 
+  >  sig type t val x : t val f : int -> t end =
+  >  struct type t = int let x = 3 let f x = 2 * x end
+  > type t = float
+  > let g x = 2 *. x 
+  > let x : Mymod.t = 3
+  > let z : Mymod.t =
+  >   _
+  > let t : t =
+  >   _
+  > EOF
+
+Here nothing is expected as t is abstract
+  $ $MERLIN single construct -position 8:2 \
+  > -filename fun3.ml <fun3.ml | jq ".value[1]"
+  []
+
+  $ $MERLIN single construct -position 8:2 -with-values local \
+  > -filename fun3.ml <fun3.ml | jq ".value[1]"
+  [
+    "x",
+    "(Mymod.f _)",
+    "Mymod.x"
+  ]
+
+  $ $MERLIN single construct -position 10:2 \
+  > -filename fun3.ml <fun3.ml | jq ".value[1]"
+  [
+    "0.0"
+  ]
+
+  $ $MERLIN single construct -position 10:2 -with-values local \
+  > -filename fun3.ml <fun3.ml | jq ".value[1]"
+  [
+    "0.0",
+    "(g _)"
   ]

--- a/tests/test-dirs/construct/c-simple.t
+++ b/tests/test-dirs/construct/c-simple.t
@@ -70,9 +70,9 @@ With values:
     [
       "(Some _)",
       "None",
+      "nice_candidate",
       "(nice_candidate_with_arg _)",
-      "(nice_candidate_with_labeled_arg ~x:_)",
-      "nice_candidate"
+      "(nice_candidate_with_labeled_arg ~x:_)"
     ]
   ]
 
@@ -95,9 +95,9 @@ With depth 2 and values:
       "(Some 0)",
       "None",
       "(Some y)",
+      "nice_candidate",
       "(nice_candidate_with_arg _)",
-      "(nice_candidate_with_labeled_arg ~x:_)",
-      "nice_candidate"
+      "(nice_candidate_with_labeled_arg ~x:_)"
     ]
   ]
 
@@ -427,8 +427,8 @@ only v1 should appear
   [
     "(App (_, _))",
     "(Int _)",
-    "x",
-    "v1"
+    "v1",
+    "x"
   ]
 
 ###################


### PR DESCRIPTION
Thank you @ulugbekna for trying construct and noticing these issues.

Even if editor modes for emacs and vim don't use that feature yet, construct is able to look in the local environment for values whose type or return type is compatible with the current hole type.

Well, at least that is what the head of marketing said, but in practice this was mostly broken, and this PR attempts to fix it.

@ulugbekna could you test is with your shiny ocaml-lsp setup ? Even if I am still not convinced that we should enable this by default in the current form (showing all matching values) I am very interested by your feedback !