### PR TITLE
Fix unqualify shouldnt qualify

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ git version
     - add new module holes that can replace module expressions (#1333)
     - add a new command `construct` that builds a list of possible terms when
       called on a typed hole (#1318)
-    - `refactor-open qualify` improvements (#1313, #1314, #1366)
+    - `refactor-open` improvements (#1313, #1314, #1366, #1372)
       - do not make paths absolute, simply prefix with the identifier under the cursor
         ```ocaml
         open Foo (* calling refactor-open qualify on this open *)
@@ -20,6 +20,7 @@ git version
       - do not return unnecessary edits that when applied do not change the document
       - handle record fields properly
       - handle multi-line paths
+      - `unqualify` should not qualify
     - Handle `Persistent_env.Error` in `Typemod.initial_env` (#1355)
     - locate: reset global state from all entry points (#1364)
   + editor modes

--- a/src/analysis/refactor_open.ml
+++ b/src/analysis/refactor_open.ml
@@ -1,21 +1,38 @@
 open Std
 
-let qual_or_unqual_path mode leftmost_ident path p =
+(** [leftmost_lident lid] returns the leftmost part of [lid], e.g., 
+    given [String.Map.empty], [String] is returned *)
+let rec leftmost_lident (lid : Longident.t) = 
+  match lid with
+  | Lident s -> s
+  | Ldot(lid', _) -> leftmost_lident lid'
+  | Lapply(_, _) -> raise @@ Invalid_argument "leftmost_lident: don't support Lapply"
+
+(** [qual_or_unqual_path mode ~open_lident ~open_path node_path node_lid] 
+    if mode is 
+      `Unqualify - returns [node_lid] or [node_lid] with prefix [open_lident] cut off, 
+        whichever is shorter
+
+      `Qualify - returns [node_path] with its prefix equal to [open_lident]
+
+    Note: by "prefix" we mean the leftmost consecutive part of a longident or a path. *)
+let qual_or_unqual_path mode open_lident ~open_path node_path =
+  let leftmost_open_lident = leftmost_lident open_lident in
   let rec aux acc (p : Path.t) =
     match p with
     | Pident ident ->
       Ident.name ident :: acc
     | Pdot (path', s) when
-        mode = `Unqualify && Path.same path path' ->
+        mode = `Unqualify && Path.same open_path path' ->
       s :: acc
     | Pdot (path', s) when
-        mode = `Qualify && s = leftmost_ident ->
+        mode = `Qualify && s = leftmost_open_lident ->
       s :: acc
     | Pdot (path', s) ->
       aux (s :: acc) path'
     | _ -> raise Not_found
   in
-  aux [] p
+  aux [] node_path
 
 let same_longident new_lident old_lident =
   List.length new_lident = List.length (Longident.flatten old_lident)
@@ -23,14 +40,13 @@ let same_longident new_lident old_lident =
 let get_rewrites ~mode typer pos =
   match Mbrowse.select_open_node (Mtyper.node_at typer pos) with
   | None | Some (_, _, []) -> []
-  | Some (orig_path, longident, ((_, node) :: _)) ->
-    let paths_and_lids = Browse_tree.all_occurrences_of_prefix orig_path node in
-    let leftmost_ident = Longident.flatten longident |> List.hd in
+  | Some (open_path, open_lident, ((_, node) :: _)) ->
+    let paths_and_lids = Browse_tree.all_occurrences_of_prefix open_path node in
     List.filter_map paths_and_lids ~f:(fun ({Location. txt = path; loc}, lid) ->
       if loc.Location.loc_ghost || Location_aux.compare_pos pos loc > 0 then
         None
       else
-        match qual_or_unqual_path mode leftmost_ident orig_path path with
+        match qual_or_unqual_path mode open_lident ~open_path path with
         | parts when same_longident parts lid -> None
         | parts -> Some (String.concat ~sep:"." parts, loc)
         | exception Not_found -> None

--- a/src/ocaml/parsing/longident.ml
+++ b/src/ocaml/parsing/longident.ml
@@ -25,6 +25,11 @@ let rec flat accu = function
 
 let flatten lid = flat [] lid
 
+let rec head = function
+    Lident s -> s
+  | Ldot(lid, _) -> head lid
+  | Lapply(_, _) -> assert false
+
 let last = function
     Lident s -> s
   | Ldot(_, s) -> s

--- a/src/ocaml/parsing/longident.mli
+++ b/src/ocaml/parsing/longident.mli
@@ -33,6 +33,11 @@ val unflatten: string list -> t option
     [unflatten []] is [None].
 *)
 
+(** [head lid] returns the leftmost part of [lid], e.g., 
+    given [String.Map.empty], returns [String].
+    
+    @raise Assert_failure if encounters [Lapply] *)
+val head: t -> string
 val last: t -> string
 val parse: string -> t
   (* (* disabled in merlin. *)

--- a/tests/test-dirs/refactor-open/unqualify.t
+++ b/tests/test-dirs/refactor-open/unqualify.t
@@ -84,4 +84,31 @@ Shouldn't return anything, as nothing to unqualify (for multi-line identifiers)
     "notifications": []
   }
 
+FIXME unqualify should not qualify
 
+  $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
+  > module M = struct
+  >   module N = struct
+  >     type t = Foo | Bar
+  >   end
+  > end
+  > open M
+  > let v : N.t = Foo
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 7,
+          "col": 14
+        },
+        "end": {
+          "line": 7,
+          "col": 17
+        },
+        "content": "N.Foo"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/refactor-open/unqualify.t
+++ b/tests/test-dirs/refactor-open/unqualify.t
@@ -84,7 +84,7 @@ Shouldn't return anything, as nothing to unqualify (for multi-line identifiers)
     "notifications": []
   }
 
-FIXME unqualify should not qualify
+Unqualify should not qualify
 
   $ $MERLIN single refactor-open -action unqualify -position 6:6 <<EOF
   > module M = struct
@@ -97,18 +97,6 @@ FIXME unqualify should not qualify
   > EOF
   {
     "class": "return",
-    "value": [
-      {
-        "start": {
-          "line": 7,
-          "col": 14
-        },
-        "end": {
-          "line": 7,
-          "col": 17
-        },
-        "content": "N.Foo"
-      }
-    ],
+    "value": [],
     "notifications": []
   }


### PR DESCRIPTION
`unqualify` previously could qualify, for example:

```
module M = struct
   module N = struct
     type t = Foo | Bar
   end
end

open M (* unqualify [M] previously qualified [Foo] below into [N.Foo], which isn't what user wants I think *)

let v : N.t = Foo
```

The PR also uses a faster way to check if the new lident is different from the old one. 

Should be easiest to review commit-by-commit.

