### PR TITLE
Mbrowse.select_leaf: correctly ignore merlin.hide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
-unreleased
-============
+git version
+===========
 
   + merlin binary
+    - Mbrowse.select_leaf: correctly ignore merlin.hide (#1376)
     - enable `occurences` to work when looking for locally abstract types
       (#1382)
 

--- a/src/kernel/mbrowse.ml
+++ b/src/kernel/mbrowse.ml
@@ -88,7 +88,10 @@ let select_leafs pos root =
   let branches = ref [] in
   let rec select_child branch env node has_selected =
     let loc = node_merlin_loc node in
-    if Location_aux.compare_pos pos loc = 0 then
+    let attrs = Browse_raw.node_attributes node in
+    if Location_aux.compare_pos pos loc = 0 &&
+       not (has_attr "merlin.hide" attrs)
+    then
       (traverse ((env, node) :: branch); true)
     else
       has_selected

--- a/tests/test-dirs/type-enclosing/merlin-hide.t
+++ b/tests/test-dirs/type-enclosing/merlin-hide.t
@@ -9,7 +9,32 @@ accessible:
   > end
   > EOF
   {
-    "class": "failure",
-    "value": "hd",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 11
+        },
+        "end": {
+          "line": 5,
+          "col": 3
+        },
+        "type": "sig val x : int end",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 5,
+          "col": 3
+        },
+        "type": "sig val x : int end",
+        "tail": "no"
+      }
+    ],
     "notifications": []
   }

--- a/tests/test-dirs/type-enclosing/merlin-hide.t
+++ b/tests/test-dirs/type-enclosing/merlin-hide.t
@@ -1,0 +1,15 @@
+Make sure type-enclosing works properly even when the precise location is not
+accessible:
+
+  $ $MERLIN single type-enclosing -position 3:7 -filename hide.ml <<EOF
+  > module M = struct
+  >   include struct
+  >     let x = 3
+  >   end[@merlin.hide]
+  > end
+  > EOF
+  {
+    "class": "failure",
+    "value": "hd",
+    "notifications": []
+  }


### PR DESCRIPTION
@lpw25 reported that type-enclosing would fail when called on `x` in
```ocaml
type t = { x : asdfasd } [@@deriving equal]
```

This PR fixes that.