### PR TITLE
Log the backtrace even when the exception is a `Failure`

### DIFF
--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -103,17 +103,20 @@ let run = function
             with
             | result ->
               ("return", result)
-            | exception (Failure str) ->
-              ("failure", `String str)
             | exception exn ->
               let trace = Printexc.get_backtrace () in
               log ~title:"run" "Command error backtrace: %s" trace;
-              match Location.error_of_exn exn with
-              | None | Some `Already_displayed ->
-                ("exception", `String (Printexc.to_string exn ^ "\n" ^ trace))
-              | Some (`Ok err) ->
-                Location.print_main Format.str_formatter err;
-                ("error", `String (Format.flush_str_formatter ()))
+              match exn with
+              | Failure str ->
+                ("failure", `String str)
+              | _ -> begin
+                match Location.error_of_exn exn with
+                | None | Some `Already_displayed ->
+                  ("exception", `String (Printexc.to_string exn ^ "\n" ^ trace))
+                | Some (`Ok err) ->
+                  Location.print_main Format.str_formatter err;
+                  ("error", `String (Format.flush_str_formatter ()))
+              end
           in
           let cpu_time = Misc.time_spent () -. start_cpu in
           let clock_time = Unix.gettimeofday () *. 1000. -. start_clock in

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -103,20 +103,19 @@ let run = function
             with
             | result ->
               ("return", result)
+            | exception (Failure str) ->
+              let trace = Printexc.get_backtrace () in
+              log ~title:"run" "Command error backtrace: %s" trace;
+              ("failure", `String str)
             | exception exn ->
               let trace = Printexc.get_backtrace () in
               log ~title:"run" "Command error backtrace: %s" trace;
-              match exn with
-              | Failure str ->
-                ("failure", `String str)
-              | _ -> begin
-                match Location.error_of_exn exn with
-                | None | Some `Already_displayed ->
-                  ("exception", `String (Printexc.to_string exn ^ "\n" ^ trace))
-                | Some (`Ok err) ->
-                  Location.print_main Format.str_formatter err;
-                  ("error", `String (Format.flush_str_formatter ()))
-              end
+              match Location.error_of_exn exn with
+              | None | Some `Already_displayed ->
+                ("exception", `String (Printexc.to_string exn ^ "\n" ^ trace))
+              | Some (`Ok err) ->
+                Location.print_main Format.str_formatter err;
+                ("error", `String (Format.flush_str_formatter ()))
           in
           let cpu_time = Misc.time_spent () -. start_cpu in
           let clock_time = Unix.gettimeofday () *. 1000. -. start_clock in


### PR DESCRIPTION
In `new_merlin.ml`, there's code to log the backtraces of exceptions for all non-`Failure` exceptions; this PR reorganizes things so that the backtrace is logged regardless of the variety of exception we have.