### PR TITLE
Avoid a race condition when the process started to read a configuration file crashes/is not found

### DIFF
--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -238,15 +238,15 @@ let get_config { workdir; process_dir; configurator } path_abs =
       raise Process_exited;
 
     (* Both [p.initial_cwd] and [path_abs] have gone through
-    [canonicalize_filename] *)
+       [canonicalize_filename] *)
     let path_rel =
       String.chop_prefix ~prefix:p.initial_cwd path_abs
       |> Option.map ~f:(fun path ->
         (* We need to remove the leading path separator after chopping.
-        There is one case where no separator is left: when [initial_cwd]
-        was the root of the filesystem *)
+           There is one case where no separator is left: when [initial_cwd]
+           was the root of the filesystem *)
         if String.length path > 0 && path.[0] = Filename.dir_sep.[0] then
-           String.drop 1 path
+          String.drop 1 path
         else path)
     in
 
@@ -257,8 +257,8 @@ let get_config { workdir; process_dir; configurator } path_abs =
     in
 
     (* Starting with Dune 2.8.3 relative paths are prefered. However to maintain
-    compatibility with 2.8 <= Dune <= 2.8.2  we always retry with an absolute
-    path if using a relative one failed *)
+       compatibility with 2.8 <= Dune <= 2.8.2  we always retry with an absolute
+       path if using a relative one failed *)
     let answer =
       match query path p with
       | Ok ([`ERROR_MSG _]) when p.kind = Dune ->
@@ -309,9 +309,9 @@ let find_project_context start_dir =
     always use that starting folder as the workdir.  *)
   let map_workdir dir = function
     | Some dir -> Some dir
-    | None -> 
+    | None ->
       let fnames = List.map ~f:(Filename.concat dir) ["dune"; "dune-file"] in
-      if List.exists ~f:(fun fname -> 
+      if List.exists ~f:(fun fname ->
         Sys.file_exists fname && not (Sys.is_directory fname)) fnames
       then Some dir else None
   in


### PR DESCRIPTION
In `Mconfig_dot`, there's a race condition around `waitpid` that can cause `ocamlmerlin` to crash if the process started to read a configuration file (either `dot-merlin-reader` or `dune`) crashes immediately or is not found.  This PR fixes that race condition; it also protects the PIDs behind a module abstraction boundary to prevent it from happening again.

The existing code could error in the following case (seven-point framing due to @stedolan):

1. We call `Mconfig_dot.get_config`.

2. On (the former) line 236, `get_config` calls `Mconfig_dot.Configurator.get_process`; this function spawns a process and stores its information in the `running_processes` hashtable.  (It doesn't matter which code path it goes down; let's suppose it starts it for the first time. i.e. the `with Not_found` path.)

3. The spawned process immediately exits in the background.

4. On (the former) line 237, `get_config` calls `Unix.waitpid` on the PID from `get_process`, returning the PID (nonzero) because the spawned process crashed.  Importantly, this means the PID can never be waited on again.

5. This raises `Process_exited`, which `get_config` catches; `get_config` then proceeds to exit after reporting an error.

6. We call `Mconfig_dot.get_config` again.

7. As in step 2, we call `get_process` on (the former) line 236; this looks up the old stale PID in `running_processes`, finds it, and calls `Unix.waitpid` on it.  Because that PID was already waited on after completion in step 4 above, this crashes with an `ECHILD` error, terminating messily.

We have actually seen this crash in practice.

To fix this and prevent it from happening again, I made two changes:

1. I provided a version of `get_process` that runs the second `Unix.waitpid` itself, returning a `Process.t option`.  The accuracy of this wait depends on exactly how fast the spawned process fails, but as this is mostly trying to catch `dot-merlin-reader` not being installed or not being on the PATH, that's fine; it only needs to be best-effort besides that.

2. I provide a module signature for the local `Configurator` module, abstracting over the `running_processes` hashtable so that we can preserve the invariant that it only contains waitable PIDs.  To make this abstraction robust, I removed the PID from the `Process.t` record, and have `running_processes` store a `Process.With_pid.t`, which is just a pair of a PID and a process; I never expose this type (or any other way to access the PID) from `Configurator`'s interface.
