### PR TITLE
Update quick setup instructions for emacs

### DIFF
--- a/merlin.opam
+++ b/merlin.opam
@@ -41,7 +41,7 @@ Also run the following line in vim to index the documentation:
 Quick setup for EMACS
 -------------------
 Add opam emacs directory to your load-path by appending this to your .emacs:
-  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
    (when (and opam-share (file-directory-p opam-share))
     ;; Register Merlin
     (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))


### PR DESCRIPTION
opam config var was deprecated in version 2.1 of the opam CLI. Use opam var instead.