### PR TITLE
Vim plugin: fix filename style when under cygwin

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -88,6 +88,9 @@ def concat_map(f, args):
 
 def current_context():
     filename = vim.eval("expand('%:p')")
+    if platform == "cygwin":
+        cygpath = os.popen('cygpath -m /').read().strip()
+        filename = cygpath + filename
     content = "\n".join(vim.current.buffer) + "\n"
     return (filename, content)
 


### PR DESCRIPTION
When under cygwin, the vim plugin tries to send a request to the merlin server with filename of the unix form `/path/to/file.ml` whereas it needs a filename of the form : `C:/cygwin/path/to/file.ml`. This PR fixes that.

The only method I stumbled upon to get the (windows) cygwin root path was to use `cygpath -m /`, but I don't know if it is a good way. Let me know if you know a better way to get it.