### PR TITLE
Emacs Xref improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ Thu Nov 24 13:31:42 CEST 2022
     - Allow program name customization when merlin is used as a library. (#1532)
   + editor modes
     - vim: load the plugin when necessary if it wasn't loaded before (#1511)
+    - emacs: xref works from context menus; better highlighting of xref
+      matches; xref recognises operators and binding operators at the
+      cursor position; bad locations are filtered out (#1385, fixes
+      #1410)
     - emacs: update CI for newer releases and fix some warnings (#1454,
       @mattiase)
   + test suite

--- a/emacs/merlin-xref.el
+++ b/emacs/merlin-xref.el
@@ -13,17 +13,70 @@
     (goto-char loc)
     (buffer-substring (line-beginning-position) (line-end-position))))
 
+(defun merlin-xref--line-col-to-pos (line-col)
+  (let ((line (cdr (assq 'line line-col)))
+        (col (cdr (assq 'col line-col))))
+    (goto-char (point-min))
+    (forward-line (1- line))
+    (byte-to-position (+ (position-bytes (point)) col))))
+
 (cl-defmethod xref-backend-references ((_backend (eql merlin-xref)) symbol)
-  (mapcar
-   (lambda (loc)
-     (let ((pt (merlin-make-point (alist-get 'start loc))))
-       (xref-make (merlin-xref--line pt)
-                  (xref-make-buffer-location (current-buffer) pt))))
-   (save-excursion
-     (let ((pt (get-text-property 0 'merlin-xref-point symbol)))
-       (when pt
-         (goto-char pt)))
-     (merlin--occurrences))))
+  (save-excursion
+    (save-restriction
+      (widen)
+      (let ((locations
+             ;; Transform the result into a list of (START END START-LINE).
+             (mapcar
+              (lambda (loc)
+                (let* ((start-line-col (cdr (assq 'start loc)))
+                       (start-line (cdr (assq 'line start-line-col)))
+                       (end-line-col (cdr (assq 'end loc)))
+                       (start (merlin-xref--line-col-to-pos start-line-col))
+                       (end (merlin-xref--line-col-to-pos end-line-col)))
+                  (list start end start-line)))
+              (let ((pt (get-text-property 0 'merlin-xref-point symbol)))
+                (when pt
+                  (goto-char pt))
+                (merlin--occurrences)))))
+        ;; To provide correct context for Xref, lines with multiple matches
+        ;; need to be partitioned into substrings, each containing a single
+        ;; match. (Prior to Emacs 28 we use the entire line because the Xref
+        ;; machinery did not put multiple matches on a single line.)
+        (let ((whole-line (< emacs-major-version 28))
+              (match-face (if (facep 'xref-match) 'xref-match 'match))
+              (file-name buffer-file-name)
+              (matches nil)
+              (prev nil)
+              (tail locations))
+          (while tail
+            (let* ((match (car tail))
+                   (next (cadr tail))
+                   (start (nth 0 match))
+                   (end (nth 1 match))
+                   (line (nth 2 match))
+                   (prev-end (nth 1 prev))
+                   (next-start (nth 0 next))
+                   (bol (progn (goto-char start)
+                               (line-beginning-position)))
+                   (eol (line-end-position))
+                   (str-start (if (and prev-end (>= prev-end bol)
+                                       (not whole-line))
+                                  start
+                                bol))
+                   (str-end (if (and next-start (< next-start eol)
+                                     (not whole-line))
+                                next-start
+                              eol))
+                   (str (buffer-substring str-start str-end))
+                   (location (xref-make-file-location
+                              file-name line (- start bol))))
+              (add-face-text-property (- start str-start) (- end str-start)
+                                      match-face nil str)
+              (push (xref-make-match str location (- end start))
+                    matches)
+              (setq prev match)
+              (setq tail (cdr tail))))
+          (nreverse matches))))))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql merlin-xref)) symbol)
   (let* ((loc (save-excursion

--- a/emacs/merlin-xref.el
+++ b/emacs/merlin-xref.el
@@ -26,14 +26,19 @@
       (widen)
       (let ((locations
              ;; Transform the result into a list of (START END START-LINE).
-             (mapcar
+             (mapcan
               (lambda (loc)
                 (let* ((start-line-col (cdr (assq 'start loc)))
-                       (start-line (cdr (assq 'line start-line-col)))
-                       (end-line-col (cdr (assq 'end loc)))
-                       (start (merlin-xref--line-col-to-pos start-line-col))
-                       (end (merlin-xref--line-col-to-pos end-line-col)))
-                  (list start end start-line)))
+                       (start-line (cdr (assq 'line start-line-col))))
+                  ;; We sometimes get bogus locations (line 0, col -1)
+                  ;; in the reply. That should be fixed, but meanwhile
+                  ;; filter them out (issue #1410).
+                  (and (> start-line 0)
+                       (let* ((end-line-col (cdr (assq 'end loc)))
+                              (start
+                               (merlin-xref--line-col-to-pos start-line-col))
+                              (end (merlin-xref--line-col-to-pos end-line-col)))
+                         (list (list start end start-line))))))
               (let ((pt (get-text-property 0 'merlin-xref-point symbol)))
                 (when pt
                   (goto-char pt))


### PR DESCRIPTION
Fix uses of Xref from mouse events, such as the context menu new in Emacs 28, by implementing the necessary methods and smuggle the buffer position in a text property of the string.

We also get better highlighting of Xref hits in the target buffer by taking advantage of a bug fixed in Emacs 28.
