### PR TITLE
Allow -pp to return an AST

### DIFF
--- a/src/kernel/mreader.ml
+++ b/src/kernel/mreader.ml
@@ -162,17 +162,24 @@ let reconstruct_identifier config source pos =
 
 (* Entry point *)
 
-let parse ?for_completion config source =
-  match
-    try_with_reader config source
-      (Mreader_extend.parse ?for_completion)
-  with
-  | Some (`No_labels no_labels_for_completion, parsetree) ->
+let parse ?for_completion config = function
+  | (source, None) ->
+    begin match
+        try_with_reader config source
+          (Mreader_extend.parse ?for_completion)
+      with
+      | Some (`No_labels no_labels_for_completion, parsetree) ->
+        let (lexer_errors, parser_errors, comments) = ([], [], []) in
+        let lexer_keywords = [] (* TODO? *) in
+        { config; lexer_keywords; lexer_errors; parser_errors; comments;
+          parsetree; no_labels_for_completion; }
+      | None -> normal_parse ?for_completion config source
+    end
+  | (_, Some parsetree) ->
     let (lexer_errors, parser_errors, comments) = ([], [], []) in
-    let lexer_keywords = [] (* TODO? *) in
-    { config; lexer_keywords; lexer_errors; parser_errors; comments; parsetree;
-      no_labels_for_completion; }
-  | None -> normal_parse ?for_completion config source
+    let lexer_keywords = [] in
+    { config; lexer_keywords; lexer_errors; parser_errors; comments;
+      parsetree; no_labels_for_completion = false; }
 
 (* Update config after parse *)
 

--- a/src/kernel/mreader.mli
+++ b/src/kernel/mreader.mli
@@ -29,7 +29,7 @@ val with_ambient_reader : Mconfig.t -> Msource.t -> (unit -> 'a) -> 'a
 (* Main functions *)
 
 val parse :
-  ?for_completion:Msource.position -> Mconfig.t -> Msource.t -> result
+  ?for_completion:Msource.position -> Mconfig.t -> Msource.t * parsetree option -> result
 
 val print_pretty :
   Mconfig.t -> Msource.t -> pretty_parsetree -> string

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -176,9 +176,9 @@ let apply_pp ~workdir ~filename ~source ~pp =
 
 let decode_potential_ast source =
   let decoder =
-    if String.starts_with ~prefix:Config.ast_impl_magic_number source then
+    if Std.String.is_prefixed ~by:Config.ast_impl_magic_number source then
       Some (fun x -> `Implementation (Obj.obj x : Parsetree.structure))
-    else if String.starts_with ~prefix:Config.ast_intf_magic_number source then
+    else if Std.String.is_prefixed ~by:Config.ast_intf_magic_number source then
       Some (fun x -> `Interface (Obj.obj x : Parsetree.signature))
     else
       None

--- a/src/ocaml/driver/pparse.mli
+++ b/src/ocaml/driver/pparse.mli
@@ -20,4 +20,5 @@ val apply_rewriters_sig: ppx:string with_workdir list -> ?restore:bool -> tool_n
 
 val apply_rewriters: ppx:string with_workdir list -> ?restore:bool -> tool_name:string -> Mreader.parsetree -> Mreader.parsetree
 
-val apply_pp : workdir:string -> filename:string -> source:string -> pp:string -> string
+val apply_pp : workdir:string -> filename:string -> source:string -> pp:string ->
+  [ `Implementation of Parsetree.structure | `Interface of Parsetree.signature | `Source of string ]


### PR DESCRIPTION
Merlin expects a source preprocessor `-pp` to return sources.
However, some existing preprocessors return marshalled ASTs.
This patch adds support for this situation, and should fix:
- https://github.com/ocaml/ocaml-lsp/issues/525
- https://github.com/ocaml/dune/issues/4169
- https://github.com/ocaml/merlin/issues/1246

Merlin functionalities will be reduced:
- recovery is up to -pp
- no support for placeholder insertion for completion
- lexer_ident will fallback to the unpreprocessed source to reconstruct
  identifiers