### PR TITLE
Ignore dune stderr in tests

### DIFF
--- a/tests/test-dirs/document/src-documentation.t/run.t
+++ b/tests/test-dirs/document/src-documentation.t/run.t
@@ -42,7 +42,7 @@ documentation for the non-last defined value (in the same file) is show
   > jq '.value'
   " List reversal. "
 
-  $ dune build --root=. ./doc.exe
+  $ dune build --root=. ./doc.exe 2> /dev/null
   $ cat >.merlin <<EOF
   > B _build/default/.doc.eobjs/byte
   > S .


### PR DESCRIPTION
This is meant to be a bug-fix in the test suite.

Current behavior: when running the test-case, `dune` calls `ocamlopt` which in turns calls `ld`. In a particular context, I have a linker that emits a warning; this makes the test case fail (for a wrong reason).

Side note: if you want to see plenty of test failures, just `export OCAMLRUNPARAM='v=0x001'` before running the test suite…