### PR TITLE
Binding operators in occurrence and locate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ git version
     - handle `=` syntax in compiler flags (#1409)
     - expose all destruct exceptions in the api (#1437)
     - fix superfluous break in error reporting (#1432)
+    - recognise binding operators in locate and occurrences (#1398, @mattiase)
   + editor modes
     - add module, module type, and class imenu items for emacs (#1244, @ivg)
   + test suite

--- a/src/kernel/mreader_lexer.ml
+++ b/src/kernel/mreader_lexer.ml
@@ -137,6 +137,7 @@ open Parser_raw
 
 let is_operator = function
   | PREFIXOP s
+  | LETOP s | ANDOP s
   | INFIXOP0 s | INFIXOP1 s | INFIXOP2 s | INFIXOP3 s | INFIXOP4 s -> Some s
   | BANG -> Some "!"
   | PERCENT -> Some "%"

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -776,10 +776,17 @@ let module_expr_paths { Typedtree. mod_desc } =
     [reloc (Path.Pident id) loc, Option.map ~f:mk_lident loc.txt]
   | _ -> []
 
+let bindop_path { bop_op_name; bop_op_path } =
+  let loc = bop_op_name in
+  let path = bop_op_path in
+  (reloc path loc, Some (Longident.Lident loc.txt))
+
 let expression_paths { Typedtree. exp_desc; exp_extra; exp_env; _ } =
   let init =
     match exp_desc with
     | Texp_ident (path,loc,_) -> [reloc path loc, Some loc.txt]
+    | Texp_letop {let_; ands} ->
+      bindop_path let_ :: List.map ~f:bindop_path ands
     | Texp_new (path,loc,_) -> [reloc path loc, Some loc.txt]
     | Texp_instvar (_,path,loc)  -> [reloc path loc, Some (Lident loc.txt)]
     | Texp_setinstvar (_,path,loc,_) -> [reloc path loc, Some (Lident loc.txt)]

--- a/src/ocaml/preprocess/lexer_ident.mll
+++ b/src/ocaml/preprocess/lexer_ident.mll
@@ -59,6 +59,10 @@ let float_literal =
   ['0'-'9'] ['0'-'9' '_']*
   ('.' ['0'-'9' '_']* )?
   (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']*)?
+let dotsymbolchar =
+  ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|']
+let kwdopchar =
+  ['$' '&' '*' '+' '-' '/' '<' '=' '>' '@' '^' '|']
 
 rule token = parse
   | "_" { EOL }
@@ -77,6 +81,8 @@ rule token = parse
       { OPTLABEL label }
   | "?" (lowercase_latin1 identchar_latin1 *) as label ':'
       { OPTLABEL label }
+  | ("let" kwdopchar dotsymbolchar *) as op { LETOP op }
+  | ("and" kwdopchar dotsymbolchar *) as op { ANDOP op }
   | (lowercase identchar *) as ident
     { LIDENT ident }
   | (lowercase_latin1 identchar_latin1 *) as ident

--- a/tests/test-dirs/locate/issue1398.t/issue1398.ml
+++ b/tests/test-dirs/locate/issue1398.t/issue1398.ml
@@ -1,0 +1,4 @@
+let (let++) x f = f x
+let (and++) a b = (a, b) ;;
+let ops = (let++), (and++) ;;
+let++ x = 3 and++ y = 4 in x + y

--- a/tests/test-dirs/locate/issue1398.t/run.t
+++ b/tests/test-dirs/locate/issue1398.t/run.t
@@ -1,0 +1,59 @@
+Test locating definition of let-based binding operator, from reified syntax:
+
+  $ $MERLIN single locate -position 3:11 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "*buffer*",
+      "pos": {
+        "line": 1,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }
+
+Test locating definition of and-based binding operator, from reified syntax:
+
+  $ $MERLIN single locate -position 3:20 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "*buffer*",
+      "pos": {
+        "line": 2,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }
+
+Test locating definition of let-based binding operator, from operator syntax:
+
+  $ $MERLIN single locate -position 4:0 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "*buffer*",
+      "pos": {
+        "line": 1,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }
+
+Test locating definition of and-based binding operator, from operator syntax:
+
+  $ $MERLIN single locate -position 4:12 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "*buffer*",
+      "pos": {
+        "line": 2,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/occurrences/issue1398.t/issue1398.ml
+++ b/tests/test-dirs/occurrences/issue1398.t/issue1398.ml
@@ -1,0 +1,4 @@
+let (let++) x f = f x
+let (and++) a b = (a, b) ;;
+let ops = (let++), (and++) ;;
+let++ x = 3 and++ y = 4 in x + y

--- a/tests/test-dirs/occurrences/issue1398.t/run.t
+++ b/tests/test-dirs/occurrences/issue1398.t/run.t
@@ -1,0 +1,99 @@
+Test finding occurrences of let-based binding operator, from reified syntax:
+
+  $ $MERLIN single occurrences -identifier-at 3:11 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 4
+        },
+        "end": {
+          "line": 1,
+          "col": 11
+        }
+      },
+      {
+        "start": {
+          "line": 3,
+          "col": 10
+        },
+        "end": {
+          "line": 3,
+          "col": 17
+        }
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 0
+        },
+        "end": {
+          "line": 4,
+          "col": 5
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+Test finding occurrences of and-based binding operator, from reified syntax:
+
+  $ $MERLIN single occurrences -identifier-at 3:20 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 4
+        },
+        "end": {
+          "line": 2,
+          "col": 11
+        }
+      },
+      {
+        "start": {
+          "line": 3,
+          "col": 19
+        },
+        "end": {
+          "line": 3,
+          "col": 26
+        }
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 12
+        },
+        "end": {
+          "line": 4,
+          "col": 17
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME -- this doesn't find anything right now
+Test finding occurrences of let-based binding operator, from operator syntax:
+
+  $ $MERLIN single occurrences -identifier-at 4:0 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }
+
+FIXME -- this doesn't find anything right now
+Test finding occurrences of and-based binding operator, from operator syntax:
+
+  $ $MERLIN single occurrences -identifier-at 4:12 ./issue1398.ml < ./issue1398.ml
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }


### PR DESCRIPTION
Find binding operator uses in Occurrence and their definitions in Locate (issue #1398)
Although Locate works from a position where the binding operator syntax is used, Occurrence does not but requires the position to indicate the reified (bracketed) operator.
