### PR TITLE
fix: wrap compiler-libs modules

### DIFF
--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -1,6 +1,10 @@
 (library
  (name merlin_analysis)
- (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils)
+ (flags
+  -open Ocaml_utils
+  -open Ocaml_parsing
+  -open Ocaml_typing
+  -open Merlin_utils)
  (libraries
   config
   merlin_specific

--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -1,14 +1,14 @@
 (library
  (name merlin_analysis)
- (flags -open Merlin_utils)
+ (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils)
  (libraries
   config
   merlin_specific
   merlin_extend
   merlin_kernel
   merlin_utils
-  parsing
+  ocaml_parsing
   preprocess
   query_protocol
-  typing
-  utils))
+  ocaml_typing
+  ocaml_utils))

--- a/src/extend/dune
+++ b/src/extend/dune
@@ -2,4 +2,5 @@
  (name      merlin_extend)
  (wrapped   false)
  (modules   (:standard \ extend_helper))
- (libraries parsing typing unix utils))
+ (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing)
+ (libraries ocaml_parsing ocaml_typing unix ocaml_utils))

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -7,7 +7,12 @@
 (library
  (name      query_commands)
  (modules   query_commands)
- (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils -open Merlin_analysis)
+ (flags
+  -open Ocaml_utils
+  -open Ocaml_parsing
+  -open Ocaml_typing
+  -open Merlin_utils
+  -open Merlin_analysis)
  (libraries
   merlin_utils
   merlin_kernel

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,19 +1,19 @@
 (library
  (name      query_protocol)
  (modules   query_protocol)
- (flags -open Merlin_utils)
- (libraries merlin_kernel merlin_utils parsing))
+ (flags -open Merlin_utils -open Ocaml_parsing)
+ (libraries merlin_kernel merlin_utils ocaml_parsing))
 
 (library
  (name      query_commands)
  (modules   query_commands)
- (flags -open Merlin_utils -open Merlin_analysis)
+ (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils -open Merlin_analysis)
  (libraries
   merlin_utils
   merlin_kernel
-  utils
-  parsing
-  typing
+  ocaml_utils
+  ocaml_parsing
+  ocaml_typing
   merlin_specific
   config
   merlin_analysis

--- a/src/frontend/ocamlmerlin/dune
+++ b/src/frontend/ocamlmerlin/dune
@@ -4,7 +4,12 @@
  (name ocamlmerlin_server)
  (package merlin)
  (public_name ocamlmerlin-server)
- (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils -open Merlin_analysis)
+ (flags
+  -open Ocaml_utils
+  -open Ocaml_parsing
+  -open Ocaml_typing
+  -open Merlin_utils
+  -open Merlin_analysis)
  (modules (:standard \ gen_ccflags))
  (libraries config yojson merlin_analysis merlin_kernel
             merlin_utils os_ipc ocaml_parsing query_protocol query_commands

--- a/src/frontend/ocamlmerlin/dune
+++ b/src/frontend/ocamlmerlin/dune
@@ -4,11 +4,11 @@
  (name ocamlmerlin_server)
  (package merlin)
  (public_name ocamlmerlin-server)
- (flags -open Merlin_utils -open Merlin_analysis)
+ (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils -open Merlin_analysis)
  (modules (:standard \ gen_ccflags))
  (libraries config yojson merlin_analysis merlin_kernel
-            merlin_utils os_ipc parsing query_protocol query_commands
-            typing utils))
+            merlin_utils os_ipc ocaml_parsing query_protocol query_commands
+            ocaml_typing ocaml_utils))
 
 (executable
  (name      gen_ccflags)

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -4,8 +4,8 @@
 (library
  (name merlin_kernel)
  (wrapped false)
- (flags -open Merlin_utils)
- (libraries config os_ipc parsing preprocess typing utils
+ (flags -open Ocaml_utils -open Merlin_utils -open Ocaml_parsing -open Ocaml_typing)
+ (libraries config os_ipc ocaml_parsing preprocess ocaml_typing ocaml_utils
             merlin_extend merlin_specific merlin_utils merlin_dot_protocol))
 
 (rule

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -4,7 +4,11 @@
 (library
  (name merlin_kernel)
  (wrapped false)
- (flags -open Ocaml_utils -open Merlin_utils -open Ocaml_parsing -open Ocaml_typing)
+ (flags
+  -open Ocaml_utils
+  -open Merlin_utils
+  -open Ocaml_parsing
+  -open Ocaml_typing)
  (libraries config os_ipc ocaml_parsing preprocess ocaml_typing ocaml_utils
             merlin_extend merlin_specific merlin_utils merlin_dot_protocol))
 

--- a/src/ocaml/merlin_specific/dune
+++ b/src/ocaml/merlin_specific/dune
@@ -1,5 +1,9 @@
 (library
   (name merlin_specific)
   (wrapped false)
-  (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils)
+  (flags
+   -open Ocaml_utils
+   -open Ocaml_parsing
+   -open Ocaml_typing
+   -open Merlin_utils)
   (libraries merlin_utils ocaml_parsing preprocess ocaml_typing ocaml_utils))

--- a/src/ocaml/merlin_specific/dune
+++ b/src/ocaml/merlin_specific/dune
@@ -1,5 +1,5 @@
 (library
   (name merlin_specific)
   (wrapped false)
-  (flags -open Merlin_utils)
-  (libraries merlin_utils parsing preprocess typing utils))
+  (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing -open Merlin_utils)
+  (libraries merlin_utils ocaml_parsing preprocess ocaml_typing ocaml_utils))

--- a/src/ocaml/parsing/dune
+++ b/src/ocaml/parsing/dune
@@ -2,8 +2,7 @@
 (rule (copy# ../../extend/extend_helper.mli extend_helper.mli))
 
 (library
-  (name parsing)
-  (wrapped false)
-  (flags -open Merlin_utils (:standard -w -9))
+  (name ocaml_parsing)
+  (flags -open Ocaml_utils -open Merlin_utils (:standard -w -9))
   (modules_without_implementation asttypes parsetree)
-  (libraries merlin_utils utils))
+  (libraries merlin_utils ocaml_utils))

--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -3,8 +3,8 @@
 (library
   (name preprocess)
   (wrapped false)
-  (flags -open Merlin_utils)
-  (libraries parsing utils merlin_utils))
+  (flags -open Ocaml_parsing -open Ocaml_utils -open Merlin_utils)
+  (libraries ocaml_parsing ocaml_utils merlin_utils))
 
 (menhir
  (modules parser_raw)

--- a/src/ocaml/typing/dune
+++ b/src/ocaml/typing/dune
@@ -1,6 +1,5 @@
 (library
-  (name typing)
-  (wrapped false)
-  (flags -open Merlin_utils (:standard -w -9))
+  (name ocaml_typing)
+  (flags -open Ocaml_utils -open Ocaml_parsing -open Merlin_utils (:standard -w -9))
   (modules_without_implementation annot outcometree)
-  (libraries merlin_utils parsing utils))
+  (libraries merlin_utils ocaml_parsing ocaml_utils))

--- a/src/ocaml/typing/dune
+++ b/src/ocaml/typing/dune
@@ -1,5 +1,9 @@
 (library
   (name ocaml_typing)
-  (flags -open Ocaml_utils -open Ocaml_parsing -open Merlin_utils (:standard -w -9))
+  (flags
+   -open Ocaml_utils
+   -open Ocaml_parsing
+   -open Merlin_utils
+   (:standard -w -9))
   (modules_without_implementation annot outcometree)
   (libraries merlin_utils ocaml_parsing ocaml_utils))

--- a/src/ocaml/utils/dune
+++ b/src/ocaml/utils/dune
@@ -1,6 +1,5 @@
 (library
-  (name utils)
-  (wrapped false)
+  (name ocaml_utils)
   (libraries config merlin_utils)
   (flags (-open Merlin_utils))
   (modules_without_implementation result_compat))


### PR DESCRIPTION
Allows loading things in utop and shouldn't increase the maintenance burden.

See the report in https://github.com/ocaml/ocaml-lsp/issues/557