### PR TITLE
test: flag `-alert` with `=` is not accepted by Merlin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ git version
     - fix handlink of ppx's under Windows (#1413)
     - locate: look for original source files before looking for preprocessed
       files (#1219 by @ddickstein, fixes #894)
+    - handle `=` syntax in compiler flags (#1409)
 
 merlin 4.4
 ==========

--- a/src/utils/marg.ml
+++ b/src/utils/marg.ml
@@ -76,9 +76,16 @@ let parse_all ~warning global_spec local_spec =
     match parse_one ~warning global_spec local_spec args global local with
     | Some (args, global, local) -> normal_parsing args global local
     | None -> match args with
-      | arg :: args ->
-        warning ("unknown flag " ^ arg);
-        resume_parsing args global local
+      | arg :: args -> begin
+        (* We split on the first '=' to check if the argument was
+           of the form name=value *)
+        try
+          let name, value = Misc.cut_at arg '=' in
+          normal_parsing (name::value::args) global local
+        with Not_found ->
+          warning ("unknown flag " ^ arg);
+          resume_parsing args global local
+        end
       | [] -> (global, local)
   and resume_parsing args global local =
     let args = match args with

--- a/tests/test-dirs/alerts.t/run.t
+++ b/tests/test-dirs/alerts.t/run.t
@@ -35,3 +35,51 @@
     "value": [],
     "notifications": []
   }
+
+FIXME Should be the same as with `-alert -deprecated`
+  $ cat > .merlin <<EOF
+  > S .
+  > B .
+  > FLG -nopervasives -alert=-deprecated
+  > EOF
+
+  $ $MERLIN single errors -filename main.ml < main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "type": "config",
+        "sub": [],
+        "valid": true,
+        "message": "unknown flag -alert=-deprecated"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 12
+        },
+        "type": "warning",
+        "sub": [],
+        "valid": true,
+        "message": "Alert deprecated: Lib.sqrt
+  I am deprecated"
+      }
+    ],
+    "notifications": []
+  }
+
+The compiler accept both
+  $ $OCAMLC -c main.ml
+  File "main.ml", line 2, characters 8-12:
+  2 | let x = sqrt 3.
+              ^^^^
+  Alert deprecated: Lib.sqrt
+  I am deprecated
+
+  $ $OCAMLC -alert -deprecated -c main.ml
+
+  $ $OCAMLC -alert=-deprecated -c main.ml

--- a/tests/test-dirs/alerts.t/run.t
+++ b/tests/test-dirs/alerts.t/run.t
@@ -36,7 +36,6 @@
     "notifications": []
   }
 
-FIXME Should be the same as with `-alert -deprecated`
   $ cat > .merlin <<EOF
   > S .
   > B .
@@ -46,29 +45,7 @@ FIXME Should be the same as with `-alert -deprecated`
   $ $MERLIN single errors -filename main.ml < main.ml
   {
     "class": "return",
-    "value": [
-      {
-        "type": "config",
-        "sub": [],
-        "valid": true,
-        "message": "unknown flag -alert=-deprecated"
-      },
-      {
-        "start": {
-          "line": 2,
-          "col": 8
-        },
-        "end": {
-          "line": 2,
-          "col": 12
-        },
-        "type": "warning",
-        "sub": [],
-        "valid": true,
-        "message": "Alert deprecated: Lib.sqrt
-  I am deprecated"
-      }
-    ],
+    "value": [],
     "notifications": []
   }
 


### PR DESCRIPTION
#1401 introduced support for the `-alert` option of the compiler however it seems that the compiler accept the syntax `-alert=-deprecated` while Merlin doesn't. This PR add a test illustrating that.

The issue arised in dune: ocaml/dune#5245

@nojb Looking at #1401 I am not sure of what the issue is since it mostly reuses compiler's functions. But maybe Merlin in general rejects the `<option>=<arg>` syntax for all command line arguments (@trefis ?)