### PR TITLE
Windows: fix ppx command output redirection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ git version
 
   + merlin binary
     - filter dups in source paths (#1218)
+    - Windows: fix ppx command output redirection (#????, follow-up to #1270)
 
 merlin 4.4
 ==========


### PR DESCRIPTION
The code introduced in #1270 switched from using `system()` to
`CreateProcess()` in order to not show a window for each execution of a
ppx. However, it kept `1>&2` which is shell syntax, leading to errors.

With this patch, we revert to `Sys.command` and appropriate quoting for
Unix systems, but on Windows we wrap `CreateProcess` and use the same
file descriptor for stdout and stderr to have the same redirection as
with the `system()` call.