### PR TITLE
Allow the use of dune-base configuration reader in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,10 +25,15 @@ Mon Jul 26 11:12:21 PM CET 2021
     - fix handling of record field expressions (#1375)
     - allow -pp to return an AST (#1394)
     - fix merlin crashing due to short-paths (#1334, fixes #1322)
+    - don't reset the environment when running merlin in single mode so that the
+      parent environement is forwarded the the child processes (#1425)
   + editor modes
     - update quick setup instructions for emacs (#1380, @ScriptDevil)
   + test suite
     - improve record field destruction testing (#1375)
+    - make `merlin-wrapper` check that the environement variable USE_DUNE_READER
+      is not set before creating a default `.merlin` file to allow tests to use
+      dune's configuration reader. (#1425)
 
 merlin 4.3.1
 ============

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -147,9 +147,12 @@ let run = function
         prerr_endline ("Exception: " ^ Printexc.to_string exn);
         1
 
-let run env wd args =
-  Os_ipc.merlin_set_environ env;
-  Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
+let run ~new_env wd args =
+  begin match new_env with
+  | Some env ->
+    Os_ipc.merlin_set_environ env;
+    Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()))
+  | None -> () end;
   let wd_msg = match wd with
     | None -> "No working directory specified"
     | Some wd ->

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -12,7 +12,7 @@ module Server = struct
   let process_request {Os_ipc. wd; environ; argv; context = _}  =
     match Array.to_list argv with
     | "stop-server" :: _ -> raise Exit
-    | args -> New_merlin.run environ (Some wd) args
+    | args -> New_merlin.run ~new_env:(Some environ) (Some wd) args
 
   let process_client client =
     let context = client.Os_ipc.context in
@@ -73,7 +73,7 @@ let main () =
   (* Setup env for extensions *)
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
   match List.tl (Array.to_list Sys.argv) with
-  | "single" :: args -> exit (New_merlin.run ("PATH=" ^ Unix.getenv "PATH" ^ "\000") None args)
+  | "single" :: args -> exit (New_merlin.run ~new_env:None None args)
   | "old-protocol" :: args -> Old_merlin.run args
   | ["server"; socket_path; socket_fd] -> Server.start socket_path socket_fd
   | ("-help" | "--help" | "-h" | "server") :: _ ->

--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -2,7 +2,13 @@
 
 export PATH=$(dirname dot-merlin-reader):$PATH
 
-touch .merlin && ocamlmerlin "$@" \
+# tests using the dune configuration reader should export the USE_DUNE_READER
+# environment variable. If not we write a generic `.merlin` file.
+if [ -z "$USE_DUNE_READER" ]; then
+  touch .merlin
+fi
+
+ocamlmerlin "$@" \
     | jq 'del(.timing)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \
     | sed -e 's:\\n:\


### PR DESCRIPTION
So far it was ankward to use the new dune-based configuration reader in the testsuite. The reason was that Merlin completely resets the environment and thus the `INSIDE_DUNE` variable was not forwarded to the spawned `.

This PR fixes that.
It might help to have a better testing story in #1219