### PR TITLE
Add prefix command to `merlin-locate` to open a new window.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ git version
     - fix superfluous break in error reporting (#1432)
   + editor modes
     - add module, module type, and class imenu items for emacs (#1244, @ivg)
+    - add prefix argument to force or prevent opening in a new buffer in locate
+      command (#1426, @panglesd)
   + test suite
     - cover locate calls on module aliases with and without dune
     - Add a test expliciting the interaction between locate and Dune's generated

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1527,10 +1527,16 @@ loading"
   (interactive "s> ")
   (merlin--locate-result (merlin-call-locate ident)))
 
-(defun merlin-locate ()
+(defun merlin-locate (prefix)
   "Locate the identifier under point"
-  (interactive)
-  (merlin--locate-result (merlin-call-locate)))
+  (interactive "P")
+  (cl-letf ((merlin-locate-in-new-window
+    (cond
+     ((equal prefix '(4)) 'never)
+     ((equal prefix '(16)) 'always)
+     (t 'merlin-locate-in-new-window)
+     )))
+    (merlin--locate-result (merlin-call-locate))))
 
 (defun merlin-locate-type ()
   "Locate the type of the expression under point."

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1534,8 +1534,7 @@ loading"
     (cond
      ((equal prefix '(4)) 'never)
      ((equal prefix '(16)) 'always)
-     (t 'merlin-locate-in-new-window)
-     )))
+     (t 'merlin-locate-in-new-window))))
     (merlin--locate-result (merlin-call-locate))))
 
 (defun merlin-locate-type ()


### PR DESCRIPTION
Currently, `merlin-locate` opens a new window if and only if the location is in another file.

However:
- When using `merlin-locate` several times in a row to find the definition we want, it can be annoying to have new windows erasing where we come from.
- Sometimes we want to keep the location we come from visible even if the definition is in the same file.

This PR gives the possibility to force a behavior, using the `prefix argument` mechanism:
- `C-u C-c C-l` force to stay in the same window, even if the cursor is moved to another file,
- `C-u C-u C-c C-l` force open another window, even if the cursor is moved the same file.

Other uses of the prefix defaults to the regular `C-c C-l`.