### PR TITLE
Fix superfluous break in error reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ git version
       files (#1219 by @ddickstein, fixes #894)
     - handle `=` syntax in compiler flags (#1409)
     - expose all destruct exceptions in the api (#1437)
+    - fix superfluous break in error reporting (#1432)
   + test suite
     - cover locate calls on module aliases with and without dune
     - Add a test expliciting the interaction between locate and Dune's generated

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -255,8 +255,7 @@ let json_of_error (error : Location.error) =
   in
   let loc = Location.loc_of_report error in
   let msg =
-    Location.print_main Format.str_formatter error;
-    String.trim (Format.flush_str_formatter ())
+    Format.asprintf "@[%a@]" Location.print_main error |> String.trim
   in
   let typ =
     match error.source with

--- a/tests/test-dirs/errors/error-node-line-break.t
+++ b/tests/test-dirs/errors/error-node-line-break.t
@@ -18,8 +18,7 @@
         "type": "typer",
         "sub": [],
         "valid": true,
-        "message": "test with several
-  words"
+        "message": "test with several words"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/errors/error-node-line-break.t
+++ b/tests/test-dirs/errors/error-node-line-break.t
@@ -1,0 +1,26 @@
+  $ cat >test.ml <<EOF
+  > [%%ocaml.error "test with several words"]
+  > EOF
+
+  $ $MERLIN single errors -filename test.ml <test.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 3
+        },
+        "end": {
+          "line": 1,
+          "col": 14
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "test with several
+  words"
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Following a report by @panglesd this PR fix an issue with the formating of errors.

The following node:
` [%%ocaml.error "test with several words"]`

is reported by the compiler as:
`Error: test with several words`

but by merlin as:
```
test with several
words
```

The difference is that Merlin uses `Location.print_main` to produce the string while the compiler uses `Location.print_report`. The latter function wrap the printing of the `main` part of the report in a pretty-printing box while the former doesn't.
This PR wraps the output of `Location.print_main` in a pp box.