### PR TITLE
Revert "fix #553"

### DIFF
--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -237,7 +237,7 @@ function! s:ShowTypeEnclosing(type)
 
   let g:merlin_latest_type = a:type['type']
 
-  if g:merlin_type_history_height <= 0 || (!has("nvim") && (v:version <= 703 || !has("patch-7.4.424")))
+  if g:merlin_type_history_height <= 0 || v:version <= 703 || !has("patch-7.4.424")
     echo a:type['type'] . a:type['tail_info']
     return
   endif

--- a/vim/merlin/autoload/merlin_type.vim
+++ b/vim/merlin/autoload/merlin_type.vim
@@ -64,15 +64,6 @@ function! s:RecordType(type)
 
   " vimscript can't append to a buffer without a refresh (?!)
   MerlinPy << EOF
-
-# Vim cursor is a global state that will leak.
-# Nvim will complain the cursor is outside of buffer (using cursor from
-# current buffer in the type buffer).
-# So put it to origin and restore it later.
-cw = vim.current.window
-cursor = cw.cursor
-cw.cursor = (1,0)
-
 idx = int(vim.eval("g:merlin_type_history"))
 typ = vim.eval("a:type")
 buf = None
@@ -95,7 +86,7 @@ else:
 
 # Note that this leaves a blank line at the beginning of the buffer, but
 # it is apparently the desired behavior.
-cw.cursor = cursor
+
 EOF
 
   call winrestview(l:view)


### PR DESCRIPTION
This reverts commit 7efcb2265ed6525bf330666713f70cc83b32ce66.

The problem reported in #553 is not reproducible when this commit is reverted,
so it's likely that the underlying Neovim bug that caused it has been resolved.
The fix introduces a problem where the window is scrolled (#1221), so this
commit reverts it.