### PR TITLE
Expose the Ill_typed exception for pkgs using Merlin as a library.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ git version
     - locate: look for original source files before looking for preprocessed
       files (#1219 by @ddickstein, fixes #894)
     - handle `=` syntax in compiler flags (#1409)
+    - expose all destruct exceptions in the api (#1437)
   + test suite
     - cover locate calls on module aliases with and without dune
 

--- a/src/analysis/destruct.mli
+++ b/src/analysis/destruct.mli
@@ -73,6 +73,7 @@
 exception Not_allowed of string
 exception Useless_refine
 exception Nothing_to_do
+exception Ill_typed
 exception Wrong_parent of string
 
 module Path_utils : sig


### PR DESCRIPTION
This is required by OCaml-LSP to improve error handling. 
See https://github.com/ocaml/ocaml-lsp/issues/617#issuecomment-1035508467

cc @ulugbekna 
