### PR TITLE
Enable type-on-hover functionality in Vim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ git version
     - add module, module type, and class imenu items for emacs (#1244, @ivg)
     - add prefix argument to force or prevent opening in a new buffer in locate
       command (#1426, @panglesd)
-		- add type-on-hover functionality for vim (#1439)
+    - add type-on-hover functionality for vim (#1439, @nilsbecker)
   + test suite
     - cover locate calls on module aliases with and without dune
     - Add a test expliciting the interaction between locate and Dune's generated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ git version
     - add module, module type, and class imenu items for emacs (#1244, @ivg)
     - add prefix argument to force or prevent opening in a new buffer in locate
       command (#1426, @panglesd)
+		- add type-on-hover functionality for vim (#1439)
   + test suite
     - cover locate calls on module aliases with and without dune
     - Add a test expliciting the interaction between locate and Dune's generated

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -644,15 +644,14 @@ def vim_case_analysis():
 
     vim_type_reset()
 
-def vim_type_enclosing():
+def type_enclosing_at_pos(to_line, to_col):
     global enclosing_types
     global current_enclosing
     vim_type_reset()
     try:
-        to_line, to_col = vim.current.window.cursor
         enclosing_types = command2(
                 ["type-enclosing",
-                 "-position", fmtpos((to_line,to_col)),
+                 "-position", fmtpos((to_line, to_col)),
                  "-index", "0"
                 ],
                 track_verbosity=True
@@ -669,6 +668,18 @@ def vim_type_enclosing():
     except MerlinExc as e:
         try_print_error(e)
         return '{}'
+
+def vim_type_enclosing_at_mouse():
+    bufnr = vim.vvars['beval_bufnr']
+    if bufnr != vim.current.buffer.number:
+        return '{}'
+    line = vim.vvars['beval_lnum']
+    col = vim.vvars['beval_col']
+    return type_enclosing_at_pos(line, col)
+
+def vim_type_enclosing():
+    to_line, to_col = vim.current.window.cursor
+    return type_enclosing_at_pos(to_line, to_col)
 
 def move_cursor_and_type(line, col):
     vim.current.window.cursor = (line, col)

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -270,6 +270,16 @@ function! merlin#TypeOfSel()
   call merlin#TypeOf(s:get_visual_selection())
 endfunction
 
+function! merlin#TypeAtBalloon()
+	MerlinPy vim.command("let l:type = " + merlin.vim_type_enclosing_at_mouse())
+	return get(l:type, 'type', '')
+endfunction
+
+function! merlin#ShowTypeAtBalloon()
+	echo merlin#TypeAtBalloon()
+	return ''
+endfunction
+
 function! merlin#PolaritySearch(debug,query)
   let s:search_result = []
   MerlinPy merlin.vim_polarity_search(vim.eval("a:query"), "s:search_result")

--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -328,6 +328,21 @@ Possible values are:
 ==============================================================================
 EXTRAS                                                         *merlin-extras*
 
+Type-on-hover~
+
+To display the type of the ocaml expression at the current mouse cursor, use Vim's |ballon-eval|
+functionality: >
+    au FileType ocaml setlocal balloonexpr=merlin#TypeAtBalloon()
+displays the type in a small popup. Alternatively, >
+    au FileType ocaml setlocal balloonexpr=merlin#ShowTypeAtBalloon()
+displays the type in the status line, similar to |MerlinTypeOf|. To switch
+this feature on, use >
+    set balloonveval
+when using a GUI version of Vim or >
+    set balloonvevalterm 
+in a terminal.
+
+
 Syntastic ~
 
 To use merlin with syntastic set the following option: >
@@ -350,7 +365,7 @@ for automatic completion can be enabled with: >
 Neocomplete ~
 
 Integration with [neocomplete](https://github.com/Shougo/neocomplete) for
-automatic completion can be enabled with:
+automatic completion can be enabled with: >
 
     if !exists('g:neocomplete#sources#omni#input_patterns')
       let g:neocomplete#sources#omni#input_patterns = {}


### PR DESCRIPTION
This PR refactors some functions in merlin.py to allow passing the mouse cursor position as input. In this way vim's balloonexpr functionality can be used to show the type at the mouse cursor. Hopefully this will be handy for browsing a codebase, where one does not necessarily wish to navigate the cursor to various places by keyboard commands.

Beware: the actualy popup window displayed by balloon-eval seems to be a bit flaky. I tested on two macos machines with identical MacVim version and identical .vimrc. The popup shows up only on one of the two. That is not a problem of merlin, as it fails also for the ALE plugin. The version with type display in the status line (or actually, below the status line? what is the bottom line of the screen called?) works in any case, so that should be a workable solution for everyone.

I'm happy for corrections, in particular also for the doc text.