### PR TITLE
Remove unused module and dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ git version
     - expose all destruct exceptions in the api (#1437)
     - fix superfluous break in error reporting (#1432)
     - recognise binding operators in locate and occurrences (#1398, @mattiase)
+    - remove dependency on Result (#1441, @kit-ty-kate)
   + editor modes
     - fix an issue in Neovim where the current line jumps to the top of the
       window on repeated calls to `MerlinTypeOf` (#1433 by @ddickstein, fixes

--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -16,7 +16,6 @@ depends: [
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
   "csexp" {>= "1.2.3"}
-  "result" {>= "1.5"}
 ]
 description:
   "Helper process: reads .merlin files and gives the normalized content to merlin"

--- a/merlin.opam
+++ b/merlin.opam
@@ -17,7 +17,6 @@ depends: [
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
-  "result" {>= "1.5"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/src/dot-merlin/dot-protocol/dune
+++ b/src/dot-merlin/dot-protocol/dune
@@ -1,4 +1,4 @@
 (library
  (name merlin_dot_protocol)
  (wrapped false)
- (libraries merlin_utils csexp result))
+ (libraries merlin_utils csexp))

--- a/src/ocaml/utils/dune
+++ b/src/ocaml/utils/dune
@@ -1,5 +1,4 @@
 (library
   (name ocaml_utils)
   (libraries config merlin_utils)
-  (flags (-open Merlin_utils))
-  (modules_without_implementation result_compat))
+  (flags (-open Merlin_utils)))

--- a/src/ocaml/utils/lazy_backtrack.ml
+++ b/src/ocaml/utils/lazy_backtrack.ml
@@ -40,7 +40,6 @@ let log () =
   ref Nil
 
 let force_logged log f x =
-  let open! Result_compat in (* merlin *)
   match !x with
   | Done x -> x
   | Raise e -> raise e

--- a/src/ocaml/utils/lazy_backtrack.mli
+++ b/src/ocaml/utils/lazy_backtrack.mli
@@ -1,5 +1,3 @@
-open! Result_compat (* merlin *)
-
 type ('a,'b) t
 
 type log

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -2,5 +2,5 @@
 
 (library
  (name merlin_utils)
- (libraries str yojson unix result)
+ (libraries str yojson unix)
  (foreign_stubs (language c) (names platform_misc)))

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -339,7 +339,7 @@ module Option = struct
 end
 
 module Result = struct
-  type ('a, 'e) t = ('a, 'e) Result.result =
+  type ('a, 'e) t = ('a, 'e) result =
   | Ok of 'a
   | Error of 'e
 end


### PR DESCRIPTION
As far as I can see, the `result` compatibility package is not required anymore