### PR TITLE
Locate infix operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ unreleased
 
   + merlin binary
     - Update internal typer to match OCaml 4.14.1 release. (#1557)
+    - fix locate calls on infix operators (#1445, fixes #949)
 
 merlin 4.7
 ==========

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -794,7 +794,7 @@ let from_path ~config ~env ~namespace ml_or_mli path =
 let from_string ~config ~env ~local_defs ~pos ?namespaces switch path =
   File_switching.reset ();
   let browse = Mbrowse.of_typedtree local_defs in
-  let lid = Longident.parse path in
+  let lid = Misc_utils.parse_longident path in
   let ident, is_label = Longident.keep_suffix lid in
   match
     match namespaces with

--- a/src/analysis/misc_utils.ml
+++ b/src/analysis/misc_utils.ml
@@ -48,7 +48,6 @@ end = struct
       maybe_replace_name ?name (Untypeast.lident_of_path path)
 end
 
-
 let parenthesize_name name =
   (* Qualified operators need parentheses *)
   if name = "" || not (Oprint.parenthesized_ident name) then name else (
@@ -57,3 +56,10 @@ let parenthesize_name name =
     else
       "(" ^ name ^ ")"
   )
+
+let parse_longident name =
+  let l =
+    if name.[String.length name - 1] = '.' then [name]
+    else String.split_on_char ~sep:'.' name
+  in
+  Longident.unflatten l |> Option.get

--- a/src/analysis/misc_utils.mli
+++ b/src/analysis/misc_utils.mli
@@ -22,3 +22,7 @@ end
 
 (* Add parenthesis to qualified operators *)
 val parenthesize_name : string -> string
+
+(* Uses [Longident.unflatten] to parse a longident while preserving infix
+   identifiers *)
+val parse_longident : string -> Longident.t

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -84,7 +84,7 @@ let from_reconstructed ~nodes ~cursor ~verbosity exprs =
   let get_context lident =
     Context.inspect_browse_tree
       ~cursor
-      (Longident.parse lident)
+      (Misc_utils.parse_longident lident)
       [nodes]
   in
 

--- a/tests/test-dirs/locate/issue949.t/issue949.ml
+++ b/tests/test-dirs/locate/issue949.t/issue949.ml
@@ -1,2 +1,0 @@
-module A = struct let (+.) a b = a +. b end
-let f x = A.(x +. 1.)

--- a/tests/test-dirs/locate/issue949.t/run.t
+++ b/tests/test-dirs/locate/issue949.t/run.t
@@ -1,8 +1,20 @@
 This test is for testing the behavior of identifiers with a . in them:
 
-  $ $MERLIN single locate -look-for ml -position 2:16 ./issue949.ml < ./issue949.ml
+  $ cat >issue949.ml <<EOF
+  > module A = struct let (+.) a b = a +. b end
+  > let f x = A.(x +. 1.)
+  > EOF
+
+
+  $ $MERLIN single locate -look-for ml -position 2:16 ./issue949.ml <./issue949.ml
   {
     "class": "return",
-    "value": "Not in environment ''",
+    "value": {
+      "file": "*buffer*",
+      "pos": {
+        "line": 1,
+        "col": 22
+      }
+    },
     "notifications": []
   }


### PR DESCRIPTION
*~Two~ Three years later*

This fixes #949 

In #949 the issue was identified as `Longident.parse` returning wrong lids for infix operators. A PR was merged in the compiler to expose the true longident parser.

In fact this PR relies on `Longident.unflatten`.

~~This PR uses that parser to parse longidents produced by `reconstruct_identifier`.
However for usages of an infix operator the reconstructed identifier does not have surrounding parenthesis and the parser fails on these.

I chose to simply rerun the parser with added parenthesis if it fails, and fallback on `Longident.parse` if it fails again.
We probably could have a more deterministic style here, but I am not sure if that is worth the effort... @trefis ?~~