### PR TITLE
Test Emacs parts on the released 28.1 as well

### DIFF
--- a/.github/workflows/emacs-lint.yml
+++ b/.github/workflows/emacs-lint.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'emacs/**'
+      - '**/emacs-lint.yml'
   pull_request:
     paths:
       - 'emacs/**'
+      - '**/emacs-lint.yml'
 
 jobs:
   build:

--- a/.github/workflows/emacs-lint.yml
+++ b/.github/workflows/emacs-lint.yml
@@ -21,7 +21,8 @@ jobs:
           #- 26.2
           #- 26.3
           #- 27.1
-          - 27.2
+          - '27.2'
+          - '28.2'
           - snapshot
         # include:
         #   - emacs_version: 24.1

--- a/.github/workflows/emacs-lint.yml
+++ b/.github/workflows/emacs-lint.yml
@@ -16,23 +16,12 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          #- 25.1
-          #- 25.2
-          #- 25.3
-          #- 26.1
-          #- 26.2
-          #- 26.3
-          #- 27.1
           - '27.2'
           - '28.2'
           - snapshot
-        # include:
-        #   - emacs_version: 24.1
-        #     lint_ignore: 1
-        #   - emacs_version: 24.2
-        #     lint_ignore: 1
     env:
-      EMACS_LINT_IGNORE: ${{ matrix.lint_ignore }}
+      EMACS_PACKAGE_LINT_IGNORE: ${{ matrix.package_lint_ignore }}
+      EMACS_BYTECOMP_WARN_IGNORE: ${{ matrix.bytecomp_warn_ignore }}
     steps:
     - uses: purcell/setup-emacs@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
       - 'emacs/**'
       - 'vim/**'
+      - '**/emacs-lint.yml'
   pull_request:
     branches: [ master ]
     paths-ignore:
@@ -23,6 +24,7 @@ on:
       - 'doc/**'
       - 'emacs/**'
       - 'vim/**'
+      - '**/emacs-lint.yml'
   schedule:
     - cron: '0 12 */6 * *'
 

--- a/emacs/merlin-ac.el
+++ b/emacs/merlin-ac.el
@@ -1,4 +1,4 @@
-;;; merlin-ac.el --- Merlin and auto-complete integration.   -*- coding: utf-8; lexical-binding: t -*-
+;;; merlin-ac.el --- Merlin and auto-complete integration   -*- coding: utf-8; lexical-binding: t -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Simon Castellan <simon.castellan(_)iuwt.fr>

--- a/emacs/merlin-cap.el
+++ b/emacs/merlin-cap.el
@@ -1,4 +1,4 @@
-;;; merlin-cap.el --- Merlin and completion-at-point integration.   -*- coding: utf-8; lexical-binding: t -*-
+;;; merlin-cap.el --- Merlin and completion-at-point integration   -*- coding: utf-8; lexical-binding: t -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Simon Castellan <simon.castellan(_)iuwt.fr>

--- a/emacs/merlin-company.el
+++ b/emacs/merlin-company.el
@@ -88,7 +88,7 @@
 
 ;; Public functions
 ;;;###autoload
-(defun merlin-company-backend (command &optional arg &rest ignored)
+(defun merlin-company-backend (command &optional arg &rest _ignored)
   (interactive (list 'interactive))
   (when merlin-mode
     (cl-case command

--- a/emacs/merlin-company.el
+++ b/emacs/merlin-company.el
@@ -1,4 +1,4 @@
-;;; merlin-company.el --- Merlin and company mode integration.   -*- coding: utf-8; lexical-binding: t -*-
+;;; merlin-company.el --- Merlin and company mode integration   -*- coding: utf-8; lexical-binding: t -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Simon Castellan <simon.castellan(_)iuwt.fr>

--- a/emacs/merlin-iedit.el
+++ b/emacs/merlin-iedit.el
@@ -1,4 +1,4 @@
-;;; merlin-iedit.el --- Merlin and iedit integration.   -*- coding: utf-8; lexical-binding: t -*-
+;;; merlin-iedit.el --- Merlin and iedit integration   -*- coding: utf-8; lexical-binding: t -*-
 ;; Licensed under the MIT license.
 
 ;; Author: Simon Castellan <simon.castellan(_)iuwt.fr>
@@ -63,4 +63,4 @@ merlin-iedit-occurrences."
           (message r))))))
 
 (provide 'merlin-iedit)
-;;; merlin.el ends here
+;;; merlin-iedit.el ends here

--- a/emacs/merlin-imenu.el
+++ b/emacs/merlin-imenu.el
@@ -1,4 +1,4 @@
-;;; merlin-imenu.el --- Merlin and imenu integration.   -*- coding: utf-8; lexical-binding: t -*-
+;;; merlin-imenu.el --- Merlin and imenu integration   -*- coding: utf-8; lexical-binding: t -*-
 ;; Licensed under the MIT license.
 
 ;; Author: tddsg (Ta Quang Trung)
@@ -8,7 +8,6 @@
 ;;   - v0.2: 27 April 2017
 ;;   - v0.3: 21 August 2019
 ;; Keywords: ocaml, imenu, merlin
-;; URL:
 
 (require 'imenu)
 (require 'subr-x)

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -219,7 +219,7 @@ merlin-locate, see `merlin-locate-in-new-window').")
 
 (defvar-local merlin-buffer-configuration nil
   "An association list describing the configuration of merlin binary for the
-current buffer.  Customize `merlin-configuration-function` to initialize it.
+current buffer.  Customize `merlin-configuration-function' to initialize it.
 The association list can contain the following optional keys:
 - `flags': extra flags to give merlin
 
@@ -992,7 +992,7 @@ prefix of `bar' is `'."
 
 (defun merlin-complete (ident)
   "Return the data for completion of IDENT, i.e. a list of tuples of the form
-  '(NAME TYPE KIND INFO)."
+  (NAME TYPE KIND INFO)."
   (setq-local merlin--dwimed nil)
   (let* ((merlin-verbosity-context t) ; increase verbosity level if necessary
          (ident- (merlin-completion-split-ident ident))
@@ -1332,8 +1332,8 @@ strictly within, or nil if there is no such element."
   (merlin-call "holes"))
 
 (defun merlin--first-hole-aux (holes current-point comp)
-  "Returns the first `hole` of the list such that
-    `(funcall comp hole current-point)`"
+  "Returns the first HOLE of the list such that
+    (funcall comp HOLE current-point) is true."
   (when holes
     (let* ((head (car holes))
            (tail (cdr holes))
@@ -1344,8 +1344,8 @@ strictly within, or nil if there is no such element."
         (merlin--first-hole-aux tail current-point comp)))))
 
 (defun merlin--first-hole (holes current-point comp)
-  "Returns the first `hole` of the list that such that
-    `(funcall comp hole current-point)`. If no hole match
+  "Returns the first HOLE of the list that such that
+    (funcall comp HOLE current-point) is true. If no hole match
     that condition the first one of the list is returned."
   (let ((hole (merlin--first-hole-aux holes current-point comp)))
     (if hole hole (car holes))))
@@ -1645,7 +1645,7 @@ Empty string defaults to jumping to all these."
   (merlin--goto-file-and-point (merlin-call-jump target)))
 
 (defun merlin-call-phrase (target)
-  "Move to next phrase (TARGET = 'next) or previous phrase (TARGET = 'prev)"
+  "Move to next phrase (TARGET = `next') or previous phrase (TARGET = `prev')."
   (if (or (not target) (equal target ""))
       (setq target "fun let module match"))
   (let ((result (merlin-call "phrase"
@@ -1798,9 +1798,9 @@ Empty string defaults to jumping to all these."
   (save-excursion
     (merlin-occurrences-populate-buffer lst)
     (cl-case merlin-occurrences-show-buffer
-      ('same
+      (same
        (switch-to-buffer (merlin--get-occ-buff)))
-      ('other
+      (other
        (switch-to-buffer-other-window (merlin--get-occ-buff)))
       (t nil))))
 
@@ -1821,7 +1821,7 @@ Empty string defaults to jumping to all these."
 ;;;;;;;;;;;;;;;;;;;
 
 (defun merlin--refactor-open (mode)
-  "Refactor open statement under cursor. mode can be 'qualify or 'unqualify"
+  "Refactor open statement under cursor. mode can be `qualify' or `unqualify'."
   (save-excursion
     (dolist (occurrence (nreverse (merlin-call
                                    "refactor-open"


### PR DESCRIPTION
28.1 was recently released; `snapshot` tracks the development version (with some lag).
Oh, and `28.1` in YAML is a number so I prefer the quotes to make it a string just in case.
