### PR TITLE
Make merlin libraries public and wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ External contributors have implemented modes for more editors:
 - [nuclide for Atom](https://nuclide.io/) includes Merlin support
 - [Sublime Text 3](https://github.com/cynddl/sublime-text-merlin)
 
+
+Merlin as a library
+===================
+
+Merlin can also be used a library. Exemplary projects that use Merlin's libraries are:
+
+- [OCaml LSP](https://github.com/ocaml/ocaml-lsp) - The official OCaml's Language Server Protocol implementation
+
+If you're building editor tools, you might also want to use Merlin as a library!
+
+Note, however, that Merlin's public API is not stable and we don't garentee backward-compatibility between releases.
+If you're a Merlin user and depend on a public API, we recommend that you contact us or open an issue.
+
 Next steps
 ==========
 

--- a/README.md
+++ b/README.md
@@ -158,14 +158,14 @@ External contributors have implemented modes for more editors:
 Merlin as a library
 ===================
 
-Merlin can also be used a library. Exemplary projects that use Merlin's libraries are:
+Merlin can also be used as a library. Some projects already rely on this:
 
 - [OCaml LSP](https://github.com/ocaml/ocaml-lsp) - The official OCaml's Language Server Protocol implementation
 
 If you're building editor tools, you might also want to use Merlin as a library!
 
-Note, however, that Merlin's public API is not stable and we don't garentee backward-compatibility between releases.
-If you're a Merlin user and depend on a public API, we recommend that you contact us or open an issue.
+Note, however, that Merlin's public API is not stable and we don't guarantee backward-compatibility between releases.
+If you're a Merlin user and depend on our public API, we recommend that you contact us or open an issue.
 
 Next steps
 ==========

--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -1,5 +1,6 @@
 (library
  (name merlin_analysis)
+ (public_name merlin.analysis)
  (flags
   -open Ocaml_utils
   -open Ocaml_parsing
@@ -7,9 +8,10 @@
   -open Ocaml_typing
   -open Merlin_utils
   -open Merlin_specific
+  -open Merlin_extend
   -open Merlin_kernel)
  (libraries
-  config
+  merlin_config
   merlin_specific
   merlin_extend
   merlin_kernel

--- a/src/config/dune
+++ b/src/config/dune
@@ -5,6 +5,6 @@
           (run %{ocaml} gen_config.ml %{ocaml_version}))))
 
 (library
- (name config)
- (wrapped false)
+ (name merlin_config)
+ (public_name merlin.config)
  (modules merlin_config))

--- a/src/dot-merlin/dot-protocol/dune
+++ b/src/dot-merlin/dot-protocol/dune
@@ -1,3 +1,4 @@
 (library
  (name merlin_dot_protocol)
+ (public_name dot-merlin-reader.merlin_dot_protocol)
  (libraries merlin_utils csexp))

--- a/src/extend/dune
+++ b/src/extend/dune
@@ -1,6 +1,6 @@
 (library
  (name      merlin_extend)
- (wrapped   false)
+ (public_name      merlin.extend)
  (modules   (:standard \ extend_helper))
  (flags -open Ocaml_utils -open Ocaml_parsing -open Ocaml_typing)
  (libraries ocaml_parsing ocaml_typing unix ocaml_utils))

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,16 +1,20 @@
 (library
- (name      query_protocol)
- (modules   query_protocol)
+ (name        query_protocol)
+ (public_name merlin.query_protocol)
+ (modules     query_protocol)
  (flags -open Merlin_utils -open Merlin_kernel -open Ocaml_parsing -open Merlin_kernel)
  (libraries merlin_kernel merlin_utils ocaml_parsing))
 
 (library
- (name      query_commands)
- (modules   query_commands)
+ (name        query_commands)
+ (public_name merlin.query_commands)
+ (modules     query_commands)
  (flags
   -open Ocaml_utils
   -open Ocaml_parsing
   -open Ocaml_typing
+  -open Merlin_kernel
+  -open Merlin_specific
   -open Merlin_utils
   -open Merlin_specific
   -open Merlin_analysis
@@ -22,6 +26,6 @@
   ocaml_parsing
   ocaml_typing
   merlin_specific
-  config
+  merlin_config
   merlin_analysis
   query_protocol))

--- a/src/frontend/ocamlmerlin/dune
+++ b/src/frontend/ocamlmerlin/dune
@@ -8,11 +8,12 @@
   -open Ocaml_utils
   -open Ocaml_parsing
   -open Ocaml_typing
+  -open Merlin_kernel
   -open Merlin_utils
   -open Merlin_analysis
   -open Merlin_kernel)
  (modules (:standard \ gen_ccflags))
- (libraries config yojson merlin_analysis merlin_kernel
+ (libraries merlin_config yojson merlin_analysis merlin_kernel
             merlin_utils os_ipc ocaml_parsing query_protocol query_commands
             ocaml_typing ocaml_utils))
 

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -3,14 +3,16 @@
 
 (library
  (name merlin_kernel)
+ (public_name merlin.kernel)
  (flags
   -open Ocaml_utils
   -open Merlin_utils
   -open Ocaml_parsing
   -open Ocaml_preprocess
   -open Ocaml_typing
-  -open Merlin_specific)
- (libraries config os_ipc ocaml_parsing ocaml_preprocess ocaml_typing ocaml_utils
+  -open Merlin_specific
+  -open Merlin_extend)
+ (libraries merlin_config os_ipc ocaml_parsing ocaml_preprocess ocaml_typing ocaml_utils
             merlin_extend merlin_specific merlin_utils merlin_dot_protocol))
 
 (rule

--- a/src/ocaml/merlin_specific/dune
+++ b/src/ocaml/merlin_specific/dune
@@ -1,9 +1,11 @@
 (library
   (name merlin_specific)
+  (public_name merlin.specific)
   (flags
    -open Ocaml_utils
    -open Ocaml_parsing
    -open Ocaml_preprocess
    -open Ocaml_typing
+   -open Ocaml_preprocess
    -open Merlin_utils)
   (libraries merlin_utils ocaml_parsing ocaml_preprocess ocaml_typing ocaml_utils))

--- a/src/ocaml/parsing/dune
+++ b/src/ocaml/parsing/dune
@@ -3,6 +3,7 @@
 
 (library
   (name ocaml_parsing)
+  (public_name merlin.ocaml_parsing)
   (flags -open Ocaml_utils -open Merlin_utils (:standard -w -9))
   (modules_without_implementation asttypes parsetree)
   (libraries merlin_utils ocaml_utils))

--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -2,6 +2,7 @@
 
 (library
   (name ocaml_preprocess)
+  (public_name merlin.ocaml_preprocess)
   (flags -open Ocaml_parsing -open Ocaml_utils -open Merlin_utils)
   (libraries ocaml_parsing ocaml_utils merlin_utils))
 

--- a/src/ocaml/typing/dune
+++ b/src/ocaml/typing/dune
@@ -1,5 +1,6 @@
 (library
   (name ocaml_typing)
+  (public_name merlin.ocaml_typing)
   (flags
    -open Ocaml_utils
    -open Ocaml_parsing

--- a/src/ocaml/utils/dune
+++ b/src/ocaml/utils/dune
@@ -1,4 +1,5 @@
 (library
   (name ocaml_utils)
-  (libraries config merlin_utils)
+  (public_name merlin.ocaml_utils)
+  (libraries merlin_config merlin_utils)
   (flags (-open Merlin_utils)))

--- a/src/platform/dune
+++ b/src/platform/dune
@@ -1,3 +1,4 @@
 (library
  (name os_ipc)
+ (public_name merlin.os_ipc)
  (foreign_stubs (language c) (names os_ipc_stub)))

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -2,5 +2,6 @@
 
 (library
  (name merlin_utils)
+ (public_name merlin.utils)
  (libraries str yojson unix)
  (foreign_stubs (language c) (names platform_misc)))

--- a/tests/dune
+++ b/tests/dune
@@ -8,5 +8,6 @@
  (applies_to :whole_subtree)
  (deps
   %{bin:merlin-wrapper}
-  (package merlin)
-  (package dot-merlin-reader)))
+  %{bin:ocamlmerlin-server}
+  %{bin:ocamlmerlin}
+  %{bin:dot-merlin-reader}))


### PR DESCRIPTION
Alternative to https://github.com/ocaml/merlin/pull/1448 and https://github.com/ocaml/merlin/pull/1172 to make the libraries public and wrap them under a single top-level module.