### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/dot-merlin/dune
+++ b/src/dot-merlin/dune
@@ -2,4 +2,4 @@
  (package dot-merlin-reader)
  (name dot_merlin_reader)
  (public_name dot-merlin-reader)
- (libraries findlib merlin-lib.utils merlin-lib.dot_protocol))
+ (libraries findlib merlin-lib.utils merlin-lib.dot_protocol str unix))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.