### PR TITLE
use unquoted merlin-locate-in-new-window with merlin-locate

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1582,7 +1582,7 @@ loading"
     (cond
      ((equal prefix '(4)) 'never)
      ((equal prefix '(16)) 'always)
-     (t 'merlin-locate-in-new-window))))
+     (t merlin-locate-in-new-window))))
     (merlin--locate-result (merlin-call-locate))))
 
 (defun merlin-locate-type ()


### PR DESCRIPTION
close #1460 

when calling `merlin-locate`, if there was no prefix set, then `merlin-locate-in-new-window` was set to `'merlin-locate-in-new-window` rather than the actual value