### PR TITLE
Fix `merlin-locate-in-new-window` being ignored

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1582,7 +1582,7 @@ loading"
     (cond
      ((equal prefix '(4)) 'never)
      ((equal prefix '(16)) 'always)
-     (t 'merlin-locate-in-new-window))))
+     (t merlin-locate-in-new-window))))
     (merlin--locate-result (merlin-call-locate))))
 
 (defun merlin-locate-type ()


### PR DESCRIPTION
Fixes the bug reported in #1460 and introduced in #1426, where the variable `merlin-locate-in-new-window` is ignored.