### PR TITLE
Use the Yojson 2.0 `Seq` API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ unreleased
       @kit-ty-kate)
     - Attempt at finding the 'real' capitalization of files on windows (#1462 by
       @mlasson)
+    - Use newer `Seq`-based API of Yojson 2.0, avoiding the need for the
+      deprecated `Stream` module (#1475 by @Leonidas-from-XIV)
 
 merlin 4.5
 ==========

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ features.
 Compilation
 -----------
 
-Dependencies: ocamlfind, yojson >= 1.6.0, dune >= 2.7.
+Dependencies: ocamlfind, yojson >= 2.0.0, dune >= 2.7.
 
 ```shell
 dune build -p dot-merlin-reader,merlin

--- a/merlin.opam
+++ b/merlin.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {= version}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
 ]
 conflicts: [

--- a/src/frontend/ocamlmerlin/old/old_IO.ml
+++ b/src/frontend/ocamlmerlin/old/old_IO.ml
@@ -314,8 +314,7 @@ let make_json ?(on_read=ignore) ~input ~output () =
       read buf len
   in
   let lexbuf  = Lexing.from_function read in
-  let input   = Yojson.Basic.(stream_from_lexbuf (init_lexer ()) lexbuf) in
-  let input () = try Some (Stream.next input) with Stream.Failure -> None in
+  let input   = Seq.to_dispenser (Yojson.Basic.(seq_from_lexbuf (init_lexer ()) lexbuf)) in
   let output  = Unix.out_channel_of_descr output in
   let output' = Yojson.Basic.to_channel output in
   let output json =


### PR DESCRIPTION
Yojson 2.0 is dropping☨ the `Stream` API for compatibility with OCaml 5, thus it added an `Seq` based API. This PR does the small changes that are required to use it instead of `Stream`.

Which also comes with the added benefit of removing usage of `Stream` from Merlin itself.

☨Yojson 2.0 will drop the API when it is released. As such this PR requires the `master` version of Yojson but the idea is to prepare most Yojson consumers in advantage, so when Yojson 2.0 ends up on OPAM the migration is as smooth as possible.