### PR TITLE
Make the prefix argument to `merlin-locate` optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ unreleased
       implementation. (#1488)
   + editor modes
     - add method imenu items for emacs (#1481, @mndrix)
+    - emacs: Make the prefix argument to `merlin-locate` optional, both for
+      consistency with Emacs convention and for backwards compatibility. (#1476,
+      @antalsz)
 
 merlin 4.5
 ==========

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1575,13 +1575,21 @@ loading"
   (interactive "s> ")
   (merlin--locate-result (merlin-call-locate ident)))
 
-(defun merlin-locate (prefix)
-  "Locate the identifier under point"
+(defun merlin-locate (&optional in-new-window)
+  "Locate the identifier at point.
+
+Whether the result appears in a new window is controlled by
+`merlin-locate-in-new-window', but can be overridden with a
+prefix argument (IN-NEW-WINDOW): if prefixed once with
+\\[universal-argument], the result appears in the current window;
+if prefixed twice with \\[universal-argument], the result appears
+in a new window; otherwise, `merlin-locate-in-new-window' is
+obeyed."
   (interactive "P")
   (cl-letf ((merlin-locate-in-new-window
     (cond
-     ((equal prefix '(4)) 'never)
-     ((equal prefix '(16)) 'always)
+     ((equal in-new-window '(4)) 'never)
+     ((equal in-new-window '(16)) 'always)
      (t merlin-locate-in-new-window))))
     (merlin--locate-result (merlin-call-locate))))
 


### PR DESCRIPTION
The `merlin-locate` command had a prefix argument added; it's elisp convention for prefix arguments to be optional, and this is especially helpful as the `merlin-locate` command is user-facing and this provides for backwards compatibility.

This change can also be backported to the 412 and 411 branches.