### PR TITLE
fix(logging): previously `ocamlmerlin_server.ml` and `new_merlin.ml` had different parsing for `MERLIN_LOG`

### DIFF
--- a/src/frontend/ocamlmerlin/log_info.ml
+++ b/src/frontend/ocamlmerlin/log_info.ml
@@ -1,0 +1,8 @@
+let get () = 
+  let log_file, sections = 
+    match String.split_on_char ',' (Sys.getenv "MERLIN_LOG") with
+    | (value :: sections) -> (Some value, sections)
+    | [] -> (None, [])
+    | exception Not_found -> (None, [])
+  in 
+  `Log_file_path log_file, `Log_sections sections

--- a/src/frontend/ocamlmerlin/log_info.mli
+++ b/src/frontend/ocamlmerlin/log_info.mli
@@ -1,0 +1,2 @@
+val get : 
+    unit -> [`Log_file_path of string option] * [`Log_sections of string list]

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -159,11 +159,8 @@ let run ~new_env wd args =
       try Sys.chdir wd; Printf.sprintf "changed directory to %S" wd
       with _ -> Printf.sprintf "cannot change working directory to %S" wd
   in
-  let log_file, sections =
-    match Std.String.split_on_char_ ',' (Sys.getenv "MERLIN_LOG") with
-    | (value :: sections) -> (Some value, sections)
-    | [] -> (None, [])
-    | exception Not_found -> (None, [])
+  let `Log_file_path log_file, `Log_sections sections =
+    Log_info.get ()
   in
   Logger.with_log_file log_file ~sections @@ fun () ->
   log ~title:"run" "%s" wd_msg;

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -93,9 +93,7 @@ let main () =
 
 let () =
   Std.Json.pretty_to_string := Yojson.Basic.pretty_to_string;
-  let log_file =
-    match Sys.getenv "MERLIN_LOG" with
-    | exception Not_found -> None
-    | file -> Some file
+  let `Log_file_path log_file, `Log_sections sections =
+    Log_info.get ()
   in
-  Logger.with_log_file log_file main
+  Logger.with_log_file log_file ~sections main


### PR DESCRIPTION
Notice how one splits `MERLIN_LOG` by `,` and passed sections while the other doesn't