### PR TITLE
Fix types deduplication 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ unreleased
     - Use newer `Seq`-based API of Yojson 2.0, avoiding the need for the
       deprecated `Stream` module (#1475 by @Leonidas-from-XIV)
     - unify parsing of `MERLIN_LOG` (#1480 by @ulugbekna)
+    - Fix type deduplication in `type-enclosing` results (#1483, fixes #1477)
   + editor modes
     - add method imenu items for emacs (#1481, @mndrix)
 

--- a/tests/test-dirs/misc/load_path.t
+++ b/tests/test-dirs/misc/load_path.t
@@ -27,18 +27,6 @@ Here is what merlin sees:
         },
         "type": "int",
         "tail": "no"
-      },
-      {
-        "start": {
-          "line": 1,
-          "col": 8
-        },
-        "end": {
-          "line": 1,
-          "col": 16
-        },
-        "type": "int",
-        "tail": "no"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
+++ b/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
@@ -15,24 +15,8 @@ Various parts of the cons.ml:
       },
       "type": "t",
       "tail": "no"
-    },
-    {
-      "start": {
-        "line": 4,
-        "col": 13
-      },
-      "end": {
-        "line": 4,
-        "col": 14
-      },
-      "type": "t",
-      "tail": "no"
     }
   ]
-
-Note: the output is duplicated because it is the result of the concatenation
-of both the ast-based and the small_enclosings (source based) heuristics.
-We aim to fix that in the future.
 
 - The pattern:
 
@@ -53,14 +37,14 @@ We aim to fix that in the future.
     },
     {
       "start": {
-        "line": 8,
-        "col": 4
+        "line": 7,
+        "col": 2
       },
       "end": {
         "line": 8,
-        "col": 5
+        "col": 11
       },
-      "type": "t",
+      "type": "unit",
       "tail": "no"
     }
   ]
@@ -143,13 +127,13 @@ We aim to fix that in the future.
     {
       "start": {
         "line": 15,
-        "col": 12
+        "col": 6
       },
       "end": {
         "line": 15,
-        "col": 15
+        "col": 22
       },
-      "type": "M.t",
+      "type": "unit -> M.t",
       "tail": "no"
     }
   ]
@@ -249,18 +233,6 @@ the expression reconstructed from  (M|.A 3).
   $ $MERLIN single type-enclosing -position 26:11 -verbosity 0 \
   > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
   [
-    {
-      "start": {
-        "line": 26,
-        "col": 8
-      },
-      "end": {
-        "line": 26,
-        "col": 11
-      },
-      "type": "int",
-      "tail": "no"
-    },
     {
       "start": {
         "line": 26,

--- a/tests/test-dirs/type-enclosing/github1003.t/run.t
+++ b/tests/test-dirs/type-enclosing/github1003.t/run.t
@@ -12,18 +12,6 @@
       },
       "type": "int",
       "tail": "no"
-    },
-    {
-      "start": {
-        "line": 5,
-        "col": 8
-      },
-      "end": {
-        "line": 5,
-        "col": 16
-      },
-      "type": "int",
-      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/issue1477.t
+++ b/tests/test-dirs/type-enclosing/issue1477.t
@@ -1,0 +1,46 @@
+  $ cat >test.ml <<EOF
+  > let g (x : int) = x
+  > let b = g 1
+  > EOF
+
+FIXME we could filter the second result out as stated in issue #1477
+  $ $MERLIN single type-enclosing -position 2:8 -filename test.ml < test.ml |
+  > jq '.value'
+  [
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
+        "col": 9
+      },
+      "type": "int -> int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
+        "col": 9
+      },
+      "type": "int -> int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
+        "col": 11
+      },
+      "type": "int",
+      "tail": "no"
+    }
+  ]

--- a/tests/test-dirs/type-enclosing/issue1477.t
+++ b/tests/test-dirs/type-enclosing/issue1477.t
@@ -3,22 +3,10 @@
   > let b = g 1
   > EOF
 
-FIXME we could filter the second result out as stated in issue #1477
-  $ $MERLIN single type-enclosing -position 2:8 -filename test.ml < test.ml |
+  $ $MERLIN single type-enclosing -position 2:8 \
+  > -filename test.ml < test.ml |
   > jq '.value'
   [
-    {
-      "start": {
-        "line": 2,
-        "col": 8
-      },
-      "end": {
-        "line": 2,
-        "col": 9
-      },
-      "type": "int -> int",
-      "tail": "no"
-    },
     {
       "start": {
         "line": 2,

--- a/tests/test-dirs/type-enclosing/letop.t/run.t
+++ b/tests/test-dirs/type-enclosing/letop.t/run.t
@@ -86,9 +86,9 @@ Various parts of the letop:
       },
       "end": {
         "line": 4,
-        "col": 29
+        "col": 37
       },
-      "type": "('a, 'b) Hashtbl.t -> 'a -> 'b option",
+      "type": "'a option",
       "tail": "no"
     }
   ]
@@ -111,13 +111,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 30
+        "col": 13
       },
       "end": {
         "line": 4,
-        "col": 33
+        "col": 37
       },
-      "type": "('a, 'b) Hashtbl.t",
+      "type": "'a option",
       "tail": "no"
     }
   ]
@@ -140,13 +140,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 34
+        "col": 13
       },
       "end": {
         "line": 4,
         "col": 37
       },
-      "type": "'a",
+      "type": "'a option",
       "tail": "no"
     }
   ]
@@ -175,7 +175,7 @@ Various parts of the letop:
       },
       "end": {
         "line": 5,
-        "col": 5
+        "col": 9
       },
       "type": "int",
       "tail": "no"

--- a/tests/test-dirs/type-enclosing/mod-type.t/run.t
+++ b/tests/test-dirs/type-enclosing/mod-type.t/run.t
@@ -43,18 +43,6 @@ Get the type of a module type with the same name as a module:
       },
       "type": "sig type a end",
       "tail": "no"
-    },
-    {
-      "start": {
-        "line": 5,
-        "col": 8
-      },
-      "end": {
-        "line": 5,
-        "col": 9
-      },
-      "type": "sig type a end",
-      "tail": "no"
     }
   ]
 
@@ -76,7 +64,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 23
+        "col": 8
       },
       "end": {
         "line": 7,
@@ -105,7 +93,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 23
+        "col": 8
       },
       "end": {
         "line": 7,

--- a/tests/test-dirs/type-enclosing/objects.t/run.t
+++ b/tests/test-dirs/type-enclosing/objects.t/run.t
@@ -112,9 +112,9 @@
       },
       "end": {
         "line": 14,
-        "col": 9
+        "col": 14
       },
-      "type": "< pop : int option; push : int -> unit >",
+      "type": "int -> unit",
       "tail": "no"
     }
   ]
@@ -195,13 +195,13 @@
     {
       "start": {
         "line": 18,
-        "col": 12
+        "col": 11
       },
       "end": {
         "line": 18,
-        "col": 15
+        "col": 58
       },
-      "type": "< pouet : string -> 'a >",
+      "type": "< pouet : string -> 'a > -> 'a",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/record.t/run.t
+++ b/tests/test-dirs/type-enclosing/record.t/run.t
@@ -95,9 +95,9 @@
       },
       "end": {
         "line": 8,
-        "col": 9
+        "col": 17
       },
-      "type": "t",
+      "type": "unit",
       "tail": "no"
     }
   ]
@@ -124,9 +124,9 @@
       },
       "end": {
         "line": 8,
-        "col": 9
+        "col": 17
       },
-      "type": "type t = { mutable b : float; }",
+      "type": "type unit = ()",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/te-413-features.t
+++ b/tests/test-dirs/type-enclosing/te-413-features.t
@@ -21,13 +21,13 @@ Named existentials in patterns
     {
       "start": {
         "line": 3,
-        "col": 59
+        "col": 51
       },
       "end": {
         "line": 3,
-        "col": 60
+        "col": 65
       },
-      "type": "a",
+      "type": "unit",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -41,18 +41,6 @@
       },
       "type": "type x = Foo",
       "tail": "no"
-    },
-    {
-      "start": {
-        "line": 5,
-        "col": 10
-      },
-      "end": {
-        "line": 5,
-        "col": 11
-      },
-      "type": "type x = Foo",
-      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -30,18 +30,6 @@ in the presence of underscores.
         "line": 3,
         "col": 6
       },
-      "type": "float",
-      "tail": "no"
-    },
-    {
-      "start": {
-        "line": 3,
-        "col": 2
-      },
-      "end": {
-        "line": 3,
-        "col": 6
-      },
       "type": "int",
       "tail": "no"
     },
@@ -67,18 +55,6 @@ in the presence of underscores.
   >   _foo
   > EOF
   [
-    {
-      "start": {
-        "line": 3,
-        "col": 2
-      },
-      "end": {
-        "line": 3,
-        "col": 6
-      },
-      "type": "float",
-      "tail": "no"
-    },
     {
       "start": {
         "line": 3,
@@ -147,18 +123,6 @@ We try several places in the identifier to check the result stability
         "line": 3,
         "col": 9
       },
-      "type": "float",
-      "tail": "no"
-    },
-    {
-      "start": {
-        "line": 3,
-        "col": 2
-      },
-      "end": {
-        "line": 3,
-        "col": 9
-      },
       "type": "int",
       "tail": "no"
     },
@@ -184,18 +148,6 @@ We try several places in the identifier to check the result stability
   >   foo_bar
   > EOF
   [
-    {
-      "start": {
-        "line": 3,
-        "col": 2
-      },
-      "end": {
-        "line": 3,
-        "col": 9
-      },
-      "type": "float",
-      "tail": "no"
-    },
     {
       "start": {
         "line": 3,
@@ -263,18 +215,6 @@ We try several places in the identifier to check the result stability
         "line": 3,
         "col": 9
       },
-      "type": "float",
-      "tail": "no"
-    },
-    {
-      "start": {
-        "line": 3,
-        "col": 2
-      },
-      "end": {
-        "line": 3,
-        "col": 9
-      },
       "type": "int",
       "tail": "no"
     },
@@ -301,18 +241,6 @@ We try several places in the identifier to check the result stability
   {
     "class": "return",
     "value": [
-      {
-        "start": {
-          "line": 3,
-          "col": 2
-        },
-        "end": {
-          "line": 3,
-          "col": 9
-        },
-        "type": "float",
-        "tail": "no"
-      },
       {
         "start": {
           "line": 3,


### PR DESCRIPTION
Fixes #1477
The actual deduplication was not working as expected, probably due to a change of the types of the results that became incomparable. 