### PR TITLE
Add benchmarks for merlin locate on irmin files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,7 @@ preprocess:
 promote:
 	dune promote
 
-.PHONY: all build dev clean test promote
+bench:
+	cd ../irmin && ../merlin/tests/bench.sh
+
+.PHONY: all build dev clean test promote bench

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,0 +1,18 @@
+# The purpose of this file is to set up the environment necessary to launch benchmarks on current-bench.
+# The goal here is to launch ./tests/bench.sh which launches benchmarks on irmin files
+
+FROM ocaml/opam:debian-10-ocaml-4.14
+RUN sudo apt-get install -y gnuplot-x11 libgmp-dev pkg-config libffi-dev jq
+RUN sudo rm /usr/bin/opam && sudo ln -s /usr/bin/opam-2.1 /usr/bin/opam
+RUN git clone https://github.com/mirage/irmin.git \
+    && cd irmin \
+    && git checkout d23b43e238c7fd417d2bbcab8c9766386c1b0a09 \
+    && opam install --deps-only --with-test . \
+    && opam exec -- dune build @check
+RUN mkdir merlin
+WORKDIR merlin
+COPY --chown=opam:opam ./*.opam ./
+RUN opam pin add -ny --with-version=dev . \
+    && opam install --deps-only .
+COPY --chown=opam:opam . ./
+RUN opam install .

--- a/tests/bench.sh
+++ b/tests/bench.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# the purpose of this file is to run the ocamlmerlin locate, type-enclosing and occurrences commands
+# on the cases that the commands take the most time on all Irmin repository
+# and make sure to match the json of merlin to that of current-bench, in order to launch benchmarks.
+
+function prbench {
+     metricname="$2:$3 $4"
+     jq '{"results": [{"name": "'$1'", "metrics": [
+               {"name": "'"$metricname"'/clock", "value": .timing.clock, "units": "ms"},
+               {"name": "'"$metricname"'/typer", "value": .timing.typer, "units": "ms"},
+               {"name": "'"$metricname"'/ppx", "value": .timing.ppx, "units": "ms"},
+               {"name": "'"$metricname"'/query", "value": .timing.query, "units": "ms"},
+               {"name": "'"$metricname"'/pp", "value": .timing.pp, "units": "ms"}]}]}'
+}
+
+function locate {
+     sed -n "$2"p "$4"
+     printf "%$3s^\n" ' '
+     ocamlmerlin single $1 -look-for ml -position $2:$3 -filename $4 < $4 \
+     | prbench $1 $2 $3 $5
+}
+
+function type-enclosing {
+     sed -n "$2"p "$4"
+     printf "%$3s^\n" ' '
+     ocamlmerlin single $1 -position $2:$3 -verbosity 0 < $4 \
+     | prbench $1 $2 $3 $5
+}
+
+function occurrences {
+     sed -n "$2"p "$4"
+     printf "%$3s^\n" ' '
+     ocamlmerlin single $1 -identifier-at $2:$3 -filename $4 < $4 \
+     | prbench $1 $2 $3 $5
+}
+
+locate locate 23 16 ./examples/irmin_git_store.ml examples-irmin_git_store.ml
+locate locate 118 21 ./examples/process.ml examples-process.ml
+locate locate 49 20 ./examples/push.ml examples-push.ml
+locate locate 34 16 ./examples/deploy.ml examples-deploy.ml
+locate locate 111 9 ./examples/process.ml examples-process.ml
+locate locate 43 26 ./examples/push.ml examples-push.ml
+locate locate 70 22 ./test/irmin-graphql/common.ml test-irmin-graphql-common.ml
+
+type-enclosing type-enclosing 215 13 ./src/irmin/watch.ml src-irmin-watch.ml
+type-enclosing type-enclosing 86 21 ./src/irmin/watch.ml src-irmin-watch.ml
+type-enclosing type-enclosing 95 22 ./src/irmin/watch.ml src-irmin-watch.ml
+type-enclosing type-enclosing 240 43 ./src/irmin/watch.ml src-irmin-watch.ml
+type-enclosing type-enclosing 303 26 ./src/irmin/watch.ml src-irmin-watch.ml
+type-enclosing type-enclosing 317 17 ./src/irmin/watch.ml src-irmin-watch.ml
+
+occurrences occurrences 40 46 ./src/irmin-mirage/git/irmin_mirage_git.ml src-irmin-mirage-git-irmin_mirage_git.ml
+occurrences occurrences 39 24 ./src/irmin-mirage/git/irmin_mirage_git.ml src-irmin-mirage-git-irmin_mirage_git.ml
+occurrences occurrences 50 18 ./src/irmin-mirage/git/irmin_mirage_git.ml src-irmin-mirage-git-irmin_mirage_git.ml
+occurrences occurrences 49 8 ./src/irmin-mirage/git/irmin_mirage_git.ml src-irmin-mirage-git-irmin_mirage_git.ml
+occurrences occurrences 178 34 ./src/irmin/tree.ml src-irmin-tree.ml
+occurrences occurrences 42 11 ./src/irmin/tree.ml src-irmin-tree.ml
+occurrences occurrences 186 30 ./src/irmin/tree.ml src-irmin-tree.ml


### PR DESCRIPTION
The purpose of this PR is to benchmark merlin locate using the command `ocamlmerlin single locate -look-for ml -position 23:22 -filename ./examples/irmin_git_store.ml < ./examples/irmin_git_store.ml | jq.` On the  `Irmin repository`.
To do this we added `bench.Dockerfile` and `./tests/bench.sh`.
The `bench.Dockerfile` file contains all the environment to clone `Irmin repository` and launch the necessary installations for `Merlin` and `Irmin`. The `./tests/bench.sh` file allows us to run the benchmark on cases where the `merlin locate` command takes the longest time to run. We were able to identify these cases by running `merlin locate` on each word of each Irmin file that we tested on two different versions of ocaml (4.14.0 and 4.12.1). 
This comparison allowed us to spot a performance regression of merlin that we have reported on `https://github.com/ocaml/merlin/issues/1468`.