### PR TITLE
Ignore unknown tags from dune configuration reader

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -107,8 +107,7 @@ module Cache = File_cache.Make (struct
           else if String.is_prefixed ~by:"#" line then
             ()
           else
-            Logger.notify ~section:".merlin"
-              "%s: unexpected directive \"%s\"" path line;
+            tell (`UNKNOWN_TAG (String.split_on_char ~sep:' ' line |> List.hd));
           aux ()
         in
         aux ()
@@ -326,7 +325,7 @@ let prepend_config ~cwd ~cfg =
     | `B _ | `S _ | `CMI _ | `CMT _  as directive ->
       { cfg with to_canonicalize = (cwd, directive) :: cfg.to_canonicalize }
     | `EXT _ | `SUFFIX _ | `FLG _ | `READER _
-    | `EXCLUDE_QUERY_DIR as directive ->
+    | (`EXCLUDE_QUERY_DIR | `UNKNOWN_TAG _) as directive ->
       { cfg with pass_forward = directive :: cfg.pass_forward }
     | `PKG ps ->
       { cfg with packages_to_load = ps @ cfg.packages_to_load }

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -39,15 +39,15 @@ module Directive = struct
     | `STDLIB of string
     | `SUFFIX of string
     | `READER of string list
-    | `EXCLUDE_QUERY_DIR ]
+    | `EXCLUDE_QUERY_DIR
+    | `UNKNOWN_TAG of string ]
 
   module Processed = struct
     type acceptable_in_input = [ include_path | no_processing_required ]
 
     type t =
       [ acceptable_in_input
-      | `ERROR_MSG of string
-      | `UNKNOWN_TAG of string ]
+      | `ERROR_MSG of string ]
   end
 
   module Raw = struct
@@ -119,7 +119,7 @@ module Sexp = struct
         | `READER ss -> ("READER", [ List (atoms_of_strings ss) ])
         | `EXCLUDE_QUERY_DIR -> ("EXCLUDE_QUERY_DIR", [])
         | `UNKNOWN_TAG tag -> ("ERROR", single @@
-            Printf.sprintf "Unknown tag: %s" tag)
+            Printf.sprintf "Unknown tag in .merlin: %s" tag)
         | `ERROR_MSG s -> ("ERROR", single s)
       in
       List (Atom tag :: body)

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -44,7 +44,10 @@ module Directive = struct
   module Processed = struct
     type acceptable_in_input = [ include_path | no_processing_required ]
 
-    type t = [ acceptable_in_input | `ERROR_MSG of string ]
+    type t =
+      [ acceptable_in_input
+      | `ERROR_MSG of string
+      | `UNKNOWN_TAG of string ]
   end
 
   module Raw = struct
@@ -73,10 +76,6 @@ module Sexp = struct
     ( List.concat [["("]; List.map ~f:to_string l;[")"]])
 
   let to_directive sexp =
-    let make_error str =
-      let str = Printf.sprintf "Unknown configuration tag \"%s\"" str in
-      `ERROR_MSG str
-    in
     match sexp with
     | List [ Atom tag; Atom value ] ->
       begin match tag with
@@ -91,7 +90,7 @@ module Sexp = struct
             (* This means merlin asked dune 2.6 for configuration.
               But the protocole evolved, only dune 2.8 should be used *)
             `ERROR_MSG "No .merlin file found. Try building the project."
-        | tag -> make_error tag
+        | tag -> `UNKNOWN_TAG tag
       end
     | List [ Atom tag; List l ] ->
         let value = strings_of_atoms l in
@@ -99,7 +98,7 @@ module Sexp = struct
         | "EXT" -> `EXT value
         | "FLG" -> `FLG value
         | "READER" -> `READER value
-        | tag -> make_error tag
+        | tag -> `UNKNOWN_TAG tag
       end
     | List [ Atom "EXCLUDE_QUERY_DIR" ] -> `EXCLUDE_QUERY_DIR
     | _ -> `ERROR_MSG "Unexpected output from external config reader"
@@ -119,6 +118,8 @@ module Sexp = struct
         | `SUFFIX s -> ("SUFFIX", single s)
         | `READER ss -> ("READER", [ List (atoms_of_strings ss) ])
         | `EXCLUDE_QUERY_DIR -> ("EXCLUDE_QUERY_DIR", [])
+        | `UNKNOWN_TAG tag -> ("ERROR", single @@
+            Printf.sprintf "Unknown tag: %s" tag)
         | `ERROR_MSG s -> ("ERROR", single s)
       in
       List (Atom tag :: body)

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -56,7 +56,10 @@ module Directive : sig
   module Processed : sig
     type acceptable_in_input = [ include_path | no_processing_required ]
 
-    type t = [ acceptable_in_input | `ERROR_MSG of string ]
+    type t =
+      [  acceptable_in_input
+      | `ERROR_MSG of string
+      | `UNKNOWN_TAG of string ]
   end
 
   module Raw : sig

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -51,15 +51,15 @@ module Directive : sig
     | `STDLIB of string
     | `SUFFIX of string
     | `READER of string list
-    | `EXCLUDE_QUERY_DIR ]
+    | `EXCLUDE_QUERY_DIR
+    | `UNKNOWN_TAG of string ]
 
   module Processed : sig
     type acceptable_in_input = [ include_path | no_processing_required ]
 
     type t =
       [  acceptable_in_input
-      | `ERROR_MSG of string
-      | `UNKNOWN_TAG of string ]
+      | `ERROR_MSG of string ]
   end
 
   module Raw : sig

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -74,30 +74,6 @@ let parse_suffix str =
     if String.get first 0 != '.' || String.get second 0 != '.' then []
     else [(first, second)]
 
-let prepend_config ~dir:cwd (directives : directive list) config =
-  List.fold_left ~init:(config, []) ~f:(fun (config, errors) ->
-    function
-    | `B path -> {config with build_path = path :: config.build_path}, errors
-    | `S path -> {config with source_path = path :: config.source_path}, errors
-    | `CMI path -> {config with cmi_path = path :: config.cmi_path}, errors
-    | `CMT path -> {config with cmt_path = path :: config.cmt_path}, errors
-    | `EXT exts ->
-      {config with extensions = exts @ config.extensions}, errors
-    | `SUFFIX suffix ->
-      {config with suffixes = (parse_suffix suffix) @ config.suffixes}, errors
-    | `FLG flags ->
-      let flags = {workdir = cwd; workval = flags} in
-      {config with flags = flags :: config.flags}, errors
-    | `STDLIB path ->
-      {config with stdlib = Some path}, errors
-    | `READER reader ->
-      {config with reader}, errors
-    | `EXCLUDE_QUERY_DIR ->
-      {config with exclude_query_dir = true}, errors
-    | `ERROR_MSG str ->
-      config, str :: errors
-  ) directives
-
 (* This module contains invariants around processes that need to be preserved *)
 module Configurator : sig
   type t =
@@ -237,6 +213,37 @@ end = struct
     end
 end
 
+let prepend_config ~dir:cwd configurator (directives : directive list) config =
+  List.fold_left ~init:(config, []) ~f:(fun (config, errors) ->
+    function
+    | `B path -> {config with build_path = path :: config.build_path}, errors
+    | `S path -> {config with source_path = path :: config.source_path}, errors
+    | `CMI path -> {config with cmi_path = path :: config.cmi_path}, errors
+    | `CMT path -> {config with cmt_path = path :: config.cmt_path}, errors
+    | `EXT exts ->
+      {config with extensions = exts @ config.extensions}, errors
+    | `SUFFIX suffix ->
+      {config with suffixes = (parse_suffix suffix) @ config.suffixes}, errors
+    | `FLG flags ->
+      let flags = {workdir = cwd; workval = flags} in
+      {config with flags = flags :: config.flags}, errors
+    | `STDLIB path ->
+      {config with stdlib = Some path}, errors
+    | `READER reader ->
+      {config with reader}, errors
+    | `EXCLUDE_QUERY_DIR ->
+      {config with exclude_query_dir = true}, errors
+    | `ERROR_MSG str ->
+      config, str :: errors
+    | `UNKNOWN_TAG _ when configurator = Configurator.Dune ->
+      (* For easier forward compatibility we ignore unknown configuration tags
+         when they are provided by dune *)
+      config, errors
+    | `UNKNOWN_TAG tag  ->
+      let error =  Printf.sprintf "Unknown configuration tag \"%s\"" tag in
+      config, error :: errors
+  ) directives
+
 let postprocess_config config =
   let clean list = List.rev (List.filter_dup list) in
   {
@@ -317,7 +324,7 @@ let get_config { workdir; process_dir; configurator } path_abs =
     match answer with
     | Ok directives ->
       let cfg, failures =
-        prepend_config ~dir:workdir directives empty_config
+        prepend_config ~dir:workdir configurator directives empty_config
       in
       postprocess_config cfg, failures
     | Error (Merlin_dot_protocol.Unexpected_output msg) -> empty_config, [ msg ]

--- a/tests/test-dirs/config/unknown_tag.t
+++ b/tests/test-dirs/config/unknown_tag.t
@@ -1,0 +1,20 @@
+  $ cat >.merlin <<EOF
+  > B foobar_dir
+  > FOOBAR bar
+  > EOF
+
+  $ $MERLIN single errors -filename test.ml <<EOF
+  > let x = 2
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "type": "config",
+        "sub": [],
+        "valid": true,
+        "message": "Unknown tag in .merlin: FOOBAR"
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Dune configuration provider should never send unknown tags unless they have been meaningfully introduced.
In comparison unknown tag in an handwritten `.merlin` can result from a user's error.

This PR ignores unknown tags when Dune is used as a configuration provider. Since the protocol can only (so far) be grown additively this allow Merlin version that does not support a newer directive to simply ignore it.