### PR TITLE
Use weak strategy when reducing shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ unreleased
       deprecated `Stream` module (#1475 by @Leonidas-from-XIV)
     - unify parsing of `MERLIN_LOG` (#1480 by @ulugbekna)
     - Fix type deduplication in `type-enclosing` results (#1483, fixes #1477)
+    - Only weakly reduce the shapes to speed up the new Merlin locate
+      implementation. (#1488)
   + editor modes
     - add method imenu items for emacs (#1481, @mndrix)
 

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -372,7 +372,7 @@ let uid_of_path ~env ~ml_or_mli ~decl_uid path ns =
     let shape = Env.shape_of_path ~namespace:ns env path in
     log ~title:"shape_of_path" "initial: %a"
       Logger.fmt (fun fmt -> Shape.print fmt shape);
-    let r = Shape_reduce.reduce env shape in
+    let r = Shape_reduce.weak_reduce env shape in
     log ~title:"shape_of_path" "reduced: %a"
       Logger.fmt (fun fmt -> Shape.print fmt r);
     r.uid

--- a/src/ocaml/typing/shape.ml
+++ b/src/ocaml/typing/shape.ml
@@ -422,6 +422,34 @@ end) = struct
     | NComp_unit s -> Comp_unit s
     | NoFuelLeft t -> t
 
+  (* When in Merlin we don't need to perform full shape reduction since we are
+     only interested by uid's stored at the "top-level" of the shape once the
+     projections have been done. *)
+  let weak_read_back env (nf : nf) : t =
+    let cache = Hashtbl.create 42 in
+    let rec weak_read_back env nf =
+      let memo_key = (env.local_env, nf) in
+      in_memo_table cache memo_key (weak_read_back_ env) nf
+    and weak_read_back_ env nf : t =
+      { uid = nf.uid; desc = weak_read_back_desc env nf.desc }
+    and weak_read_back_desc env desc : desc =
+      let weak_read_back_no_force (Thunk (_local_env, t)) = t in
+      match desc with
+      | NVar v ->
+          Var v
+      | NApp (nft, nfu) ->
+          App(weak_read_back env nft, weak_read_back env nfu)
+      | NAbs (_env, x, _t, nf) ->
+          Abs(x, weak_read_back_no_force nf)
+      | NStruct nstr ->
+          Struct (Item.Map.map weak_read_back_no_force nstr)
+      | NProj (nf, item) ->
+          Proj (read_back env nf, item)
+      | NLeaf -> Leaf
+      | NComp_unit s -> Comp_unit s
+      | NoFuelLeft t -> t
+    in weak_read_back env nf
+
   let reduce global_env t =
     let fuel = ref Params.fuel in
     let reduce_memo_table = Hashtbl.create 42 in
@@ -435,6 +463,20 @@ end) = struct
       local_env;
     } in
     reduce_ env t |> read_back env
+
+  let weak_reduce global_env t =
+    let fuel = ref Params.fuel in
+    let reduce_memo_table = Hashtbl.create 42 in
+    let read_back_memo_table = Hashtbl.create 42 in
+    let local_env = Ident.Map.empty in
+    let env = {
+      fuel;
+      global_env;
+      reduce_memo_table;
+      read_back_memo_table;
+      local_env;
+    } in
+    reduce_ env t |> weak_read_back env
 end
 
 module Local_reduce =

--- a/src/ocaml/typing/shape.mli
+++ b/src/ocaml/typing/shape.mli
@@ -152,6 +152,7 @@ module Make_reduce(Context : sig
     val find_shape : env -> Ident.t -> t
   end) : sig
   val reduce : Context.env -> t -> t
+  val weak_reduce : Context.env -> t -> t
 end
 
 val local_reduce : t -> t

--- a/tests/test-dirs/locate/dune
+++ b/tests/test-dirs/locate/dune
@@ -10,3 +10,7 @@
   (and
    (<> %{architecture} i386)
    (<> %{os_type} Win32))))
+
+(cram
+ (applies_to :whole_subtree)
+ (alias all-locate-tests))


### PR DESCRIPTION
This prevent unnecessary computations when reducing shapes in Merlin.
For example, in the current released version, Merlin would completely reduce the whole shape of the module `Irmin_unix` when performing a jump-to-definition at `Irmin_u|nix.Git.Some(Stuff)` which is wasteful since we only need the UID attributed to the top-level structure of the shape.

This patch leads to a huge speed up in this case. Improving #1468 a lot.

cc @gasche 