### PR TITLE
Improvement: jumping to a label's precise declaration.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ undefined
     - Filter-out duplicates from the `enclosing` command result (#1512)
     - Add a new `verbosity=smart` mode for type enclosing that only expand
       modules' types (#1374, @ulugbekna)
+    - Improve locate for labels' declarations in the current buffer.
+      (#1505, fixes #1524)
   + editor modes
     - vim: load the plugin when necessary if it wasn’t loaded before (#1511)
   + test suite
@@ -20,6 +22,7 @@ undefined
     - add test cases for label comment documentation (#1526, @mheiber)
   + test suite
     - Add a test for the `enclosing` command (#1512)
+    - Add tests for interactions between locate and record labels (#1505)
 
 merlin 4.6
 ==========

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -414,7 +414,7 @@ let from_uid ~ml_or_mli uid loc path =
           Some (uid, loc)
         | None ->
           log ~title
-            "Uid not found.@.\
+            "Uid not found in the local table.\
             Fallbacking to the node's location: %a"
           Logger.fmt (fun fmt -> Location.print_loc fmt loc);
           Some (uid, loc)
@@ -444,8 +444,10 @@ let from_uid ~ml_or_mli uid loc path =
                 Logger.fmt (fun fmt -> Location.print_loc fmt loc);
               Some (uid, loc)
             | None ->
-              log ~title "Uid not found in the loaded shape.";
-            None
+              log ~title "Uid not found in the cmt table. \
+                Fallbacking to the node's location: %a"
+                Logger.fmt (fun fmt -> Location.print_loc fmt loc);
+              Some (uid, loc)
           end
         | _ ->
           log ~title "Failed to load the shapes";

--- a/src/ocaml/typing/typedecl.ml
+++ b/src/ocaml/typing/typedecl.ml
@@ -232,12 +232,14 @@ let transl_labels env univars closed lbls =
       (fun ld ->
          let ty = ld.ld_type.ctyp_type in
          let ty = match get_desc ty with Tpoly(t,[]) -> t | _ -> ty in
+         let ld_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
+         Env.register_uid ld_uid ld.ld_loc;
          {Types.ld_id = ld.ld_id;
           ld_mutable = ld.ld_mutable;
           ld_type = ty;
           ld_loc = ld.ld_loc;
           ld_attributes = ld.ld_attributes;
-          ld_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
+          ld_uid;
          }
       )
       lbls in

--- a/src/ocaml/typing/typedecl.ml
+++ b/src/ocaml/typing/typedecl.ml
@@ -402,12 +402,14 @@ let transl_declaration env sdecl (id, uid) =
               cd_attributes = scstr.pcd_attributes }
           in
           let cstr =
+            let cd_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
+            Env.register_uid cd_uid scstr.pcd_loc;
             { Types.cd_id = name;
               cd_args = args;
               cd_res = ret_type;
               cd_loc = scstr.pcd_loc;
               cd_attributes = scstr.pcd_attributes;
-              cd_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) }
+              cd_uid; }
           in
             tcstr, cstr
         in

--- a/tests/test-dirs/document/issue1513.t
+++ b/tests/test-dirs/document/issue1513.t
@@ -16,18 +16,22 @@ Merlin should show comments for a type's constructor from another module:
 
   $ $OCAMLC -c -bin-annot naux.ml
 
-FIXME: the constructors are missing from the [uid_to_loc] tables
+FIXME: We should not rely on "fallbacking". This requires a compiler change.
   $ $MERLIN single document -position 1:13 \
-  > -filename main.ml <main.ml | jq '.value'
-  "didn't manage to find Naux.t"
+  > -log-file - -log-section locate \
+  > -filename main.ml <main.ml 2>&1 | 
+  > grep "Uid not found in the cmt table"
+  Uid not found in the cmt table. Fallbacking to the node's location: File "naux.ml", line 2, characters 2-5
 
+FIXME: expected "B Comment"
   $ $MERLIN single document -position 2:13 \
   > -filename main.ml <main.ml | tr '\n' ' ' | jq '.value'
-  "didn't manage to find Naux.t"
+  "A Comment B Comment"
 
+FIXME
   $ $MERLIN single document -position 3:13 \
   > -filename main.ml <main.ml | jq '.value'
-  "didn't manage to find Naux.t"
+  "B Comment"
 
   $ rm naux.cmt
 

--- a/tests/test-dirs/document/label-comments.t
+++ b/tests/test-dirs/document/label-comments.t
@@ -62,5 +62,5 @@ FIXME: expected "fld_b comment"
   > EOF
 
   $ $MERLIN single document -position 8:4 \
-  > -filename main.ml <main.ml | jq '.value'
-  "fld_a comment"
+  > -filename main.ml <main.ml | tr '\r\n' ' ' | jq '.value'
+  "fld_a comment fld_b comment"

--- a/tests/test-dirs/locate/context-detection/cd-label.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-label.t/run.t
@@ -25,3 +25,49 @@
     "notifications": []
   }
 
+  $ cat >record.ml <<EOF
+  > type t = { bar: int}
+  > let foo = { bar = 42 }
+  > let () = print_int foo.bar
+  > EOF
+
+  $ $MERLIN single locate -look-for mli -position 3:24 \
+  > -filename ./record.ml < ./record.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/record.ml",
+    "pos": {
+      "line": 1,
+      "col": 11
+    }
+  }
+
+FIXME: this is not a very satisfying answer. 
+We could expect 2:12 or at least 2:4
+  $ $MERLIN single locate  -look-for ml -position 3:24 \
+  > -filename ./record.ml < ./record.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/record.ml",
+    "pos": {
+      "line": 1,
+      "col": 0
+    }
+  }
+
+  $ cat >other_module.ml <<EOF
+  > let foo = Record.{ bar = 42 }
+  > let () = print_int foo.bar
+  > EOF
+
+  $ $OCAMLC -c -bin-annot record.ml
+
+FIXME: Merlin looks for the Uid of the label in Record's `uid_to_loc` table but
+doesn't find it. We need a compiler fix for this, see #1505.
+  $ $MERLIN single locate -look-for mli -position 2:24 \
+  > -filename ./other_module.ml < ./other_module.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/record.ml",
+    "pos": {
+      "line": 1,
+      "col": 0
+    }
+  }

--- a/tests/test-dirs/locate/dune
+++ b/tests/test-dirs/locate/dune
@@ -1,6 +1,7 @@
 (cram
  (applies_to looping-substitution mutually-recursive partial-cmt includes
-   issue802 issue845 issue1199 sig-substs l-413-features module-aliases)
+   issue802 issue845 issue1199 issue1524 sig-substs l-413-features
+   module-aliases locate-constrs)
  (enabled_if
   (<> %{os_type} Win32)))
 

--- a/tests/test-dirs/locate/issue1524.t
+++ b/tests/test-dirs/locate/issue1524.t
@@ -1,0 +1,19 @@
+  $ cat >main.ml <<EOF
+  > type t = {
+  >   data : int;
+  > }
+  > let f x =
+  >   x.data + 1
+  > EOF
+
+
+  $ $MERLIN single locate -look-for mli -position 5:6 \
+  > -filename ./main.ml < ./main.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/main.ml",
+    "pos": {
+      "line": 2,
+      "col": 2
+    }
+  }
+

--- a/tests/test-dirs/locate/locate-constrs.t
+++ b/tests/test-dirs/locate/locate-constrs.t
@@ -1,0 +1,77 @@
+/**
+* VARIANTS
+**/
+
+  $ cat >constr.ml <<EOF
+  > type t = A of int |  B
+  > let foo : t = A 42
+  > EOF
+
+  $ $MERLIN single locate -look-for mli -position 2:14 \
+  > -filename ./constr.ml < ./constr.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/constr.ml",
+    "pos": {
+      "line": 1,
+      "col": 9
+    }
+  }
+
+FIXME: this is not a very satisfying answer. 
+We could expect 1:9
+  $ $MERLIN single locate  -look-for ml -position 2:14 \
+  > -filename ./constr.ml < ./constr.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/constr.ml",
+    "pos": {
+      "line": 1,
+      "col": 0
+    }
+  }
+
+With the declaration in another compilation unit:
+  $ cat >other_module.ml <<EOF
+  > let foo = Constr.B
+  > EOF
+
+  $ $OCAMLC -c -bin-annot constr.ml
+
+  $ $MERLIN single locate -look-for mli -position 1:17 \
+  > -filename ./other_module.ml < ./other_module.ml | jq '.value'
+  {
+    "file": "$TESTCASE_ROOT/constr.ml",
+    "pos": {
+      "line": 1,
+      "col": 18
+    }
+  }
+
+/**
+* POLYMORPHIC VARIANTS
+**/
+  $ cat >constr.ml <<EOF
+  > type t = [\`A of int | \`B]
+  > let foo : t = \`A 42
+  > EOF
+
+FIXME: we could expect constr.ml 1:11
+  $ $MERLIN single locate -look-for mli -position 2:14 \
+  > -filename ./constr.ml < ./constr.ml | jq '.value'
+  "Not a valid identifier"
+
+FIXME: we could expect constr.ml 1:11
+  $ $MERLIN single locate -look-for ml -position 2:14 \
+  > -filename ./constr.ml < ./constr.ml | jq '.value'
+  "Not a valid identifier"
+
+With the declaration in another compilation unit:
+  $ cat >other_module.ml <<EOF
+  > let foo = Constr.\`B
+  > EOF
+
+  $ $OCAMLC -c -bin-annot constr.ml
+
+FIXME: we expect constr.ml 1:23
+  $ $MERLIN single locate -look-for mli -position 1:18 \
+  > -filename ./other_module.ml < ./other_module.ml | jq '.value'
+  "Not a valid identifier"


### PR DESCRIPTION
When querying jump to declaration of a record's label `foo.ba|r` merlin would only jump to the beginning of the corresponding record type declaration.

This is due to the uid's of labels not being registered by the compiler in the `Env.uid_to_loc` table.

This PR adds these uid registration to `typedecl.ml`. This means that the fix will only work for the current buffer and we would need to be upstreamed for it to work when jumping to external compilation units. 

cc @rgrinberg 