### PR TITLE
Recovery caused nested outline

### DIFF
--- a/src/ocaml/typing/typemod.ml
+++ b/src/ocaml/typing/typemod.ml
@@ -2231,6 +2231,10 @@ let simplify_app_summary app_view =
   | false, None -> Includemod.Error.Anonymous, mty
 
 let rec type_module ?(alias=false) sttn funct_body anchor env smod =
+  (* Merlin: when we start typing a module we don't want to include potential
+    saved_items from its parent. We backup them before starting and restore them
+    when finished. *)
+  Msupport.with_saved_types @@ fun () ->
   try
     Builtin_attributes.warning_scope smod.pmod_attributes
       (fun () -> type_module_aux ~alias sttn funct_body anchor env smod)

--- a/tests/test-dirs/outline-recovery.t
+++ b/tests/test-dirs/outline-recovery.t
@@ -6,7 +6,6 @@
   > end
   > EOF
 
-FIXME: A is not a child of B ! This is likely due to the typing recovery.
   $ $MERLIN single outline -filename test.ml <test.ml
   {
     "class": "return",
@@ -51,23 +50,7 @@ FIXME: A is not a child of B ! This is likely due to the typing recovery.
             "name": "B",
             "kind": "Module",
             "type": null,
-            "children": [
-              {
-                "start": {
-                  "line": 2,
-                  "col": 2
-                },
-                "end": {
-                  "line": 2,
-                  "col": 23
-                },
-                "name": "A",
-                "kind": "Module",
-                "type": null,
-                "children": [],
-                "deprecated": false
-              }
-            ],
+            "children": [],
             "deprecated": false
           },
           {

--- a/tests/test-dirs/outline-recovery.t
+++ b/tests/test-dirs/outline-recovery.t
@@ -1,0 +1,93 @@
+  $ cat >test.ml <<EOF
+  > module Make = struct
+  >   module A = struct end
+  >   module B = C.C1
+  >   module D = struct end
+  > end
+  > EOF
+
+FIXME: A is not a child of B ! This is likely due to the typing recovery.
+  $ $MERLIN single outline -filename test.ml <test.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 5,
+          "col": 3
+        },
+        "name": "Make",
+        "kind": "Module",
+        "type": null,
+        "children": [
+          {
+            "start": {
+              "line": 4,
+              "col": 2
+            },
+            "end": {
+              "line": 4,
+              "col": 23
+            },
+            "name": "D",
+            "kind": "Module",
+            "type": null,
+            "children": [],
+            "deprecated": false
+          },
+          {
+            "start": {
+              "line": 3,
+              "col": 2
+            },
+            "end": {
+              "line": 3,
+              "col": 17
+            },
+            "name": "B",
+            "kind": "Module",
+            "type": null,
+            "children": [
+              {
+                "start": {
+                  "line": 2,
+                  "col": 2
+                },
+                "end": {
+                  "line": 2,
+                  "col": 23
+                },
+                "name": "A",
+                "kind": "Module",
+                "type": null,
+                "children": [],
+                "deprecated": false
+              }
+            ],
+            "deprecated": false
+          },
+          {
+            "start": {
+              "line": 2,
+              "col": 2
+            },
+            "end": {
+              "line": 2,
+              "col": 23
+            },
+            "name": "A",
+            "kind": "Module",
+            "type": null,
+            "children": [],
+            "deprecated": false
+          }
+        ],
+        "deprecated": false
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Fixes issue https://github.com/ocaml/ocaml-lsp/issues/841 reported for ocaml-lsp-server.

When typing of a module structure item failed the saved types from the structure were wrongly added to that sub module causing outline to misbehave:

```
  $ cat >test.ml <<EOF
  > module Make = struct
  >   module A = struct end
  >   module B = C.C1
  >   module D = struct end
  > end
  > EOF

FIXME: A is not a child of B ! This is likely due to the typing recovery.
  $ $MERLIN single outline -filename test.ml <test.ml
  {
    "class": "return",
    "value": [
        "name": "Make",
        "children": [
            "name": "D",
            "children": [],
          },
            "name": "B",
            "children": [
                "name": "A",
                "children": [],
              }
            ],
          },
            "name": "A",
            "children": [],
          }
        ],
      }
    ],
  }
```