### PR TITLE
fix #1513: variant constructor docs 'only_after'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ undefined
     - Do not change temporarily Merlin's cwd when starting a PPX (#1521)
     - Fix a parsing issue when declaring the `(??)` custom prefix operator.
       (#1507, fixes #1506)
+    - Fix variant constructors' comments grouping (#1516, @mheiber, fixes #1513)
   + editor modes
     - vim: load the plugin when necessary if it wasn’t loaded before (#1511)
   + test suite

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -1015,8 +1015,16 @@ let get_doc ~config ~env ~local_defs ~comments ~pos =
               Location.print_loc l);
         Format.fprintf fmt "]\n"
       );
+    let (_, deepest_before) = List.hd @@ Mbrowse.deepest_before loc.loc_start [browse] in
+    (* based on https://v2.ocaml.org/manual/doccomments.html#ss:label-comments: *)
+    let after_only = begin match deepest_before with
+      | Browse_raw.Constructor_declaration _ -> true
+      (* The remaining `true` cases are currently not reachable *)
+      | Label_declaration _ | Record_field _ | Row_field _  -> true
+      | _ -> false
+    end in
     begin match
-      Ocamldoc.associate_comment comments loc !last_location
+      Ocamldoc.associate_comment ~after_only comments loc !last_location
     with
     | None, _     -> `No_documentation
     | Some doc, _ -> `Found doc

--- a/src/analysis/ocamldoc.ml
+++ b/src/analysis/ocamldoc.ml
@@ -15,7 +15,7 @@
 (** Pops comments from a list of comments (string * loc) to find the ones that
    are associated to a given location. Also returns the remaining comments after
    the location. *)
-let associate_comment ?(after_only=false) comments loc nextloc =
+let associate_comment ~after_only comments loc nextloc =
   let lstart = loc.Location.loc_start.Lexing.pos_lnum
   and lend =  loc.Location.loc_end.Lexing.pos_lnum in
   let isnext c =

--- a/tests/test-dirs/document/issue1513.t
+++ b/tests/test-dirs/document/issue1513.t
@@ -45,14 +45,10 @@ Merlin should show comments for a type's constructor from the current module:
   > -filename main.ml <main.ml | jq '.value'
   "A Comment"
 
-FIXME: expected "B Comment"
   $ $MERLIN single document -position 4:4 \
   > -filename main.ml <main.ml | tr '\n' ' ' | jq '.value'
-  "A Comment B Comment"
-
-FIXME: expected ""
-  $ $MERLIN single document -position 6:4 \
-  > -filename main.ml <main.ml | jq '.value'
   "B Comment"
 
-The issue probaby lies in the heuristics in [ocamldoc.ml]
+  $ $MERLIN single document -position 6:4 \
+  > -filename main.ml <main.ml | jq '.value'
+  "No documentation available"


### PR DESCRIPTION
Fix #1513  Group doc comments for variant constructors only with only the constructor before

Reference:
https://v2.ocaml.org/manual/doccomments.html#ss:label-comments