### PR TITLE
Update to latest merlin (4.7)

### DIFF
--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -89,4 +89,24 @@ type read_error =
   directives it represents *)
 val read : in_channel:in_channel -> (directive list, read_error) Merlin_utils.Std.Result.t
 
-val write : out_channel:out_channel -> directive list -> unit
+module Make (IO : sig
+  type 'a t
+
+  module O : sig
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+  end
+end) (Chan : sig
+  type t
+
+  val read : t -> Csexp.t option IO.t
+
+  val write : t -> Csexp.t -> unit IO.t
+end) : sig
+  val read : Chan.t -> (directive list, read_error) Merlin_utils.Std.Result.t IO.t
+
+  module Commands : sig
+    val send_file : Chan.t -> string -> unit IO.t
+
+    val halt : Chan.t -> unit IO.t
+  end
+end


### PR DESCRIPTION
- Drops several commits that are no longer needed because of changes in the upstream

  - drop bf63d90d16ca13ff95a4ef7a813b4a7322ae5455
     there's now `Lib_config.program_name` that can be set to `OCaml LSP`

  - 9a3c4e9b2d666018f936fcd97ec17f861ce2ed4c disappears during rebase 

  - drop 2bb9e14f3fc8059b795e0b78464e687ad47af6fc 
    done upstream

  - drop 87e952dac24d1067348d9de08b6e69793d1c0e57
    `parenthesize_name` now lives in `Misc` module

  - drop 953a5354349157be4cb2f0a42eae2db875cc0916
    done in ocamllsp itself


Note: when upgrading to latest merlin in ocamllsp (I plan to do it myself if ok), need to keep in mind to adapt to these changes