### PR TITLE
Improve locate locs

### DIFF
--- a/tests/test-dirs/environment_on_open.t/run.t
+++ b/tests/test-dirs/environment_on_open.t/run.t
@@ -6,7 +6,7 @@
       "file": "$TESTCASE_ROOT/environment_on_open.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate-type.t/run.t
+++ b/tests/test-dirs/locate-type.t/run.t
@@ -7,7 +7,7 @@
       "file": "$TESTCASE_ROOT/a.ml",
       "pos": {
         "line": 2,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -20,7 +20,7 @@
       "file": "$TESTCASE_ROOT/a.ml",
       "pos": {
         "line": 2,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/check-locs.t
+++ b/tests/test-dirs/locate/check-locs.t
@@ -1,0 +1,243 @@
+  $ cat >locs.ml <<EOF
+  > module M : sig
+  >   val x : int (* Psig_value *)
+  >   external e : int = "ext" 
+  >   type t = A of int (* Psig_type *)
+  >   type te = ..
+  >   type te += B (* Psig_typeext *)
+  >   exception E (* Psig_exception *)
+  >   module A : sig end (* Psig_module *)
+  >   module rec R1 : sig end 
+  >   and R2 : sig end (* Psig_recmodule *)
+  >   module type S = sig end (* Psig_modtype *)
+  >   class c : object end (* Psig_class *)
+  >   and d : object end
+  >   class type ct = object end (* Psig_class_type *)
+  >   and dt = object end
+  > end = struct
+  >   let x = 4 (* Pstr_value *)
+  >   external e : int = "ext" (* Pstr_primitive *)
+  >   type t = A of int (* Pstr_type *)
+  >   type te = ..
+  >   type te += B (* Pstr_typeext *)
+  >   exception E (* Pstr_exception *)
+  >   module A = struct end (* Pstr_module *)
+  >   module rec R1 : sig end = struct end 
+  >   and R2 : sig end = struct end (* Pstr_recmodule *)
+  >   module type S = sig end (* Pstr_modtype *)
+  >   class c = object end (* Pstr_class *)
+  >   and d = object end
+  >   class type ct = object end (* Pstr_class_type *)
+  >   and dt = object end
+  > end
+  > open M
+  > let _ = x
+  > let _ = e
+  > let _ : t = A 42
+  > let _ : te = B
+  > let _  = raise E
+  > module _ = A
+  > module _ = R1
+  > module _ = R2
+  > module _ : S = A
+  > let _ = new c 
+  > let _ = new d
+  > let _ = fun (_ : ct) (_ : dt) -> ()
+  > EOF
+
+FIXME Most of the following locs are wrong. 
+
+We expect merlin to jump to the identifier, not the beginning of the definition
+/ declaration.
+
+(* value *)
+  $ $MERLIN  single locate -look-for mli -position 33:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 2,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 33:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 17,
+    "col": 6
+  }
+
+(* primitive *)
+  $ $MERLIN  single locate -look-for mli -position 34:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 3,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 34:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 18,
+    "col": 2
+  }
+
+(* type *)
+  $ $MERLIN  single locate -look-for mli -position 35:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 4,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 35:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 19,
+    "col": 2
+  }
+
+(* typext *)
+  $ $MERLIN  single locate -look-for mli -position 36:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 5,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 36:8 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 20,
+    "col": 2
+  }
+
+(* exception *)
+  $ $MERLIN  single locate -look-for mli -position 37:15 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 7,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 37:15 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 22,
+    "col": 2
+  }
+
+(* module *)
+  $ $MERLIN  single locate -look-for mli -position 38:11 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 8,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 38:11 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 23,
+    "col": 2
+  }
+
+(* module rec *)
+  $ $MERLIN  single locate -look-for mli -position 39:11 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 9,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 39:11 \
+  > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
+  {
+    "line": 9,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for mli -position 40:11 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 10,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 40:11 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 10,
+    "col": 2
+  }
+
+(* module type *)
+  $ $MERLIN  single locate -look-for mli -position 41:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 11,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 41:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 26,
+    "col": 2
+  }
+
+(* class *)
+  $ $MERLIN  single locate -look-for mli -position 42:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 12,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 42:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 27,
+    "col": 8
+  }
+
+  $ $MERLIN  single locate -look-for mli -position 43:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 13,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 43:12 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 28,
+    "col": 6
+  }
+
+(* class type *)
+  $ $MERLIN  single locate -look-for mli -position 44:17 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 14,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 44:17 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 29,
+    "col": 13
+  }
+
+  $ $MERLIN  single locate -look-for mli -position 44:26 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 15,
+    "col": 2
+  }
+
+  $ $MERLIN  single locate -look-for ml -position 44:26 \
+  > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
+  {
+    "line": 30,
+    "col": 6
+  }

--- a/tests/test-dirs/locate/check-locs.t
+++ b/tests/test-dirs/locate/check-locs.t
@@ -45,8 +45,6 @@
   > let _ = fun (_ : ct) (_ : dt) -> ()
   > EOF
 
-FIXME Most of the following locs are wrong. 
-
 We expect merlin to jump to the identifier, not the beginning of the definition
 / declaration.
 
@@ -55,7 +53,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 2,
-    "col": 2
+    "col": 6
   }
 
   $ $MERLIN  single locate -look-for ml -position 33:8 \
@@ -70,14 +68,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 3,
-    "col": 2
+    "col": 11
   }
 
   $ $MERLIN  single locate -look-for ml -position 34:8 \
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 18,
-    "col": 2
+    "col": 11
   }
 
 (* type *)
@@ -85,14 +83,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 4,
-    "col": 2
+    "col": 7
   }
 
   $ $MERLIN  single locate -look-for ml -position 35:8 \
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 19,
-    "col": 2
+    "col": 7
   }
 
 (* typext *)
@@ -100,14 +98,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 5,
-    "col": 2
+    "col": 7
   }
 
   $ $MERLIN  single locate -look-for ml -position 36:8 \
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 20,
-    "col": 2
+    "col": 7
   }
 
 (* exception *)
@@ -115,14 +113,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
   {
     "line": 7,
-    "col": 2
+    "col": 12
   }
 
   $ $MERLIN  single locate -look-for ml -position 37:15 \
   > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
   {
     "line": 22,
-    "col": 2
+    "col": 12
   }
 
 (* module *)
@@ -130,14 +128,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
   {
     "line": 8,
-    "col": 2
+    "col": 9
   }
 
   $ $MERLIN  single locate -look-for ml -position 38:11 \
   > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
   {
     "line": 23,
-    "col": 2
+    "col": 9
   }
 
 (* module rec *)
@@ -145,7 +143,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml  | jq ".value.pos"
   {
     "line": 9,
-    "col": 2
+    "col": 13
   }
 
   $ $MERLIN  single locate -look-for ml -position 39:11 \
@@ -159,7 +157,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 10,
-    "col": 2
+    "col": 6
   }
 
   $ $MERLIN  single locate -look-for ml -position 40:11 \
@@ -174,14 +172,14 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 11,
-    "col": 2
+    "col": 14
   }
 
   $ $MERLIN  single locate -look-for ml -position 41:12 \
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 26,
-    "col": 2
+    "col": 14
   }
 
 (* class *)
@@ -189,7 +187,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 12,
-    "col": 2
+    "col": 8
   }
 
   $ $MERLIN  single locate -look-for ml -position 42:12 \
@@ -203,7 +201,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 13,
-    "col": 2
+    "col": 6
   }
 
   $ $MERLIN  single locate -look-for ml -position 43:12 \
@@ -218,7 +216,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 14,
-    "col": 2
+    "col": 13
   }
 
   $ $MERLIN  single locate -look-for ml -position 44:17 \
@@ -232,7 +230,7 @@ We expect merlin to jump to the identifier, not the beginning of the definition
   > -filename ./locs.ml < ./locs.ml | jq ".value.pos"
   {
     "line": 15,
-    "col": 2
+    "col": 6
   }
 
   $ $MERLIN  single locate -look-for ml -position 44:26 \

--- a/tests/test-dirs/locate/context-detection/cd-field.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-field.t/run.t
@@ -6,7 +6,7 @@
       "file": "$TESTCASE_ROOT/field.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
@@ -19,7 +19,7 @@
       "file": "$TESTCASE_ROOT/field.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
@@ -34,7 +34,7 @@ the field bar rather than the identifier.
       "file": "$TESTCASE_ROOT/field.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/context-detection/cd-from_a_pattern.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-from_a_pattern.t/run.t
@@ -31,7 +31,7 @@ We call locate from the broken pattern:
       "file": "$TESTCASE_ROOT/from_a_pattern.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/context-detection/cd-label.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-label.t/run.t
@@ -42,14 +42,14 @@
   }
 
 FIXME: this is not a very satisfying answer. 
-We could expect 2:12 or at least 2:4
+We could expect 2:12
   $ $MERLIN single locate  -look-for ml -position 3:24 \
   > -filename ./record.ml < ./record.ml | jq '.value'
   {
     "file": "$TESTCASE_ROOT/record.ml",
     "pos": {
       "line": 1,
-      "col": 0
+      "col": 5
     }
   }
 

--- a/tests/test-dirs/locate/context-detection/cd-test.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-test.t/run.t
@@ -7,20 +7,23 @@ Trying them all:
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
   }
 
-  $ $MERLIN single locate -look-for ml -position 7:17 -filename ./test.ml < ./test.ml
+We expect 3:12
+
+  $ $MERLIN single locate -look-for ml -position 7:17 \
+  > -filename ./test.ml < ./test.ml
   {
     "class": "return",
     "value": {
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 3,
-        "col": 0
+        "col": 12
       }
     },
     "notifications": []
@@ -33,7 +36,7 @@ Trying them all:
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 7,
-        "col": 0
+        "col": 12
       }
     },
     "notifications": []
@@ -54,6 +57,8 @@ FIXME this should say "Already at definition point" (we're defining the label):
     "notifications": []
   }
 
+We expect 1:5
+
   $ $MERLIN single locate -look-for ml -position 13:16 -filename ./test.ml < ./test.ml
   {
     "class": "return",
@@ -61,7 +66,7 @@ FIXME this should say "Already at definition point" (we're defining the label):
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
@@ -89,6 +94,8 @@ FIXME we failed to parse/reconstruct the ident, that's interesting
     "notifications": []
   }
 
+We expect 1:5
+
   $ $MERLIN single locate -look-for ml -position 16:20 -filename ./test.ml < ./test.ml
   {
     "class": "return",
@@ -96,7 +103,7 @@ FIXME we failed to parse/reconstruct the ident, that's interesting
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
@@ -109,20 +116,23 @@ FIXME we failed to parse/reconstruct the ident, that's interesting
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
   }
 
-  $ $MERLIN single locate -look-for ml -position 18:15 -filename ./test.ml < ./test.ml
+We expect 11:10
+
+  $ $MERLIN single locate -look-for ml -position 18:15 \
+  > -filename ./test.ml < ./test.ml
   {
     "class": "return",
     "value": {
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 11,
-        "col": 0
+        "col": 10
       }
     },
     "notifications": []
@@ -144,6 +154,8 @@ FIXME this should jump to line 11:
     "notifications": []
   }
 
+FIXME unprecise, we want 13:12
+
   $ $MERLIN single locate -look-for ml -position 23:13 -filename ./test.ml < ./test.ml
   {
     "class": "return",
@@ -151,7 +163,7 @@ FIXME this should jump to line 11:
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 13,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []
@@ -177,7 +189,7 @@ FIXME this should jump to line 11:
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
         "line": 13,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/functors/f-all_local.t/run.t
+++ b/tests/test-dirs/locate/functors/f-all_local.t/run.t
@@ -7,7 +7,7 @@ Check that we can jump locally inside the functor:
       "file": "$TESTCASE_ROOT/all_local.ml",
       "pos": {
         "line": 12,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -53,7 +53,7 @@ Check the argument is substituted for the parameter
       "file": "$TESTCASE_ROOT/all_local.ml",
       "pos": {
         "line": 6,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/functors/f-from_application.t/run.t
+++ b/tests/test-dirs/locate/functors/f-from_application.t/run.t
@@ -8,7 +8,7 @@ FIXME: we confuse the module for the constructor and jump to the wrong place
       "file": "$TESTCASE_ROOT/from_application.ml",
       "pos": {
         "line": 5,
-        "col": 0
+        "col": 7
       }
     },
     "notifications": []
@@ -23,7 +23,7 @@ Jump from inside the functor application to inside the functor application:
       "file": "$TESTCASE_ROOT/from_application.ml",
       "pos": {
         "line": 14,
-        "col": 4
+        "col": 9
       }
     },
     "notifications": []
@@ -38,7 +38,7 @@ Jump from inside the functor application to the outer scope:
       "file": "$TESTCASE_ROOT/from_application.ml",
       "pos": {
         "line": 9,
-        "col": 0
+        "col": 5
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/functors/f-generative.t/run.t
+++ b/tests/test-dirs/locate/functors/f-generative.t/run.t
@@ -7,7 +7,7 @@ Check that we handle generative functors properly:
       "file": "$TESTCASE_ROOT/generative.ml",
       "pos": {
         "line": 3,
-        "col": 2
+        "col": 6
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/functors/f-missed_shadowing.t/run.t
+++ b/tests/test-dirs/locate/functors/f-missed_shadowing.t/run.t
@@ -22,7 +22,7 @@ Reproduce bug described (and fixed) in commit e558d203334fd06f7653a6388b46dba895
       "file": "$TESTCASE_ROOT/missed_shadowing.ml",
       "pos": {
         "line": 7,
-        "col": 0
+        "col": 12
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/functors/f-nested_applications.t/run.t
+++ b/tests/test-dirs/locate/functors/f-nested_applications.t/run.t
@@ -7,7 +7,7 @@
       "file": "$TESTCASE_ROOT/nested_applications.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -21,7 +21,7 @@
       "file": "$TESTCASE_ROOT/nested_applications.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -35,7 +35,7 @@
       "file": "$TESTCASE_ROOT/nested_applications.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -49,7 +49,7 @@
       "file": "$TESTCASE_ROOT/nested_applications.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []
@@ -63,7 +63,7 @@
       "file": "$TESTCASE_ROOT/nested_applications.ml",
       "pos": {
         "line": 10,
-        "col": 2
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/issue1199.t
+++ b/tests/test-dirs/locate/issue1199.t
@@ -30,7 +30,7 @@ straight to the functor.
       "file": "$TESTCASE_ROOT/func.ml",
       "pos": {
         "line": 5,
-        "col": 0
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/l-413-features.t
+++ b/tests/test-dirs/locate/l-413-features.t
@@ -58,7 +58,7 @@ Module types substitutions
       "file": "$TESTCASE_ROOT/mtsubst.ml",
       "pos": {
         "line": 5,
-        "col": 19
+        "col": 31
       }
     },
     "notifications": []
@@ -86,7 +86,7 @@ Module types substitutions
       "file": "$TESTCASE_ROOT/mtsubst.ml",
       "pos": {
         "line": 5,
-        "col": 19
+        "col": 31
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/locate-constrs.t
+++ b/tests/test-dirs/locate/locate-constrs.t
@@ -17,15 +17,14 @@
     }
   }
 
-FIXME: this is not a very satisfying answer. 
-We could expect 1:9
+We expect 1:23
   $ $MERLIN single locate  -look-for ml -position 2:14 \
   > -filename ./constr.ml < ./constr.ml | jq '.value'
   {
     "file": "$TESTCASE_ROOT/constr.ml",
     "pos": {
       "line": 1,
-      "col": 0
+      "col": 5
     }
   }
 

--- a/tests/test-dirs/locate/module-aliases.t/run.t
+++ b/tests/test-dirs/locate/module-aliases.t/run.t
@@ -73,7 +73,7 @@ declaration of the alias and not to the aliased module itself.
     "file": "$TESTCASE_ROOT/main.ml",
     "pos": {
       "line": 1,
-      "col": 0
+      "col": 7
     }
   }
 
@@ -176,6 +176,6 @@ declaration of the alias and not to the aliased module itself.
     "file": "$TESTCASE_ROOT/main.ml",
     "pos": {
       "line": 1,
-      "col": 0
+      "col": 7
     }
   }

--- a/tests/test-dirs/locate/reconstruct-identifier/off_by_one.t/run.t
+++ b/tests/test-dirs/locate/reconstruct-identifier/off_by_one.t/run.t
@@ -7,7 +7,7 @@ Regression test for #624
       "file": "$TESTCASE_ROOT/off_by_one.ml",
       "pos": {
         "line": 1,
-        "col": 0
+        "col": 7
       }
     },
     "notifications": []

--- a/tests/test-dirs/locate/sig-substs.t/run.t
+++ b/tests/test-dirs/locate/sig-substs.t/run.t
@@ -9,7 +9,7 @@ when both are present in the buffer (the struct will always be preferred).
       "file": "$TESTCASE_ROOT/basic.ml",
       "pos": {
         "line": 8,
-        "col": 2
+        "col": 9
       }
     },
     "notifications": []
@@ -23,7 +23,7 @@ TODO SHAPES: it could be more precise by answering 8:21
       "file": "$TESTCASE_ROOT/basic.ml",
       "pos": {
         "line": 8,
-        "col": 2
+        "col": 9
       }
     },
     "notifications": []


### PR DESCRIPTION
The compiler registers UIDs' location during typing.
This is used by `locate` to perform jump to definition:
1. first locate reduce the shape of the identifier and gets its definition's UID
2. then Merlin queries the uid-to-loc table to get the location of the definition

However right these location are not the one we could expect: the compiler register the location of the definition's (or decl's) node instead of its name.

That means that when locating type `t`'s definition Merlin will jump to `  |type t = int` instead of `  type |t = int`.

This is not a big issue for the locate command since the user does land near the expected location, but it will be much more of an issue when performing `occurrences`queries based on shapes. If the user wants to rename an identifier after performing such a query we need to return the names/labels loc and not the nodes'.

These changes fix that issue for the working buffer but need to be upstreamed to the compiler for them to take effect in external modules (I will open a PR as soon as possible @Octachron).