### PR TITLE
Accept the `-safe-string` flag but make it a no-op

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+merlin 4.7.1
+==========
+Thu Dec 13 12:49:42 CEST 2022
+
+  + merlin binary
+    - Restore compatibility with the compielr command line by accepting the
+      `-safe-string` flag as a no-op instead of rejecting it. (#1544, fixes
+      #1518)
+
 merlin 4.7
 ==========
 Thu Nov 24 17:49:42 CEST 2022

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -133,20 +133,20 @@ module Verbosity = struct
 
   let default = Lvl 0
 
-  let to_int t ~for_smart = 
-    match t with 
+  let to_int t ~for_smart =
+    match t with
     | Smart -> for_smart
     | Lvl v -> v
 
   let param_spec = "\"smart\" | <integer>"
 
-  let of_string = function 
-    | "smart" -> Smart 
+  let of_string = function
+    | "smart" -> Smart
     | maybe_int ->
       try Lvl (int_of_string maybe_int)
       with _ -> invalid_arg ("argument should be: " ^ param_spec)
 
-  let to_string = function 
+  let to_string = function
     | Smart -> "smart"
     | Lvl v -> "lvl " ^ (string_of_int v)
 
@@ -366,7 +366,7 @@ let query_flags = [
     "-verbosity",
     Marg.param Verbosity.param_spec (fun verbosity query ->
         let verbosity =
-          Verbosity.of_string verbosity        
+          Verbosity.of_string verbosity
         in
         {query with verbosity}),
     "\"smart\" | <integer> Verbosity determines the number of \
@@ -500,6 +500,11 @@ let ocaml_flags = [
     "-vmthread",
     Marg.unit (fun ocaml -> {ocaml with threads = `None}),
     " Add support for VM-scheduled threads library"
+  );
+  (
+    "-safe-string",
+    Marg.unit (fun ocaml -> ocaml),
+    " Default to true unconditionally since 5.00"
   );
   (
     "-nopervasives",

--- a/tests/test-dirs/issue1518.t
+++ b/tests/test-dirs/issue1518.t
@@ -16,15 +16,8 @@
   $ dune exec ./main.exe
   42
 
-FIXME: in 5.0 the compiler still accept the deleted flag "-safe-string". It
-simply is a noop. Merlin should ignore it as well.
+In 5.0 the compiler still accept the deleted flag "-safe-string". 
+It simply is a no-op. Merlin should ignore it as well.
   $ $MERLIN single errors -filename main.ml <main.ml |
   > jq '.value'
-  [
-    {
-      "type": "config",
-      "sub": [],
-      "valid": true,
-      "message": "unknown flag -safe-string"
-    }
-  ]
+  []

--- a/tests/test-dirs/issue1518.t
+++ b/tests/test-dirs/issue1518.t
@@ -1,0 +1,30 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > print_endline "42"
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable
+  >  (name main)
+  >  (flags :standard -safe-string))
+  > EOF
+
+
+  $ dune exec ./main.exe
+  42
+
+FIXME: in 5.0 the compiler still accept the deleted flag "-safe-string". It
+simply is a noop. Merlin should ignore it as well.
+  $ $MERLIN single errors -filename main.ml <main.ml |
+  > jq '.value'
+  [
+    {
+      "type": "config",
+      "sub": [],
+      "valid": true,
+      "message": "unknown flag -safe-string"
+    }
+  ]


### PR DESCRIPTION
This should fix #1518 

@kit-ty-kate do you no if other configuration options have been removed from OCaml 5 but are still accepted by the compiler as a no-op ?