### PR TITLE
Backport: mark some C variables as unused (#1541)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Thu Dec 13 12:49:42 CEST 2022
     - Restore compatibility with the compielr command line by accepting the
       `-safe-string` flag as a no-op instead of rejecting it. (#1544, fixes
       #1518)
+    - mark some C variables as unused to remove warnings (#1541, @antalsz)
 
 merlin 4.7
 ==========

--- a/src/platform/platform_misc.c
+++ b/src/platform/platform_misc.c
@@ -80,6 +80,7 @@ value ml_merlin_fs_exact_case_basename(value path)
 
 value ml_merlin_fs_exact_case_basename(value path)
 {
+  (void)path;
   return Val_int(0);
 }
 
@@ -187,6 +188,8 @@ value ml_merlin_dont_inherit_stdio(value vstatus)
 
 CAMLprim value ml_merlin_system_command(value v_command, value v_cwd)
 {
+  (void)v_command;
+  (void)v_cwd;
   caml_invalid_argument("ml_merlin_system_command is only available on windows");
 }
 


### PR DESCRIPTION
from antalsz/unused-c-variables