### PR TITLE
Locate fails in ill-typed expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ unreleased
       incorrectly rejected by Merlin. (#1556)
     - Traverse aliases when jumping to declaration. This matches
       jump-to-definition'q behavior (#1563)
+    - Improve locate's behavior in various ill-typed expressions (#1546, fixes
+      #1567 and partially #1543)
+  + test suite
+    - Add multiple tests for locate over ill-typed expressions (#1546)
 
 merlin 4.7
 ==========

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -2246,7 +2246,8 @@ let check_unused ?(lev=get_current_level ()) env expected_ty cases =
           env expected_ty constrs labels spat
       with
         Some pat when refute ->
-          raise (error (spat.ppat_loc, env, Unrefuted_pattern pat))
+          raise_error (error (spat.ppat_loc, env, Unrefuted_pattern pat));
+          Some pat
       | r -> r)
     cases
 

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -4074,8 +4074,10 @@ and type_expect_
       | exception exn ->
         raise_error exn;
         (* We're dropping the local open node and keeping only its body.
-           Seems fine. *)
-        type_expect env e ty_expected_explained
+           We also don't report any error in the body, as there's no way to
+           tell if it is due to the failed open. *)
+        Msupport.catch_errors (Warnings.backup ()) (ref [])
+          (fun () -> type_expect env e ty_expected_explained)
       end
   | Pexp_letop{ let_ = slet; ands = sands; body = sbody } ->
       let rec loop spat_acc ty_acc sands =

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -4238,7 +4238,10 @@ and type_function ?(in_function : (Location.t * type_expr) option)
             | None   -> Not_a_function(ty_fun, explanation)
           end
       in
-      raise (error(loc_fun, env, err))
+      (* Merlin: we recover with an expected type of 'a -> 'b *)
+      let level = get_level (instance ty_expected) in
+      raise_error (error(loc_fun, env, err));
+      (newvar2 level, newvar2 level)
   in
   let ty_arg =
     if is_optional arg_label then

--- a/tests/test-dirs/locate/ill-typed/local-open.t
+++ b/tests/test-dirs/locate/ill-typed/local-open.t
@@ -1,0 +1,11 @@
+  $ cat >open.ml <<EOF
+  > let x = false
+  > let f () =
+  >   let open Unknown in
+  >   x
+  > ;;
+  > EOF
+
+  $ $MERLIN single locate -position 4:2 \
+  > -filename open.ml <open.ml | jq '.value'
+  "Not in environment 'x'"

--- a/tests/test-dirs/locate/ill-typed/local-open.t
+++ b/tests/test-dirs/locate/ill-typed/local-open.t
@@ -7,5 +7,8 @@
   > EOF
 
   $ $MERLIN single locate -position 4:2 \
-  > -filename open.ml <open.ml | jq '.value'
-  "Not in environment 'x'"
+  > -filename open.ml <open.ml | jq '.value.pos'
+  {
+    "line": 1,
+    "col": 4
+  }

--- a/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
+++ b/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
@@ -50,11 +50,17 @@ Merlin is still able to give the type of an identifier involved in the error:
     "tail": "no"
   }
 
-Fixme: But fails to locate it's definition:
+And locate finds its definition:
   $ $MERLIN single locate -position 9:13 \
   > -filename ill.ml <ill.ml
   {
     "class": "return",
-    "value": "Not in environment 'problem'",
+    "value": {
+      "file": "$TESTCASE_ROOT/ill.ml",
+      "pos": {
+        "line": 4,
+        "col": 6
+      }
+    },
     "notifications": []
   }

--- a/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
+++ b/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
@@ -1,0 +1,60 @@
+  $ cat >ill.ml <<EOF
+  > module ERROR_locate_from_incorrectly_refutable_match = struct
+  >   (* We expect to end up here.
+  >    *  vvvvvvv *)
+  >   let problem = \`Problem
+  > 
+  >   let () =
+  >     (* We jump to defn or intf from here:
+  >      *    vvvvvvv *)
+  >     match problem with
+  >     | _ -> .
+  >   ;;
+  > 
+  >   (* We get the message "Not in environment 'problem'" and go nowhere. *)
+  > end
+  > EOF
+
+When a typing error happens:
+  $ $MERLIN single errors \
+  > -filename ill.ml <ill.ml |
+  > tr '\r\n' ' ' | jq '.value[0]'
+  {
+    "start": {
+      "line": 10,
+      "col": 6
+    },
+    "end": {
+      "line": 10,
+      "col": 7
+    },
+    "type": "typer",
+    "sub": [],
+    "valid": true,
+    "message": "This match case could not be refuted. Here is an example of a value that would reach it: _"
+  }
+
+Merlin is still able to give the type of an identifier involved in the error:
+  $ $MERLIN single type-enclosing -position 9:13 \
+  > -filename ill.ml <ill.ml | jq '.value[0]'
+  {
+    "start": {
+      "line": 9,
+      "col": 10
+    },
+    "end": {
+      "line": 9,
+      "col": 17
+    },
+    "type": "[> `Problem ]",
+    "tail": "no"
+  }
+
+Fixme: But fails to locate it's definition:
+  $ $MERLIN single locate -position 9:13 \
+  > -filename ill.ml <ill.ml
+  {
+    "class": "return",
+    "value": "Not in environment 'problem'",
+    "notifications": []
+  }

--- a/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
+++ b/tests/test-dirs/locate/ill-typed/locate-cannot-refute.t
@@ -52,15 +52,8 @@ Merlin is still able to give the type of an identifier involved in the error:
 
 And locate finds its definition:
   $ $MERLIN single locate -position 9:13 \
-  > -filename ill.ml <ill.ml
+  > -filename ill.ml <ill.ml | jq '.value.pos'
   {
-    "class": "return",
-    "value": {
-      "file": "$TESTCASE_ROOT/ill.ml",
-      "pos": {
-        "line": 4,
-        "col": 6
-      }
-    },
-    "notifications": []
+    "line": 4,
+    "col": 6
   }

--- a/tests/test-dirs/locate/ill-typed/locate-non-fun.t
+++ b/tests/test-dirs/locate/ill-typed/locate-non-fun.t
@@ -1,0 +1,61 @@
+  $ cat >ill.ml <<EOF
+  > module ERROR_locate_from_non_function_being_applied_sometimes = struct
+  >   let remove_duplicates : 'a list -> eq:('a -> 'a -> bool) -> 'a list =
+  >     fun _ ~eq:_ ->
+  >       (* Pretend we have an implementation *)
+  >       []
+  >   ;;
+  > 
+  >   (* We expect to end up here:
+  >    *  vvvvvvv *)
+  >   let problem = \`Problem
+  >   let cmp a b = Float.compare a b
+  > 
+  >   (* We jump from here:
+  >    *                                                              vvvvvvv *)
+  >   let () = remove_duplicates ~eq:Int.equal (ListLabels.sort ~cmp (problem 1.0))
+  > 
+  >   (* We get the error message "Not in environment 'problem'" and go nowhere. *)
+  > end
+  > EOF
+
+When some typing error happens
+
+  $ $MERLIN single errors \
+  > -filename ill.ml <ill.ml |
+  > tr '\r\n' ' ' | jq '.value[0]'
+  {
+    "start": {
+      "line": 15,
+      "col": 33
+    },
+    "end": {
+      "line": 15,
+      "col": 42
+    },
+    "type": "typer",
+    "sub": [],
+    "valid": true,
+    "message": "This expression has type int -> int -> bool but an expression was expected of type Float.t -> Float.t -> bool Type int is not compatible with type Float.t = float"
+  }
+
+Merlin is still able to inspect part of the ill-typed tree
+  $ $MERLIN single type-enclosing -position 15:70 \
+  > -filename ill.ml <ill.ml | tr '\r\n' ' ' | jq '.value[0]'
+  {
+    "start": {
+      "line": 15,
+      "col": 66
+    },
+    "end": {
+      "line": 15,
+      "col": 73
+    },
+    "type": "[> `Problem ]",
+    "tail": "no"
+  }
+
+FIXME: And locate should as well...
+  $ $MERLIN single locate -position 15:70 \
+  > -filename ill.ml <ill.ml | jq '.value'
+  "Not in environment 'problem'"

--- a/tests/test-dirs/locate/ill-typed/not-a-function.t
+++ b/tests/test-dirs/locate/ill-typed/not-a-function.t
@@ -56,7 +56,10 @@ Merlin is still able to inspect part of the ill-typed tree
     "tail": "no"
   }
 
-FIXME and we expect locate to work as well
+And locate works as well
   $ $MERLIN single locate -position 8:25 \
-  > -filename ill.ml <ill.ml | jq '.value'
-  "Not in environment 'problem'"
+  > -filename ill.ml <ill.ml | jq '.value.pos'
+  {
+    "line": 4,
+    "col": 6
+  }

--- a/tests/test-dirs/locate/ill-typed/not-a-function.t
+++ b/tests/test-dirs/locate/ill-typed/not-a-function.t
@@ -1,0 +1,62 @@
+  $ cat >ill.ml <<EOF
+  > module ERROR_locate_from_inside_function_literal_used_as_non_function = struct
+  >   (* We expect to end up here:
+  >    *  vvvvvvv *)
+  >   let problem = \`Problem
+  > 
+  >   (* We jump to the definition or interface from here...:
+  >    *                 vvvvvvv *)
+  >   let () = fun () -> problem
+  > 
+  >   (* ...or from here...:
+  >    *                                vvvvvvv *)
+  >   let _ : int = Int.succ (fun () -> problem)
+  >   
+  >   (* ...or from here:
+  >    *                                      vvvvvvv *)
+  >   let not_a_function : string = fun () -> problem
+  > 
+  >   (* We get the error message "Not in environment 'problem'" and go nowhere. *)
+  > end
+  > EOF
+
+When some typing error happens
+
+  $ $MERLIN single errors \
+  > -filename ill.ml <ill.ml |
+  > tr '\r\n' ' ' | jq '.value[0]'
+  {
+    "start": {
+      "line": 8,
+      "col": 11
+    },
+    "end": {
+      "line": 8,
+      "col": 28
+    },
+    "type": "typer",
+    "sub": [],
+    "valid": true,
+    "message": "This expression should not be a function, the expected type is unit"
+  }
+
+Merlin is still able to inspect part of the ill-typed tree
+  $ $MERLIN single type-enclosing -position 8:25 \
+  > -filename ill.ml <ill.ml | jq '.value[0]'
+  {
+    "start": {
+      "line": 8,
+      "col": 21
+    },
+    "end": {
+      "line": 8,
+      "col": 28
+    },
+    "type": "[> `Problem ]",
+    "tail": "no"
+  }
+
+FIXME and we expect locate to work as well
+  $ $MERLIN single locate -position 8:25 \
+  > -filename ill.ml <ill.ml | jq '.value'
+  "Not in environment 'problem'"

--- a/tests/test-dirs/type-enclosing/inside-tydecl.t
+++ b/tests/test-dirs/type-enclosing/inside-tydecl.t
@@ -1,0 +1,78 @@
+test
+
+  $ $MERLIN single type-enclosing -position 1:18 -filename inside_decl.ml \
+  > -log-section type-enclosing -log-file - <<EOF
+  > type t1 = [ \`A of t1 | \`B ]
+  > EOF
+  # 0.01 type-enclosing - reconstruct-identifier
+  paths: [t1]
+  # 0.01 type-enclosing - reconstruct identifier
+  [
+    { "start": { "line": 1, "col": 18 }, "end": { "line": 1, "col": 20 },
+    "identifier": "t1" }
+  ]
+  # 0.01 type-enclosing - from_reconstructed
+  node = core_type
+  exprs = [t1]
+  # 0.01 type-enclosing - from_reconstructed
+  source = t1; context = type
+  # 0.01 type-enclosing - from_reconstructed
+  typed t1
+  # 0.01 type-enclosing - small enclosing
+  result = [ File "inside_decl.ml", line 1, characters 18-20 ]
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 18
+        },
+        "end": {
+          "line": 1,
+          "col": 20
+        },
+        "type": "type t1 = t1",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 18
+        },
+        "end": {
+          "line": 1,
+          "col": 20
+        },
+        "type": "t1",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 10
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": "[ `A of t1 | `B ]",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": "type t1 = [ `A of t1 | `B ]",
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+test

--- a/tests/test-dirs/type-enclosing/inside-tydecl.t
+++ b/tests/test-dirs/type-enclosing/inside-tydecl.t
@@ -1,24 +1,21 @@
 test
 
   $ $MERLIN single type-enclosing -position 1:18 -filename inside_decl.ml \
-  > -log-section type-enclosing -log-file - <<EOF
+  > -log-section type-enclosing -log-file - <<EOF 2>&1 | grep -v "^#"
   > type t1 = [ \`A of t1 | \`B ]
   > EOF
-  # 0.01 type-enclosing - reconstruct-identifier
   paths: [t1]
-  # 0.01 type-enclosing - reconstruct identifier
   [
-    { "start": { "line": 1, "col": 18 }, "end": { "line": 1, "col": 20 },
-    "identifier": "t1" }
+    {
+      "start": { "line": 1, "col": 18 },
+      "end": { "line": 1, "col": 20 },
+      "identifier": "t1"
+    }
   ]
-  # 0.01 type-enclosing - from_reconstructed
   node = core_type
   exprs = [t1]
-  # 0.01 type-enclosing - from_reconstructed
   source = t1; context = type
-  # 0.01 type-enclosing - from_reconstructed
   typed t1
-  # 0.01 type-enclosing - small enclosing
   result = [ File "inside_decl.ml", line 1, characters 18-20 ]
   {
     "class": "return",

--- a/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -294,6 +294,30 @@ We try several places in the identifier to check the result stability
     "value": [
       {
         "start": {
+          "line": 5,
+          "col": 9
+        },
+        "end": {
+          "line": 5,
+          "col": 12
+        },
+        "type": "int",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 5,
+          "col": 4
+        },
+        "end": {
+          "line": 5,
+          "col": 12
+        },
+        "type": "int option",
+        "tail": "no"
+      },
+      {
+        "start": {
           "line": 2,
           "col": 18
         },
@@ -301,7 +325,19 @@ We try several places in the identifier to check the result stability
           "line": 5,
           "col": 17
         },
-        "type": "int",
+        "type": "int option -> int",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 10
+        },
+        "end": {
+          "line": 5,
+          "col": 17
+        },
+        "type": "'a",
         "tail": "no"
       },
       {
@@ -313,7 +349,7 @@ We try several places in the identifier to check the result stability
           "line": 5,
           "col": 17
         },
-        "type": "'a -> int",
+        "type": "'a -> 'b",
         "tail": "no"
       }
     ],

--- a/tests/test-dirs/typing-recovery.t
+++ b/tests/test-dirs/typing-recovery.t
@@ -693,21 +693,6 @@ FIXME
         "valid": true,
         "message": "Unbound module Lsit
   Hint: Did you mean List?"
-      },
-      {
-        "start": {
-          "line": 9,
-          "col": 2
-        },
-        "end": {
-          "line": 9,
-          "col": 5
-        },
-        "type": "typer",
-        "sub": [],
-        "valid": true,
-        "message": "Unbound value map
-  Hint: Did you mean max?"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/typing-recovery.t
+++ b/tests/test-dirs/typing-recovery.t
@@ -639,3 +639,76 @@ make sure we also handle that correctly in structures:
   ",
     "notifications": []
   }
+
+# Spurious errors
+
+Sometimes typing recovery consists in dropping intermediate nodes, which could
+generate errors in subtrees. We don't want to tell the user about sub errors,
+since they might go away when fixing the first one.
+
+FIXME
+
+  $ cat >open.ml <<EOF
+  > let x = false
+  > let f () =
+  >   let open Unknown in
+  >   x
+  > ;;
+  > 
+  > let g () =
+  >   let open Lsit in
+  >   map
+  > ;;
+  > EOF
+
+  $ $MERLIN single errors -filename open.ml < open.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 11
+        },
+        "end": {
+          "line": 3,
+          "col": 18
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module Unknown"
+      },
+      {
+        "start": {
+          "line": 8,
+          "col": 11
+        },
+        "end": {
+          "line": 8,
+          "col": 15
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module Lsit
+  Hint: Did you mean List?"
+      },
+      {
+        "start": {
+          "line": 9,
+          "col": 2
+        },
+        "end": {
+          "line": 9,
+          "col": 5
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound value map
+  Hint: Did you mean max?"
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
This PR tracks the progress on fixing issue #1543.

- [x] Bug 1
- [x] Bug 2
- [ ] Bug 3

Merlin tries to recover from typing errors, but large part of the typedtree are sometimes dropped. Fixing the error cases documented in #1543 requires improvement to the typing recovery.