### PR TITLE
Recognize OCaml 5.0 cmi magic number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+merlin 4.7.2
+============
+undefined
+
+  + merlin binary
+    - Recognize OCaml 5.0 cmi magic number in compiler version mismatch message
+      (#1554, fixes #1553)
+
 merlin 4.7.1
 ==========
 Thu Dec 13 11:49:42 CEST 2022

--- a/src/ocaml/typing/magic_numbers.ml
+++ b/src/ocaml/typing/magic_numbers.ml
@@ -22,7 +22,10 @@ module Cmi = struct
     | "Caml1999I029" -> Some "4.12"
     | "Caml1999I030" -> Some "4.13"
     | "Caml1999I031" -> Some "4.14"
+    | "Caml1999I032" -> Some "5.0"
     | _ -> None
+
+  let () = assert (to_version_opt Config.cmi_magic_number <> None)
 
   open Format
 


### PR DESCRIPTION
And add an assertion that we can recognize our own magic number that we got compiled with.

Fixes https://github.com/ocaml/merlin/issues/1553

