### PR TITLE
Add missing ocamlc flags to the ignore list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ unreleased
     - Update internal typer to match OCaml 4.14.1 release. (#1557)
     - Improve type-enclosing behaviour when used on records' labels (#1565,
       fixes #1564)
+    - Restore compatibility with some OCaml compiler's debug flags that were
+      incorrectly rejected by Merlin. (#1556)
 
 merlin 4.7
 ==========

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -135,20 +135,20 @@ module Verbosity = struct
 
   let default = Lvl 0
 
-  let to_int t ~for_smart = 
-    match t with 
+  let to_int t ~for_smart =
+    match t with
     | Smart -> for_smart
     | Lvl v -> v
 
   let param_spec = "\"smart\" | <integer>"
 
-  let of_string = function 
-    | "smart" -> Smart 
+  let of_string = function
+    | "smart" -> Smart
     | maybe_int ->
       try Lvl (int_of_string maybe_int)
       with _ -> invalid_arg ("argument should be: " ^ param_spec)
 
-  let to_string = function 
+  let to_string = function
     | Smart -> "smart"
     | Lvl v -> "lvl " ^ (string_of_int v)
 
@@ -368,7 +368,7 @@ let query_flags = [
     "-verbosity",
     Marg.param Verbosity.param_spec (fun verbosity query ->
         let verbosity =
-          Verbosity.of_string verbosity        
+          Verbosity.of_string verbosity
         in
         {query with verbosity}),
     "\"smart\" | <integer> Verbosity determines the number of \

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -404,7 +404,7 @@ let ocaml_ignored_flags = [
   "-no-unbox-specialised-args"; "-O2"; "-O3"; "-Oclassic"; "-opaque";
   "-output-complete-obj"; "-output-obj"; "-p"; "-pack";
   "-remove-unused-arguments"; "-S"; "-shared"; "-unbox-closures"; "-v";
-  "-verbose"; "-where"; "-force-tmc";
+  "-verbose"; "-where";
 ]
 
 let ocaml_ignored_parametrized_flags = [

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -392,7 +392,7 @@ let ocaml_ignored_flags = [
   "-c"; "-compact"; "-compat-32"; "-config"; "-custom"; "-dalloc";
   "-dclambda"; "-dcmm"; "-dcombine"; "-dcse"; "-dflambda";
   "-dflambda-no-invariants"; "-dflambda-verbose"; "-dinstr"; "-dinterf";
-  "-dlambda"; "-dlinear"; "-dlive"; "-dparsetree"; "-dprefer";
+  "-dlambda"; "-dlinear"; "-dlive"; "-dparsetree"; "-dprefer"; "-dshape";
   "-drawclambda"; "-drawflambda"; "-drawlambda"; "-dreload"; "-dscheduling";
   "-dsel"; "-dsource"; "-dspill"; "-dsplit"; "-dstartup"; "-dtimings";
   "-dtypedtree"; "-dtypes"; "-dump-pass"; "-fno-PIC"; "-fPIC"; "-g"; "-i";
@@ -404,7 +404,7 @@ let ocaml_ignored_flags = [
   "-no-unbox-specialised-args"; "-O2"; "-O3"; "-Oclassic"; "-opaque";
   "-output-complete-obj"; "-output-obj"; "-p"; "-pack";
   "-remove-unused-arguments"; "-S"; "-shared"; "-unbox-closures"; "-v";
-  "-verbose"; "-where";
+  "-verbose"; "-where"; "-force-tmc";
 ]
 
 let ocaml_ignored_parametrized_flags = [
@@ -415,7 +415,7 @@ let ocaml_ignored_parametrized_flags = [
   "-inline"; "-inline-prim-cost"; "-inline-toplevel"; "-intf";
   "-intf_suffix"; "-intf-suffix"; "-o"; "-rounds"; "-runtime-variant";
   "-unbox-closures-factor"; "-use-prims"; "-use_runtime"; "-use-runtime";
-  "-error-style";
+  "-error-style"; "-dump-dir";
 ]
 
 let ocaml_warnings_spec ~error =


### PR DESCRIPTION
These flags where added to OCaml 4.14 but are not accepted by Merlin.

Note for the 5.0 backport: the flag `-force-tmc` was removed in 5.0.

CC @antalsz 