### PR TITLE
ocamlmerlin.c: chdir to root also on Windows to continue working if cwd is deleted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ unreleased
     - Correctly traverse patterns when looking for docs in the typedtree (#1572)
     - Get documentation when the declaration or definition is selected (#1542,
       fixes #1540)
+    - On Windows, change to a harmless directory when launching server to avoid
+      locking down current directory. (#1569, fixes #1474)
   + test suite
     - Add multiple tests for locate over ill-typed expressions (#1546)
 

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -153,6 +153,7 @@ let run ~new_env wd args =
     Os_ipc.merlin_set_environ env;
     Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()))
   | None -> () end;
+  let old_wd = Sys.getcwd () in
   let wd_msg = match wd with
     | None -> "No working directory specified"
     | Some wd ->
@@ -163,5 +164,5 @@ let run ~new_env wd args =
     Log_info.get ()
   in
   Logger.with_log_file log_file ~sections @@ fun () ->
-  log ~title:"run" "%s" wd_msg;
+  log ~title:"run" "%s (old wd: %S)" wd_msg old_wd;
   run args

--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -279,7 +279,7 @@ static int connect_socket(const char *socketname, int fail)
 #ifdef _WIN32
 static void start_server(const char *socketname, const char* eventname, const char *exec_path)
 {
-  char buf[PATHSZ];
+  char buf[PATHSZ], lpSystemDir[PATHSZ];
   PROCESS_INFORMATION pi;
   STARTUPINFO si;
   HANDLE hEvent = CreateEvent(NULL, FALSE, FALSE, eventname);
@@ -288,9 +288,12 @@ static void start_server(const char *socketname, const char* eventname, const ch
   ZeroMemory(&si, sizeof(si));
   si.cb = sizeof(si);
   ZeroMemory(&pi, sizeof(pi));
+  /* Change to a harmless directory, so that process still works if the current
+     directory is deleted. */
+  GetSystemDirectory(lpSystemDir, PATHSZ);
   /* Note that DETACHED_PROCESS means that the process does not appear in Task Manager
      but the server can still be stopped with ocamlmerlin server stop-server */
-  if (!CreateProcess(exec_path, buf, NULL, NULL, FALSE, DETACHED_PROCESS, NULL, NULL, &si, &pi))
+  if (!CreateProcess(exec_path, buf, NULL, NULL, FALSE, DETACHED_PROCESS, NULL, lpSystemDir, &si, &pi))
     failwith_perror("fork");
   CloseHandle(pi.hProcess);
   CloseHandle(pi.hThread);

--- a/tests/test-dirs/server-tests/chdir_to_root.t
+++ b/tests/test-dirs/server-tests/chdir_to_root.t
@@ -9,5 +9,5 @@ Check that the working directory of the server process is correctly restored.
   $ $MERLIN server errors -filename test.ml < test.ml 2>&1 | grep 'old wd'
   changed directory to "$TESTCASE_ROOT" (old wd: "/")
   $ $MERLIN server errors -filename test.ml < test.ml 2>&1 | grep 'old wd'
-  changed directory to "$TESTCASE_ROOT" (old wd: "$TESTCASE_ROOT")
+  changed directory to "$TESTCASE_ROOT" (old wd: "/")
   $ $MERLIN server stop-server

--- a/tests/test-dirs/server-tests/chdir_to_root.t
+++ b/tests/test-dirs/server-tests/chdir_to_root.t
@@ -1,0 +1,13 @@
+In case server is running, stop it.
+
+  $ $MERLIN server stop-server
+
+Check that the working directory of the server process is correctly restored.
+
+  $ touch test.ml
+  $ export MERLIN_LOG=-
+  $ $MERLIN server errors -filename test.ml < test.ml 2>&1 | grep 'old wd'
+  changed directory to "$TESTCASE_ROOT" (old wd: "/")
+  $ $MERLIN server errors -filename test.ml < test.ml 2>&1 | grep 'old wd'
+  changed directory to "$TESTCASE_ROOT" (old wd: "$TESTCASE_ROOT")
+  $ $MERLIN server stop-server

--- a/tests/test-dirs/server-tests/dune
+++ b/tests/test-dirs/server-tests/dune
@@ -3,3 +3,8 @@
  (applies_to :whole_subtree)
  (alias all-server-tests)
  (locks merlin_server))
+
+(cram
+ (applies_to chdir_to_root)
+ (enabled_if
+  (<> %{os_type} Win32)))


### PR DESCRIPTION
On Windows, the process `ocamlmerlin-server.exe` is launched with the directory of the current source file as current working directory. This causes problems if one tries to move or delete that directory.

To avoid this problem, this PR makes sure to `chdir` to a different directory (TMPDIR) before launching `ocamlmerlin-server.exe`. Note that the same logic already exists for Unix: https://github.com/ocaml/merlin/blob/f1b877cd20d5c99b24bb8d051a63088488d26846/src/frontend/ocamlmerlin/ocamlmerlin.c#L314-L317

cc @dra27 @MisterDA 

Fixes #1474