### PR TITLE
Fix false "no cmi" reporting from errors command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ unreleased
     - Fix object method completion not working (#1606, fixes #1575)
     - Improve context detection for package types (#1608, fixes #1607)
     - Fix incorrect locations for string literals (#1574)
+    - Fixed an issue that caused `errors` to erroneously alert about missing
+      `cmi` files (#1577)
   + editor modes
     - emacs: call the user's configured completion UI in
       `merlin-construct` (#1598)

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -656,10 +656,10 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
   | Errors { lexing; parsing; typing }->
     let typer = Mpipeline.typer_result pipeline in
     let verbosity = verbosity pipeline in
-    Printtyp.wrap_printing_env (Mtyper.get_env typer) ~verbosity @@ fun () ->
     let lexer_errors  = Mpipeline.reader_lexer_errors pipeline  in
     let parser_errors = Mpipeline.reader_parser_errors pipeline in
     let typer_errors  = Mpipeline.typer_errors pipeline  in
+    Printtyp.wrap_printing_env (Mtyper.get_env typer) ~verbosity @@ fun () ->
     (* When there is a cmi error, we will have a lot of meaningless errors,
        there is no need to report them. *)
     let typer_errors =

--- a/tests/test-dirs/errors/no-cmi.t
+++ b/tests/test-dirs/errors/no-cmi.t
@@ -23,22 +23,7 @@
   libb.cmt
   libb.ml
 
-FIXME: the cmi do exist, there should be no errors
+There should be no errors
   $ cd liba && $MERLIN single errors -filename liba.ml<liba.ml |
   > jq '.value'
-  [
-    {
-      "start": {
-        "line": 1,
-        "col": 14
-      },
-      "end": {
-        "line": 1,
-        "col": 18
-      },
-      "type": "warning",
-      "sub": [],
-      "valid": true,
-      "message": "Warning 49: no cmi file was found in path for module Libb"
-    }
-  ]
+  []

--- a/tests/test-dirs/errors/no-cmi.t
+++ b/tests/test-dirs/errors/no-cmi.t
@@ -1,0 +1,44 @@
+  $ mkdir liba
+  $ cat >liba/liba.ml <<EOF
+  > module Libb = Libb
+  > EOF
+
+  $ mkdir libb
+  $ cat >libb/libb.ml <<EOF
+  > let x = 42
+  > EOF
+
+  $ cat >liba/.merlin <<EOF
+  > B .
+  > B ../libb
+  > EOF
+
+  $ (cd libb && $OCAMLC -c -bin-annot libb.ml)
+  $ (cd liba && $OCAMLC -c -bin-annot liba.ml -I ../libb)
+
+
+  $ ls libb
+  libb.cmi
+  libb.cmo
+  libb.cmt
+  libb.ml
+
+FIXME: the cmi do exist, there should be no errors
+  $ cd liba && $MERLIN single errors -filename liba.ml<liba.ml |
+  > jq '.value'
+  [
+    {
+      "start": {
+        "line": 1,
+        "col": 14
+      },
+      "end": {
+        "line": 1,
+        "col": 18
+      },
+      "type": "warning",
+      "sub": [],
+      "valid": true,
+      "message": "Warning 49: no cmi file was found in path for module Libb"
+    }
+  ]


### PR DESCRIPTION
In some cases `errors` command can alert about missing cmis that are, in fact, not missing.
This is due to `wrap_printing_env` setting `Cannot_load_cmis` in `Persistent_env`.

It looks like the forçage of `Typecore.force_delayed_checks` in `Typer.get_errors` requires `cmi` loading and thus should not happen under `wrap_printing_env`.

cc @ddickstein 