### PR TITLE
Allow monadic IO in dot protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ merlin 4.9
 ==========
 unreleased
 
+  + merlin binary
+    - Allow monadic IO in dot protocol (#1581)
   + test suite
     - Add missing dependency to a test using ppxlib (#1583)
 

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -476,11 +476,12 @@ let load dot_merlin_file =
 let dot_merlin_file =  Filename.concat (Sys.getcwd ()) ".merlin"
 
 let rec main () =
-  match Merlin_dot_protocol.Commands.read_input stdin with
+  let open Merlin_dot_protocol.Blocking in
+  match Commands.read_input stdin with
   | Halt -> exit 0
   | File _path ->
     let directives = load dot_merlin_file in
-    Merlin_dot_protocol.write ~out_channel:stdout directives;
+    write stdout directives;
     flush stdout;
     main ()
   | Unknown -> main ()

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -127,14 +127,16 @@ module Sexp = struct
     List (List.map ~f directives)
 end
 
+type read_error =
+  | Unexpected_output of string
+  | Csexp_parse_error of string
+
+type command = File of string | Halt | Unknown
+
 module type S = sig
   type 'a io
   type in_chan
   type out_chan
-
-  type read_error =
-  | Unexpected_output of string
-  | Csexp_parse_error of string
 
   (** [read] reads one csexp from the channel and returns the list of
       directives it represents *)
@@ -144,8 +146,7 @@ module type S = sig
   val write : out_chan -> directive list -> unit io
 
   module Commands : sig
-    type t = File of string | Halt | Unknown
-    val read_input : in_chan -> t io
+    val read_input : in_chan -> command io
 
     val send_file : out_chan -> string -> unit io
 
@@ -172,13 +173,7 @@ struct
   type in_chan = Chan.in_chan
   type out_chan = Chan.out_chan
 
-  type read_error =
-  | Unexpected_output of string
-  | Csexp_parse_error of string
-
   module Commands = struct
-    type t = File of string | Halt | Unknown
-
     let read_input chan =
       let open Sexp in
       let open IO.O in

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -90,3 +90,25 @@ type read_error =
 val read : in_channel:in_channel -> (directive list, read_error) Merlin_utils.Std.Result.t
 
 val write : out_channel:out_channel -> directive list -> unit
+
+module Make (IO : sig
+  type 'a t
+
+  module O : sig
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+  end
+end) (Chan : sig
+  type t
+
+  val read : t -> Csexp.t option IO.t
+
+  val write : t -> Csexp.t -> unit IO.t
+end) : sig
+  val read : Chan.t -> (directive list, read_error) Merlin_utils.Std.Result.t IO.t
+
+  module Commands : sig
+    val send_file : Chan.t -> string -> unit IO.t
+
+    val halt : Chan.t -> unit IO.t
+  end
+end

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -74,14 +74,16 @@ end
 
 type directive = Directive.Processed.t
 
+type read_error =
+  | Unexpected_output of string
+  | Csexp_parse_error of string
+
+type command = File of string | Halt | Unknown
+
 module type S = sig
   type 'a io
   type in_chan
   type out_chan
-
-  type read_error =
-  | Unexpected_output of string
-  | Csexp_parse_error of string
 
   (** [read] reads one csexp from the channel and returns the list of
       directives it represents *)
@@ -91,8 +93,7 @@ module type S = sig
   val write : out_chan -> directive list -> unit io
 
   module Commands : sig
-    type t = File of string | Halt | Unknown
-    val read_input : in_chan -> t io
+    val read_input : in_chan -> command io
 
     val send_file : out_chan -> string -> unit io
 

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -74,23 +74,34 @@ end
 
 type directive = Directive.Processed.t
 
-module Commands : sig
-  type t = File of string | Halt | Unknown
+module type S = sig
+  type 'a io
+  type in_chan
+  type out_chan
 
-  val read_input : in_channel -> t
-  val send_file : out_channel:out_channel -> string -> unit
-end
-
-type read_error =
+  type read_error =
   | Unexpected_output of string
   | Csexp_parse_error of string
 
-(** [read inc] reads one csexp from the channel [inc] and returns the list of
-  directives it represents *)
-val read : in_channel:in_channel -> (directive list, read_error) Merlin_utils.Std.Result.t
+  (** [read] reads one csexp from the channel and returns the list of
+      directives it represents *)
+  val read :
+    in_chan -> (directive list, read_error) Merlin_utils.Std.Result.t io
 
-val write : out_channel:out_channel -> directive list -> unit
+  val write : out_chan -> directive list -> unit io
 
+  module Commands : sig
+    type t = File of string | Halt | Unknown
+    val read_input : in_chan -> t io
+
+    val send_file : out_chan -> string -> unit io
+
+    val halt : out_chan -> unit io
+  end
+end
+
+(** Provided for projects using merlin as a library in order to use
+    custom IO implementation *)
 module Make (IO : sig
   type 'a t
 
@@ -98,17 +109,18 @@ module Make (IO : sig
     val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
   end
 end) (Chan : sig
-  type t
+  type in_chan
+  type out_chan
 
-  val read : t -> Csexp.t option IO.t
+  val read : in_chan -> (Csexp.t, string) result IO.t
 
-  val write : t -> Csexp.t -> unit IO.t
-end) : sig
-  val read : Chan.t -> (directive list, read_error) Merlin_utils.Std.Result.t IO.t
+  val write : out_chan -> Csexp.t -> unit IO.t
+end) : S
+  with type 'a io = 'a IO.t
+   and type in_chan = Chan.in_chan
+   and type out_chan = Chan.out_chan
 
-  module Commands : sig
-    val send_file : Chan.t -> string -> unit IO.t
-
-    val halt : Chan.t -> unit IO.t
-  end
-end
+module Blocking : S
+  with type 'a io = 'a
+   and type in_chan = in_channel
+   and type out_chan = out_channel

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -279,12 +279,11 @@ let get_config { workdir; process_dir; configurator } path_abs =
       workdir
   in
   let query path (p : Configurator.Process.t) =
+    let open Merlin_dot_protocol.Blocking in
     log_query path;
-    Merlin_dot_protocol.Commands.send_file
-      ~out_channel:p.stdin
-      path;
+    Commands.send_file p.stdin path;
     flush p.stdin;
-    Merlin_dot_protocol.read ~in_channel:p.stdout
+    read p.stdout
   in
   try
     let p =
@@ -327,8 +326,8 @@ let get_config { workdir; process_dir; configurator } path_abs =
         prepend_config ~dir:workdir configurator directives empty_config
       in
       postprocess_config cfg, failures
-    | Error (Merlin_dot_protocol.Unexpected_output msg) -> empty_config, [ msg ]
-    | Error (Merlin_dot_protocol.Csexp_parse_error _) -> raise End_of_input
+    | Error (Merlin_dot_protocol.Blocking.Unexpected_output msg) -> empty_config, [ msg ]
+    | Error (Merlin_dot_protocol.Blocking.Csexp_parse_error _) -> raise End_of_input
   with
     | Process_exited ->
       (* This can happen

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -326,8 +326,8 @@ let get_config { workdir; process_dir; configurator } path_abs =
         prepend_config ~dir:workdir configurator directives empty_config
       in
       postprocess_config cfg, failures
-    | Error (Merlin_dot_protocol.Blocking.Unexpected_output msg) -> empty_config, [ msg ]
-    | Error (Merlin_dot_protocol.Blocking.Csexp_parse_error _) -> raise End_of_input
+    | Error (Merlin_dot_protocol.Unexpected_output msg) -> empty_config, [ msg ]
+    | Error (Merlin_dot_protocol.Csexp_parse_error _) -> raise End_of_input
   with
     | Process_exited ->
       (* This can happen


### PR DESCRIPTION
As discussed in: https://github.com/ocaml/ocaml-lsp/issues/1052