### PR TITLE
Locally enable ocamlformat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,3 +77,9 @@ jobs:
           opam exec -- dune clean
           opam exec -- dune build
           git diff --exit-code
+
+      - name: Check that the changes are correctly formatted
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          opam install ocamlformat.0.24.1
+          opam exec -- dune build @fmt

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,11 @@
+version=0.24.1
+disable=true
+
+break-cases=fit-or-vertical
+doc-comments=before
+cases-exp-indent=2
+dock-collection-brackets=false
+# Preserve begin/end
+exp-grouping=preserve
+module-item-spacing=preserve
+parse-docstrings=false

--- a/dune-project
+++ b/dune-project
@@ -3,5 +3,5 @@
 (using menhir 2.0)
 
 (cram enable)
-(formatting disabled)
+(formatting (enabled_for ocaml))
 (implicit_transitive_deps false)


### PR DESCRIPTION
This PR add an ocamlformat configuration file and an empty `.ocamlformat-enable`.

The idea is to progressively format more and more files. When merging PR all changed file should be added to the `.ocamlformat-enable` file and formatted.