### PR TITLE
Add a scope option to the occurrences command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ unreleased
 
   + merlin binary
     - Allow monadic IO in dot protocol (#1581)
+    - Add a `scope` option to the `occurrences` command in preparation for
+      the upcoming `project-wide-occurrences` feature (#1596)
   + test suite
     - Add missing dependency to a test using ppxlib (#1583)
 

--- a/doc/dev/PROTOCOL.md
+++ b/doc/dev/PROTOCOL.md
@@ -348,11 +348,15 @@ Returns either:
 - `{'pos': position}` if the location is in the current buffer,
 - `{'file': string, 'pos': position}` if definition is located in a different file.
 
-### `occurrences -identifier-at <position>`
+### `occurrences -identifier-at <position> [ -scope <buffer|project> ]`
 
 -identifier-at <position>  Position to complete
+  -scope <buffer|project>  Scope of the request
 
-Returns a list of locations `{'start': position, 'end': position}` of all occurrences in current buffer of the entity at the specified position.
+Returns a list of locations `{'start': position, 'end': position}` of all
+occurrences in current buffer of the entity at the specified position. If scope
+is set to `project` the returned locations will also contain a field `file`:
+`{'file': string, 'start': position, 'end': position}`.
 
 ### `outline`
 

--- a/src/frontend/ocamlmerlin/old/old_IO.ml
+++ b/src/frontend/ocamlmerlin/old/old_IO.ml
@@ -161,7 +161,7 @@ let request_of_json context =
     | [`String "shape"; pos] ->
       request (Query (Shape (pos_of_json pos)))
     | [`String "occurrences"; `String "ident"; `String "at"; jpos] ->
-      request (Query (Occurrences (`Ident_at (pos_of_json jpos))))
+      request (Query (Occurrences (`Ident_at (pos_of_json jpos), `Buffer)))
     | (`String ("reset"|"checkout") :: document) ->
       request (Sync (Checkout (document_of_json document)))
     | [`String "refresh"] ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -781,7 +781,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     let config = Mpipeline.final_config pipeline in
     Mconfig.(config.merlin.source_path)
 
-  | Occurrences (`Ident_at pos) ->
+  | Occurrences (`Ident_at pos, _scope) ->
     let typer = Mpipeline.typer_result pipeline in
     let str = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
     let pos = Mpipeline.get_lexing_pos pipeline pos in

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -194,7 +194,7 @@ type _ t =
     :  [`Build|`Source]
     -> string list t
   | Occurrences(* *)
-    : [`Ident_at of Msource.position]
+    : [`Ident_at of Msource.position] * [`Project | `Buffer]
     -> Location.t list t
   | Version
     : string t


### PR DESCRIPTION
When this option is set to ``` `Project``` Merlin will (in the future) answer with project-wide occurrences.  In that case the answer also contains file paths associated to each locations.

This is useless without the rest of the project-wide occurrences machinery but since it is a breaking api change for ocaml-lsp it might be worth merging as soon as possible.