### PR TITLE
Elisp: make merlin-construct use the user's configured completion interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ unreleased
       `construct` command, for consistency (#1599).
     - Add a hook to configure system command for spawning ppxes when Merlin is
       used as a library. (#1585)
+  + editor modes
+    - emacs: call the user's configured completion UI in
+      `merlin-construct` (#1598)
   + test suite
     - Add missing dependency to a test using ppxlib (#1583)
 

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1490,7 +1490,7 @@ strictly within, or nil if there is no such element."
 
 (defun merlin--project-get ()
   "Returns a pair of two string lists (dot_merlins . failures) with a list of
-.merlins file loaded and a list of error messages, if any error occurred during
+.merlin files loaded and a list of error messages, if any error occurred during
 loading"
   (let ((ret (merlin-call "check-configuration")))
     (setq merlin--project-cache

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1460,22 +1460,18 @@ strictly within, or nil if there is no such element."
             (display-completion-list results)))))))
 
 (defun merlin--construct-point (point)
-  "Execute a construct on POINT"
-  (progn
-    (ignore point) ; Without this Emacs bytecode compiler complains about an
-                   ; unused variable. This may be a bug in the compiler
-    (let ((result (merlin-call "construct"
-                              "-position" (merlin-unmake-point (point)))))
-      (when result
-        (let* ((loc   (car result))
-              (start (cdr (assoc 'start loc)))
-              (stop  (cdr (assoc 'end loc))))
-          (merlin--construct-complete start stop (cadr result)))))))
+  "Execute a construct at POINT."
+  (when-let ((result (merlin-call "construct"
+                                  "-position" (merlin-unmake-point point))))
+    (let* ((loc   (car result))
+           (start (cdr (assoc 'start loc)))
+           (stop  (cdr (assoc 'end loc))))
+      (merlin--construct-complete start stop (cadr result)))))
 
 (defun merlin-construct ()
-  "Construct over the current hole"
+  "Construct over the current hole."
   (interactive)
-  (merlin--construct-point (cons (point) (point))))
+  (merlin--construct-point (point)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1444,20 +1444,16 @@ strictly within, or nil if there is no such element."
 
 
 (defun merlin--construct-complete (start stop results)
+  "Read a constructor from RESULTS, and replace the text between START and STOP."
   (let ((start (merlin--point-of-pos start))
         (stop  (merlin--point-of-pos stop)))
-    (cl-labels ((insert-choice (_b _e newtext)
+    (cl-labels ((insert-choice (newtext)
           (completion--replace start stop newtext)
           (merlin--first-hole-between start (+ start (length newtext)))))
-      (if (= (length results) 1)
-        (insert-choice 0 0 (car results))
-        (with-output-to-temp-buffer "*Constructions*"
-          (progn
-            (with-current-buffer "*Constructions*"
-              (setq-local
-                completion-list-insert-choice-function
-                #'insert-choice))
-            (display-completion-list results)))))))
+      (pcase results
+        ('() (error "No constructors for this hole"))
+        (`(,result) (insert-choice result))
+        (results (insert-choice (completing-read "Constructor: " results nil t)))))))
 
 (defun merlin--construct-point (point)
   "Execute a construct at POINT."


### PR DESCRIPTION
The current `merlin-construct` interface is somewhat awkward.  It requires the user to switch buffers, and forces the use of the old-style built-in completion buffer, rather than using whatever completion interface the user has set up (e.g., ivy, helm).

Also make the following small improvements:
1. Fix some docstring typos
2. Clean up unused variable
3. Signal an error if the hole has no constructors, instead of just presenting an empty list of completions