### PR TITLE
Cleanup functor caches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ unreleased
     - Add a hook to configure system command for spawning ppxes when Merlin is
       used as a library. (#1585)
     - Implement an all-or-nothing cache for the PPX phase (#1584)
+    - Cleanup functors caches when backtracking, to avoid memory leaks
+      (#1609, fixes #1529 and ocaml-lsp#1032)
   + editor modes
     - emacs: call the user's configured completion UI in
       `merlin-construct` (#1598)

--- a/src/ocaml/typing/env.ml
+++ b/src/ocaml/typing/env.ml
@@ -496,8 +496,8 @@ type type_descriptions = type_descr_kind
 
 let in_signature_flag = 0x01
 
-let stamped_changes =
-  s_table Stamped_hashtable.create_changes ()
+let stamped_changelog =
+  s_table Stamped_hashtable.create_changelog ()
 
 let stamped_add table path value =
   let rec path_stamp = function
@@ -516,7 +516,7 @@ let stamped_find table path =
   Stamped_hashtable.find table path
 
 let stamped_create n =
-  Stamped_hashtable.create !stamped_changes n
+  Stamped_hashtable.create !stamped_changelog n
 
 type t = {
   values: (value_entry, value_data) IdTbl.t;
@@ -4119,4 +4119,4 @@ let short_paths env =
   | Some short_paths -> short_paths
 
 let cleanup_functor_caches ~stamp =
-  Stamped_hashtable.backtrack !stamped_changes ~stamp
+  Stamped_hashtable.backtrack !stamped_changelog ~stamp

--- a/src/ocaml/typing/env.mli
+++ b/src/ocaml/typing/env.mli
@@ -532,3 +532,4 @@ val with_cmis : (unit -> 'a) -> 'a
 (* helper for merlin *)
 
 val add_merlin_extension_module: Ident.t -> module_type -> t -> t
+val cleanup_functor_caches : stamp:int -> unit

--- a/src/ocaml/typing/ident.ml
+++ b/src/ocaml/typing/ident.ml
@@ -362,3 +362,6 @@ let rename_no_exn = function
       incr currentstamp;
       Local { name; stamp = !currentstamp }
   | id -> id
+
+let get_currentstamp () =
+  !currentstamp

--- a/src/ocaml/typing/ident.mli
+++ b/src/ocaml/typing/ident.mli
@@ -84,3 +84,7 @@ val make_key_generator : unit -> (t -> t)
 
 val rename_no_exn: t -> t
         (** Like [rename], but does not fail on persistent/predef idents. *)
+
+val get_currentstamp: unit -> int
+	(** Get the value of the current stamp (the stamp of the last created
+            identifier). Used to flush identifier-based caches when backtracking. *)

--- a/src/utils/stamped_hashtable.ml
+++ b/src/utils/stamped_hashtable.ml
@@ -1,0 +1,51 @@
+type ('a, 'b) t = {
+  table: ('a, 'b) Hashtbl.t;
+  mutable recent: (int * 'a) list;
+  mutable sorted: (int * 'a) list;
+}
+
+let create n = {
+  table = Hashtbl.create n;
+  recent = [];
+  sorted = [];
+}
+
+let add t ~stamp a b =
+  Hashtbl.add t.table a b;
+  t.recent <- (stamp, a) :: t.recent
+
+let mem t a =
+  Hashtbl.mem t.table a
+
+let find t a =
+  Hashtbl.find t.table a
+
+(* Sort by decreasing stamps *)
+let order (i1, _) (i2, _) =
+  Int.compare i2 i1
+
+let rec filter_prefix pred = function
+  | x :: xs when not (pred x) ->
+    filter_prefix pred xs
+  | xs -> xs
+
+let backtrack t ~stamp =
+  let process (stamp', path) =
+    if stamp' > stamp then (
+      Hashtbl.remove t.table path;
+      false
+    ) else
+      true
+  in
+  let recent =
+    t.recent
+    |> List.filter process
+    |> List.fast_sort order
+  in
+  t.recent <- [];
+  let sorted =
+    t.sorted
+    |> filter_prefix process
+    |> List.merge order recent
+  in
+  t.sorted <- sorted

--- a/src/utils/stamped_hashtable.ml
+++ b/src/utils/stamped_hashtable.ml
@@ -6,31 +6,32 @@ type cell =
       key: 'a;
     } -> cell
 
-type changes = {
+type changelog = {
   mutable recent: cell list;
   mutable sorted: cell list;
 }
 
-let create_changes () = {
+let create_changelog () = {
   recent = [];
   sorted = [];
 }
 
 type ('a, 'b) t = {
   table: ('a, 'b) Hashtbl.t;
-  changes: changes;
+  changelog: changelog;
 }
 
-let create changes n = {
+let create changelog n = {
   table = Hashtbl.create n;
-  changes;
+  changelog;
 }
 
-let add {table; changes} ?stamp key value =
+let add {table; changelog} ?stamp key value =
   Hashtbl.add table key value;
   match stamp with
   | None -> ()
-  | Some stamp -> changes.recent <- Cell {stamp; key; table} :: changes.recent
+  | Some stamp ->
+    changelog.recent <- Cell {stamp; key; table} :: changelog.recent
 
 let mem t a =
   Hashtbl.mem t.table a

--- a/src/utils/stamped_hashtable.mli
+++ b/src/utils/stamped_hashtable.mli
@@ -1,11 +1,13 @@
 type ('a, 'b) t
 type changes
 
-val create : int -> ('a, 'b) t
-val add : ('a, 'b) t -> stamp:int -> 'a -> 'b -> unit
+val create : changes -> int -> ('a, 'b) t
+val add : ('a, 'b) t -> ?stamp:int -> 'a -> 'b -> unit
 val mem : ('a, 'b) t -> 'a -> bool
 val find : ('a, 'b) t -> 'a -> 'b
 
-(* [backtrack table ~stamp] remove all items of [table] with a stamp strictly
-   greater than [stamp] *)
-val backtrack : ('a, 'b) t -> stamp:int -> unit
+val create_changes : unit -> changes
+
+(* [backtrack changes ~stamp] remove all items added to tables created using
+   [changes] with a stamp strictly greater than [stamp] *)
+val backtrack : changes -> stamp:int -> unit

--- a/src/utils/stamped_hashtable.mli
+++ b/src/utils/stamped_hashtable.mli
@@ -1,14 +1,41 @@
+(* A stamped hashtable is a hashtable that can associate an optional integer
+   stamp to its bindings.
+   The user can then efficiently remove all bindings with stamps greater than a
+   bound.
+
+   This datastructure is used to flush of the compiler caches: stamps come from
+   [Ident.stamp] which are monotonically increasing unique identifiers.
+
+   Merlin keeps regular snapshots of the compiler state to minimize the amount
+   of work that needs to be redone. Flushing the cache is necessary to avoid
+   state (and memory) leaking when backtracking.
+*)
+
 type ('a, 'b) t
+(** An instance of a stamped hashtable *)
 
 type changelog
+(** The [changelog] datastructure logs stamped bindings added to tables.
+    By separating the log from the table, it is possible to efficiently remove
+    stamped bindings spread accross multiple tables. *)
 
 val create : changelog -> int -> ('a, 'b) t
+(** [create changelog n] creates a new table with an initial size of [n]
+    (see [Hashtbl.create]) that logs its changes to [changelog]. *)
 
 val add : ('a, 'b) t -> ?stamp:int -> 'a -> 'b -> unit
+(** Add a binding, like [Hashtbl.add], with an optional [stamp].
+    Unlike [Hashtbl.add], having multiple bindings with the same key is
+    undefined. (It's ok, this feature is not used by the caches!) *)
+
 val mem : ('a, 'b) t -> 'a -> bool
+(** See [Hashtbl.mem]. *)
+
 val find : ('a, 'b) t -> 'a -> 'b
+(** See [Hashtbl.find]. *)
 
 val create_changelog : unit -> changelog
+(** Create a new change log. *)
 
 (* [backtrack changelog ~stamp] remove all items added to tables logging to
    [changelog] with a stamp strictly greater than [stamp] *)

--- a/src/utils/stamped_hashtable.mli
+++ b/src/utils/stamped_hashtable.mli
@@ -1,0 +1,11 @@
+type ('a, 'b) t
+type changes
+
+val create : int -> ('a, 'b) t
+val add : ('a, 'b) t -> stamp:int -> 'a -> 'b -> unit
+val mem : ('a, 'b) t -> 'a -> bool
+val find : ('a, 'b) t -> 'a -> 'b
+
+(* [backtrack table ~stamp] remove all items of [table] with a stamp strictly
+   greater than [stamp] *)
+val backtrack : ('a, 'b) t -> stamp:int -> unit

--- a/src/utils/stamped_hashtable.mli
+++ b/src/utils/stamped_hashtable.mli
@@ -1,13 +1,15 @@
 type ('a, 'b) t
-type changes
 
-val create : changes -> int -> ('a, 'b) t
+type changelog
+
+val create : changelog -> int -> ('a, 'b) t
+
 val add : ('a, 'b) t -> ?stamp:int -> 'a -> 'b -> unit
 val mem : ('a, 'b) t -> 'a -> bool
 val find : ('a, 'b) t -> 'a -> 'b
 
-val create_changes : unit -> changes
+val create_changelog : unit -> changelog
 
-(* [backtrack changes ~stamp] remove all items added to tables created using
-   [changes] with a stamp strictly greater than [stamp] *)
-val backtrack : changes -> stamp:int -> unit
+(* [backtrack changelog ~stamp] remove all items added to tables logging to
+   [changelog] with a stamp strictly greater than [stamp] *)
+val backtrack : changelog -> stamp:int -> unit


### PR DESCRIPTION
This PR adds a mechanism to track the stamp of functor components cached in `fcomp_cache` and `fcomp_subst_cache`. They can they be removed from the cache when backtracking.

Its probably only necessary to track the components added to the persistent_env caches, this feature might be added later if this patch makes things too slow (or just worsen the problem :D).