### PR TITLE
Add changelog check to CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Changelog check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  Changelog-Entry-Check:
+    name: Check Changelog Action
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
     name: Check Changelog Action
     runs-on: ubuntu-20.04
     steps:
-      - uses: tarides/changelog-check-action@v1
+      - uses: tarides/changelog-check-action@v2

--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ If it seems relevant, also include information about your development environmen
 
 Found a bug and know how to fix it? Or have a feature you can implement directly? We appreciate pull requests to improve Merlin. Please note: any significant fix should start life as an issue first.
 
+#### Changelog
+
+User-visible changes should come with an entry in the changelog under
+the appropriate part of the unreleased section. PR that doesn't
+provide an entry will fail CI check. This behavior can be overridden
+by using the "no changelog" label, which is used for changes that are
+not user-visible.
+
 ### Documentation and Wiki
 Help is greatly appreciated, the wiki needs love.
 


### PR DESCRIPTION
This PR adds changelog check action, that fails CI when there is no entry to `CHANGES.md`.
For PRs that doesn't contain changes that should be logged, there should be a label `no changelog`. It needs to be added to merlin project by a maintainer, so that contributors can use it.