### PR TITLE
construct: Do not produce redundant prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@ unreleased
   + merlin binary
     - Handle concurrent server start (#1622)
     - Omit module prefixes for constructors and record fields in the
-      `construct` command (#1618).
+      `construct` command (#1618).  Prefixes are still produced when
+      warning 42 (disambiguated name) is active.
   + editor modes
     - emacs: call merlin-client-logger with "interrupted" if the
       merlin binary itself is interrupted, not just the parsing of the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ unreleased
 ==========
   + merlin binary
     - Handle concurrent server start (#1622)
+    - Omit module prefixes for constructors and record fields in the
+      `construct` command (#1618).
   + editor modes
     - emacs: call merlin-client-logger with "interrupted" if the
       merlin binary itself is interrupted, not just the parsing of the

--- a/src/analysis/construct.mli
+++ b/src/analysis/construct.mli
@@ -5,6 +5,7 @@ type values_scope = Null | Local
 
 val node
   : ?depth : int
+  -> config : Mconfig.t
   -> keywords : string list
   -> values_scope : values_scope
   -> Browse_raw.node

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -623,6 +623,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
       | Some `None | None -> Construct.Null
       | Some `Local -> Construct.Local
     in
+    let config = Mpipeline.final_config pipeline in
     let keywords = Mpipeline.reader_lexer_keywords pipeline in
     let typer = Mpipeline.typer_result pipeline in
     let typedtree = Mtyper.get_typedtree typer in
@@ -633,11 +634,11 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     | (_, (Browse_raw.Module_expr { mod_desc = Tmod_hole; _ } as node_for_loc))
       :: (_, node) :: _parents ->
         let loc = Mbrowse.node_loc node_for_loc in
-        (loc, Construct.node ~keywords ?depth ~values_scope node)
+        (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
     | (_,  (Browse_raw.Expression { exp_desc = Texp_hole; _ } as node))
       :: _parents ->
       let loc = Mbrowse.node_loc node in
-      (loc, Construct.node ~keywords ?depth ~values_scope node)
+      (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
     | _ :: _ -> raise Construct.Not_a_hole
     | [] -> raise No_nodes
     end

--- a/tests/test-dirs/construct/c-prefix.t
+++ b/tests/test-dirs/construct/c-prefix.t
@@ -99,3 +99,30 @@ Test 1.3 :
     "{ a = _ }"
   ]
 
+With warning 42 (disambiguated name) active, prefixes are added:
+
+  $ $MERLIN single construct -position 5:20 -filename c13.ml <c13.ml -w +disambiguated-name |
+  >  jq ".value[1]"
+  [
+    "(Prefix.A _)",
+    "Prefix.B"
+  ]
+
+  $ $MERLIN single construct -position 6:20 -filename c13.ml <c13.ml -w +disambiguated-name |
+  >  jq ".value[1]"
+  [
+    "{ Prefix.a = _ }"
+  ]
+
+  $ $MERLIN single construct -position 8:13 -filename c13.ml <c13.ml -w +disambiguated-name |
+  >  jq ".value[1]"
+  [
+    "(A _)",
+    "B"
+  ]
+
+  $ $MERLIN single construct -position 9:13 -filename c13.ml <c13.ml -w +disambiguated-name |
+  >  jq ".value[1]"
+  [
+    "{ a = _ }"
+  ]

--- a/tests/test-dirs/construct/c-prefix.t
+++ b/tests/test-dirs/construct/c-prefix.t
@@ -25,8 +25,8 @@ Test 1.1 :
       }
     },
     [
-      "(Prefix.A _)",
-      "Prefix.B"
+      "(A _)",
+      "B"
     ]
   ]
 
@@ -76,14 +76,14 @@ Test 1.3 :
   $ $MERLIN single construct -position 5:20 -filename c13.ml <c13.ml |
   >  jq ".value[1]"
   [
-    "(Prefix.A _)",
-    "Prefix.B"
+    "(A _)",
+    "B"
   ]
 
   $ $MERLIN single construct -position 6:20 -filename c13.ml <c13.ml |
   >  jq ".value[1]"
   [
-    "{ Prefix.a = _ }"
+    "{ a = _ }"
   ]
 
   $ $MERLIN single construct -position 8:13 -filename c13.ml <c13.ml |


### PR DESCRIPTION
As suggested in #1552, there shouldn't be any need to generate module prefixes for constructors or record fields when using `construct`, since the hole's type can be used with type-directed disambiguation.

Closes #1552.