### PR TITLE
Restrict dmr to ocaml 4.14 for the CI

### DIFF
--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08" & < "6.0"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {>= "4.9"}
   "ocamlfind" {>= "1.6.0"}


### PR DESCRIPTION
Attempt to fix `ocaml-ci`