### PR TITLE
Emacs: fix logging when merlin call is interrupted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@ unreleased
 ==========
   + merlin binary
     - Handle concurrent server start (#1622)
+  + editor modes
+    - emacs: call merlin-client-logger with "interrupted" if the
+      merlin binary itself is interrupted, not just the parsing of the
+      result (#1626).
 
 
 merlin 4.9


### PR DESCRIPTION
Currently, "interrupted" is only logged when the result parsing is interrupted (by C-g), but it seems pretty clear that the original intent (and more useful behavior) was to log "interrupted" when the actual merlin call was interrupted.

We do this by setting up separate condition handlers for (1) the result parse failing; and (2) the merlin call or result parse being interrupted.