### PR TITLE
Override menhir version in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,25 @@
         "type": "github"
       }
     },
+    "menhir-repository": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.inria.fr",
+        "lastModified": 1608146308,
+        "narHash": "sha256-i/Xs6G1L/bZ1zj+LB5ehiaBC10ounc1koURV3vFolhI=",
+        "owner": "fpottier",
+        "repo": "menhir",
+        "rev": "abb46d3d9c536bcbe30025f37474e3b4c8288590",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.inria.fr",
+        "owner": "fpottier",
+        "ref": "20201216",
+        "repo": "menhir",
+        "type": "gitlab"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1686331126,
@@ -36,6 +55,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "menhir-repository": "menhir-repository",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,22 +7,20 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages."${system}";
-        menhirOver = self: _: rec {
-          version = "20201216";
-          src = pkgs.fetchFromGitLab {
-            domain = "gitlab.inria.fr";
-            owner = "fpottier";
-            repo = "menhir";
-            rev = version;
-            sha256 = "sha256:04lnd3qxwma4l5jcv79f9bbl5849l6bhg2rzrrsvdzabdplfrxcb";
-          };
-          name = "ocaml${pkgs.ocaml.version}-${self.pname}-${version}";
-        };
-        menhirLib = pkgs.ocamlPackages.menhirLib.overrideAttrs menhirOver;
-        menhirSdk = pkgs.ocamlPackages.menhirSdk.overrideAttrs menhirOver;
-        menhir = (pkgs.ocamlPackages.menhir.overrideAttrs menhirOver)
-          .overrideAttrs(_: _: { buildInputs = [ menhirLib menhirSdk ]; });
+        pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
+          ocamlPackages = super.ocamlPackages.overrideScope' (oself: osuper: {
+            menhirLib = osuper.menhirLib.overrideAttrs (_: rec {
+              version = "20201216";
+              src = pkgs.fetchFromGitLab {
+                domain = "gitlab.inria.fr";
+                owner = "fpottier";
+                repo = "menhir";
+                rev = version;
+                sha256 = "sha256:04lnd3qxwma4l5jcv79f9bbl5849l6bhg2rzrrsvdzabdplfrxcb";
+              };
+            });
+          });
+        });
         inherit (pkgs.ocamlPackages) buildDunePackage;
       in
       rec {

--- a/flake.nix
+++ b/flake.nix
@@ -3,21 +3,19 @@
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.menhir-repository = {
+    url = "gitlab:fpottier/menhir/20201216?host=gitlab.inria.fr";
+    flake = false;
+  };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, menhir-repository }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages."${system}".extend (self: super: {
-          ocamlPackages = super.ocamlPackages.overrideScope' (oself: osuper: {
-            menhirLib = osuper.menhirLib.overrideAttrs (_: rec {
+        pkgs = nixpkgs.legacyPackages."${system}".extend (_: super: {
+          ocamlPackages = super.ocamlPackages.overrideScope' (_: osuper: {
+            menhirLib = osuper.menhirLib.overrideAttrs (_: {
               version = "20201216";
-              src = pkgs.fetchFromGitLab {
-                domain = "gitlab.inria.fr";
-                owner = "fpottier";
-                repo = "menhir";
-                rev = version;
-                sha256 = "sha256:04lnd3qxwma4l5jcv79f9bbl5849l6bhg2rzrrsvdzabdplfrxcb";
-              };
+              src = menhir-repository;
             });
           });
         });

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,21 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages."${system}";
+        menhirOver = self: _: rec {
+          version = "20201216";
+          src = pkgs.fetchFromGitLab {
+            domain = "gitlab.inria.fr";
+            owner = "fpottier";
+            repo = "menhir";
+            rev = version;
+            sha256 = "sha256:04lnd3qxwma4l5jcv79f9bbl5849l6bhg2rzrrsvdzabdplfrxcb";
+          };
+          name = "ocaml${pkgs.ocaml.version}-${self.pname}-${version}";
+        };
+        menhirLib = pkgs.ocamlPackages.menhirLib.overrideAttrs menhirOver;
+        menhirSdk = pkgs.ocamlPackages.menhirSdk.overrideAttrs menhirOver;
+        menhir = (pkgs.ocamlPackages.menhir.overrideAttrs menhirOver)
+          .overrideAttrs(_: _: { buildInputs = [ menhirLib menhirSdk ]; });
         inherit (pkgs.ocamlPackages) buildDunePackage;
       in
       rec {


### PR DESCRIPTION
As described [here](https://github.com/ocaml/merlin/tree/master#compilation), menhir should be pinned to specific version. This PR overrides menhir in flake.nix, so that it matches.

@rgrinberg , could you take a look please? :)