### PR TITLE
Constrain socket path buffer size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
   + merlin binary
+    - Constrain socket path buffer size to avoid build warnings (#1631)
     - Handle concurrent server start (#1622)
     - Omit module prefixes for constructors and record fields in the
       `construct` command (#1618).  Prefixes are still produced when

--- a/src/frontend/ocamlmerlin/ocamlmerlin.c
+++ b/src/frontend/ocamlmerlin/ocamlmerlin.c
@@ -94,6 +94,12 @@ static void failwith(const char *msg)
 
 #define PATHSZ (PATH_MAX+1)
 
+/* On Linux, sun_path size is 108 bytes.
+   On macOS it's 104.
+   We use 102 buffer, as we later append './'
+*/
+#define SOCKSZ (102)
+
 #define BEGIN_PROTECTCWD \
   { char previous_cwd[PATHSZ]; \
     if (!getcwd(previous_cwd, PATHSZ)) previous_cwd[0] = '\0';
@@ -569,7 +575,7 @@ LPSTR retrieve_user_sid_string()
 
 static void compute_socketname(char socketname[PATHSZ], char eventname[PATHSZ], const char merlin_path[PATHSZ])
 #else
-static void compute_socketname(char socketname[PATHSZ], struct stat *st)
+static void compute_socketname(char socketname[SOCKSZ], struct stat *st)
 #endif
 {
 #ifdef _WIN32
@@ -595,7 +601,7 @@ static void compute_socketname(char socketname[PATHSZ], struct stat *st)
 
   LocalFree(user_sid_string);
 #else
-  snprintf(socketname, PATHSZ,
+  snprintf(socketname, SOCKSZ,
       "ocamlmerlin_%llu_%llu_%llu.socket",
       (unsigned long long)getuid(),
       (unsigned long long)st->st_dev,
@@ -607,7 +613,7 @@ static void compute_socketname(char socketname[PATHSZ], struct stat *st)
 
 static char
   merlin_path[PATHSZ] = "<not computed yet>",
-  socketname[PATHSZ] = "<not computed yet>",
+  socketname[SOCKSZ] = "<not computed yet>",
   eventname[PATHSZ] = "<not computed yet>";
 static unsigned char argbuffer[262144];
 


### PR DESCRIPTION
While playing with nix build of merlin, I came across this warning:
```
       > In function 'snprintf',
       >     inlined from 'connect_socket.constprop' at ocamlmerlin.c:262:5:
       > /nix/store/i29k9pvl90385mpsavifqvm4rag684dn-glibc-2.37-8-dev/include/bits/stdio2.h:54:10: note: '__builtin___snprintf_chk' output between 3 and 4099 bytes into a destination of size 104
       >    54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
       >       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       >    55 |                                    __glibc_objsize (__s), __fmt,
       >       |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       >    56 |                                    __va_arg_pack ());
       >       |                                    ~~~~~~~~~~~~~~~~~
```

The problem is described here:
https://blog.8-p.info/en/2020/06/11/unix-domain-socket-length/

I changed socket path size to be lowest upper bound for Linux and macOS