### PR TITLE
Improve nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,50 +26,52 @@
           default = merlin;
           merlin-lib = buildDunePackage {
             pname = "merlin-lib";
-            version = "n/a";
+            version = "dev";
             src = ./.;
             duneVersion = "3";
-            buildInputs = with pkgs.ocamlPackages; [ menhirSdk menhir ];
             propagatedBuildInputs = with pkgs.ocamlPackages; [
-              findlib
               csexp
-              yojson
-              menhirLib
             ];
             doCheck = true;
           };
           dot-merlin-reader = buildDunePackage {
             pname = "dot-merlin-reader";
-            version = "n/a";
+            version = "dev";
             src = ./.;
             duneVersion = "3";
-            buildInputs = [ merlin-lib ];
+            buildInputs = with pkgs.ocamlPackages; [
+              merlin-lib
+              findlib
+            ];
             doCheck = true;
           };
           merlin = buildDunePackage {
             pname = "merlin";
-            version = "n/a";
+            version = "dev";
             src = ./.;
             duneVersion = "3";
             buildInputs = with pkgs.ocamlPackages; [
               merlin-lib
               dot-merlin-reader
-            ];
-            propagatedBuildInputs = with pkgs.ocamlPackages; [
-              dot-merlin-reader
-              merlin-lib
-              findlib
+              menhirLib
+              menhirSdk
+              yojson
             ];
             nativeBuildInputs = [
-              dot-merlin-reader
+              pkgs.ocamlPackages.menhir
+              pkgs.jq
             ];
             checkInputs = with pkgs.ocamlPackages; [
               ppxlib
-              pkgs.jq
             ];
-            # merlin tests rely on wrapper shell script and env vars.
-            # TODO: make them work
-            doCheck = false;
+            doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+              patchShebangs tests/merlin-wrapper
+              dune build @check @runtest
+              runHook postCheck
+           '';
+
             meta = with pkgs; {
               mainProgram = "ocamlmerlin";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,11 @@
             version = "dev";
             src = ./.;
             duneVersion = "3";
+            propagatedBuildInputs = [
+              pkgs.ocamlPackages.findlib
+            ];
             buildInputs = [
               merlin-lib
-              pkgs.ocamlPackages.findlib
             ];
             doCheck = true;
           };
@@ -66,6 +68,12 @@
               ppxlib
             ];
             doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+              patchShebangs tests/merlin-wrapper
+              dune build @check @runtest
+              runHook postCheck
+           '';
             meta = with pkgs; {
               mainProgram = "ocamlmerlin";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,9 @@
             version = "dev";
             src = ./.;
             duneVersion = "3";
-            buildInputs = with pkgs.ocamlPackages; [
+            buildInputs = [
               merlin-lib
-              findlib
+              pkgs.ocamlPackages.findlib
             ];
             doCheck = true;
           };
@@ -50,12 +50,12 @@
             version = "dev";
             src = ./.;
             duneVersion = "3";
-            buildInputs = with pkgs.ocamlPackages; [
+            buildInputs = [
               merlin-lib
               dot-merlin-reader
-              menhirLib
-              menhirSdk
-              yojson
+              pkgs.ocamlPackages.menhirLib
+              pkgs.ocamlPackages.menhirSdk
+              pkgs.ocamlPackages.yojson
             ];
             nativeBuildInputs = [
               pkgs.ocamlPackages.menhir
@@ -64,14 +64,7 @@
             checkInputs = with pkgs.ocamlPackages; [
               ppxlib
             ];
-            doCheck = true;
-            checkPhase = ''
-              runHook preCheck
-              patchShebangs tests/merlin-wrapper
-              dune build @check @runtest
-              runHook postCheck
-           '';
-
+            doCheck = false;
             meta = with pkgs; {
               mainProgram = "ocamlmerlin";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -61,10 +61,11 @@
               pkgs.ocamlPackages.menhir
               pkgs.jq
             ];
+            nativeCheckInputs = [ dot-merlin-reader ];
             checkInputs = with pkgs.ocamlPackages; [
               ppxlib
             ];
-            doCheck = false;
+            doCheck = true;
             meta = with pkgs; {
               mainProgram = "ocamlmerlin";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,8 @@
       rec {
         packages = rec {
           default = merlin;
-          merlin = buildDunePackage {
-            pname = "merlin";
+          merlin-lib = buildDunePackage {
+            pname = "merlin-lib";
             version = "n/a";
             src = ./.;
             duneVersion = "3";
@@ -36,8 +36,43 @@
               yojson
               menhirLib
             ];
-            checkInputs = with pkgs.ocamlPackages; [ ppxlib pkgs.jq ];
             doCheck = true;
+          };
+          dot-merlin-reader = buildDunePackage {
+            pname = "dot-merlin-reader";
+            version = "n/a";
+            src = ./.;
+            duneVersion = "3";
+            buildInputs = [ merlin-lib ];
+            doCheck = true;
+          };
+          merlin = buildDunePackage {
+            pname = "merlin";
+            version = "n/a";
+            src = ./.;
+            duneVersion = "3";
+            buildInputs = with pkgs.ocamlPackages; [
+              merlin-lib
+              dot-merlin-reader
+            ];
+            propagatedBuildInputs = with pkgs.ocamlPackages; [
+              dot-merlin-reader
+              merlin-lib
+              findlib
+            ];
+            nativeBuildInputs = [
+              dot-merlin-reader
+            ];
+            checkInputs = with pkgs.ocamlPackages; [
+              ppxlib
+              pkgs.jq
+            ];
+            # merlin tests rely on wrapper shell script and env vars.
+            # TODO: make them work
+            doCheck = false;
+            meta = with pkgs; {
+              mainProgram = "ocamlmerlin";
+            };
           };
         };
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
Currently, merlin can only use `nix develop`.
This PR makes regular nix workflow work (`nix build`, `nix run`, `nix shell`).
Example command to test it with:
```
[rafal@nixos:~/Projects/Tarides/merlin]$ nix run . -- server
Usage: ocamlmerlin command [options] -- [compiler flags]
Help commands are:
  -version        Print version and exit
  -vnum           Print version number and exit
  -warn-help      Show description of warning numbers
  -flags-help     Show description of accepted compiler flags
  -commands-help  Describe all accepted commands
```