### PR TITLE
merl-an benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,7 @@ promote:
 	dune promote
 
 bench:
+	merl-an benchmark -p /projects/irmin -s 1 --data=merl-an_bench
+	jq . merl-an_bench/bench.json
 
 .PHONY: all build dev clean test promote bench

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -7,3 +7,26 @@ RUN sudo apt-get -y install jq
 COPY . .
 RUN sudo chown -R opam /app
 RUN eval $(opam env)
+
+# install merlin
+RUN opam install .
+
+# install merl-an
+RUN opam pin -y merl-an https://github.com/pitag-ha/merl-an.git
+
+RUN eval $(opam env)
+
+# Create directory for projects to run benchmarks on
+RUN sudo mkdir /projects
+RUN sudo chown opam /projects
+WORKDIR /projects
+
+# Irmin
+RUN git clone https://github.com/mirage/irmin.git
+WORKDIR /projects/irmin
+RUN git checkout 8da4d16e7cc8beddfc8a824feca325426bae08a9
+RUN sudo apt install -y gnuplot-x11 libgmp-dev pkg-config libffi-dev
+RUN opam install . --deps-only --with-test --no-checksums
+RUN opam exec -- dune build
+
+WORKDIR /app


### PR DESCRIPTION
This PR introduces benchmarking based on `merl-an`.

Note:
Results are shown for multiple groups, because one commit has used wrong workdir. Currently, we generate only results for buffer-typed.