### PR TITLE
Remove cache hack leftover

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -12,7 +12,6 @@ RUN eval $(opam env)
 RUN opam install .
 
 # install merl-an
-RUN echo "uncache this thing"
 RUN opam pin -y merl-an https://github.com/pitag-ha/merl-an.git
 
 RUN eval $(opam env)


### PR DESCRIPTION
I have used this, so that docker image gets rebuilt in current-bench pipeline. The PR got merged so fast that I didn't have time to remove it. Let's do it now. :wink: