### PR TITLE
feat(emacs): Add support for opam-switch-mode (>= 1.3)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ unreleased
       local values in the completion options.  Alternatively, this
       behavior can be enabled permanently by customizing
       `merlin-construct-with-local-values` (#1644)
+    - emacs: add support for opam-switch-mode (#1654, fixes #1591).
+      See <https://github.com/ProofGeneral/opam-switch-mode>
 
 merlin 4.9
 ==========

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Just add the following to your *.emacs* file:
 ;; (require 'merlin-iedit)       ; iedit.el editing of occurrences
 ;; (require 'merlin-company)     ; company.el completion
 ;; (require 'merlin-ac)          ; auto-complete.el completion
+;; To easily change opam switches and pick the ocamlmerlin binary accordingly,
+;; you can use the minor mode https://github.com/ProofGeneral/opam-switch-mode
 ```
 
 More comprehensive documentation can be found on the [emacs-from-scratch wiki](https://github.com/ocaml/merlin/wiki/emacs-from-scratch).
@@ -127,6 +129,8 @@ Emacs startup file is sufficient:
 ;; (require 'merlin-iedit)       ; iedit.el editing of occurrences
 ;; (require 'merlin-company)     ; company.el completion
 ;; (require 'merlin-ac)          ; auto-complete.el completion
+;; To easily change opam switches and pick the ocamlmerlin binary accordingly,
+;; you can use the minor mode https://github.com/ProofGeneral/opam-switch-mode
 ```
 
 ### Other Editors

--- a/merlin.opam
+++ b/merlin.opam
@@ -51,8 +51,11 @@ Add opam emacs directory to your load-path by appending this to your .emacs:
     (add-hook 'tuareg-mode-hook 'merlin-mode t)
     (add-hook 'caml-mode-hook 'merlin-mode t)
     ;; Use opam switch to lookup ocamlmerlin binary
-    (setq merlin-command 'opam)))
-
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
 Take a look at https://github.com/ocaml/merlin for more information
 
 Quick setup with opam-user-setup


### PR DESCRIPTION
## Overall description

This PR adds support for `opam-switch-mode` (initially written by @hendriktews for [proof-general](https://proofgeneral.github.io) then as a separate ELPA package, further extended by @monnier and myself).

This new feature makes it possible to fully fix #1591, given it is now as easy as clicking on either of the "OPSW" menu-bar or the "OPSW" mode-bar, which changes Emacs underlying PATH accordingly (`exec-path`), and triggers the functions registered in the opam-switch-mode hook (typically, `merlin-stop-server`).

See the following screenshot of opam-switch-mode version 1.3 for a glimpse of the minor mode.

![2023-07-11_16-04-24_Screenshot_OPSW_menus](https://github.com/ocaml/merlin/assets/10367254/76d1c5dc-0e76-4f76-95a0-aa5314ba4440)

## Remarks

* This PR does NOT add opam-switch-mode as a dependency of merlin: it is an optional, accompanying package (only useful for ocaml developers that rely on opam), and it is mostly language-agnostic (apart from using the opam tool).
* The [opam-switch-mode](https://github.com/ProofGeneral/opam-switch-mode) package is available in MELPA, MELPA Stable, NonGNU-devel, [NonGNU](https://elpa.nongnu.org/nongnu/opam-switch-mode.html).
* ~~It requires to use `(setq merlin-command "ocamlmerlin")`, but I was wary of backward-compatibility, so I didn't change the default value of `merlin-command` but documented the requirement instead.~~ this constraint is now lifted.
* The only `Package-Requires:` of opam-switch-mode is `(emacs "25.1")`, which matches with Merlin's ones.

## Details of the commit

* Add option `merlin-stop-server-on-opam-switch` (default: t) and related function `(merlin-stop-server-on-opam-switch)` that kills the merlin server just before we change the opam switch using the OPSW menu-bar or the OPSW mode-bar from opam-switch-mode.