### PR TITLE
Add support for parsing negative numbers in sexps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ unreleased
       fixes #1647)
     - Prevent `short-path` from looping in some cases related to recursive type
       definitions (#1645)
+    - Support parsing negative numbers in sexps (#1655)
   + editor modes
     - emacs: call merlin-client-logger with "interrupted" if the
       merlin binary itself is interrupted, not just the parsing of the

--- a/src/utils/sexp.ml
+++ b/src/utils/sexp.ml
@@ -103,7 +103,7 @@ let is_alpha c =
   || (c >= 'A' && c <= 'Z')
 
 let is_num c =
-  (c >= '0' && c <= '9')
+  (c >= '0' && c <= '9' || c == '-')
 
 let is_alphanum c = is_alpha c || is_num c
 
@@ -149,22 +149,22 @@ let read_sexp getch =
   and read_num getch c =
     Buffer.clear buf;
     Buffer.add_char buf c;
-    let is_float = ref false in
-    let rec aux () =
+    let rec aux ~is_start ~is_float =
       match getch () with
+      | '-' when is_start ->
+        Buffer.add_char buf c; aux ~is_start:false ~is_float
       | c when c >= '0' && c <= '9' ->
-        Buffer.add_char buf c; aux ()
+        Buffer.add_char buf c; aux ~is_start:false ~is_float
       | '.' | 'e' | 'E' as c ->
-        is_float := true;
-        Buffer.add_char buf c; aux ()
+        Buffer.add_char buf c; aux ~is_start:false ~is_float:true
       | c ->
         let s = Buffer.contents buf in
-        (if !is_float
+        (if is_float
          then Float (float_of_string s)
          else Int (int_of_string s)),
         Some c
     in
-    aux ()
+    aux ~is_start:true ~is_float:false
 
   and read_string getch =
     Buffer.clear buf;


### PR DESCRIPTION
The motivation for this came from failing to parse a response that Merlin returned due to the `-1` values for `col` in the `start` and `end` fields:

```
((assoc)
 (class . "return")
 (value (
   (assoc)
   (start (assoc) (line . 0) (col . -1))
   (end (assoc) (line . 0) (col . -1))
   (type . "typer")
   (sub)
   (valid . true)
   (message . "omitted")))
 (notifications)
 (timing (assoc) (clock . 166) (cpu . 145) (query . 1) (pp . 0) (reader . 21) (ppx . 36) (typer . 76) (error . 11)))
```