### PR TITLE
Illustrate and fix issue #1617 with construct and inlined records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ unreleased
     - Prevent `short-path` from looping in some cases related to recursive type
       definitions (#1645)
     - Support parsing negative numbers in sexps (#1655)
+    - Fix construct not working with inline records (#1658)
   + editor modes
     - emacs: call merlin-client-logger with "interrupted" if the
       merlin binary itself is interrupted, not just the parsing of the

--- a/src/analysis/construct.ml
+++ b/src/analysis/construct.ml
@@ -93,6 +93,10 @@ module Util = struct
       | (_ : Typedtree.expression) -> true
       | exception _ -> false
     in
+    if not typeable then
+      log ~title:"constructor" "%a does not have the expected type %a"
+        Logger.fmt (fun fmt -> Printast.expression 0 fmt exp)
+        Logger.fmt (fun fmt -> Printtyp.type_expr fmt type_expected);
     Btype.backtrack snap;
     typeable
 
@@ -370,8 +374,11 @@ module Gen = struct
                 We therefore check that constructed expressions
                 can be typed. *)
               if Util.typeable env exp type_expr
-              then Some exp
-              else None)
+              then Some exp else (
+                log ~title:"constructor" "%s's type is not unifiable with %a"
+                  cstr_descr.Types.cstr_name
+                  Logger.fmt (fun fmt -> Printtyp.type_expr fmt type_expr);
+                None))
         | None -> []
       in
       List.map constrs ~f:(make_constr env path type_expr)

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -5001,6 +5001,8 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
     | None -> Rejected
     | Some _ ->
       begin match sargs with
+      | [{pexp_desc = Pexp_extension ({ txt; _ }, _); _ }]
+        when txt = Ast_helper.hole_txt -> Required
       | [{pexp_desc =
             Pexp_ident _ |
             Pexp_record (_, (Some {pexp_desc = Pexp_ident _}| None))}] ->

--- a/tests/test-dirs/construct/c-inline-record-issue1617.t
+++ b/tests/test-dirs/construct/c-inline-record-issue1617.t
@@ -1,0 +1,20 @@
+  $ cat >main.ml <<EOF
+  > type foo_record = { foo : int }
+  > 
+  > type foo = Foo of foo_record
+  > type bar = Bar of { bar : int }
+  > 
+  > let x : foo = _ (* succeeds *)
+  > let y : bar = _ (* fails *)
+  > EOF
+
+  $ $MERLIN single construct -position 6:15 \
+  > -filename main.ml <main.ml | jq '.value[1]'
+  [
+    "(Foo _)"
+  ]
+
+FIXME: construct should work with inline records
+  $ $MERLIN single construct -position 7:15 \
+  > -filename main.ml <main.ml | jq '.value[1]'
+  []

--- a/tests/test-dirs/construct/c-inline-record-issue1617.t
+++ b/tests/test-dirs/construct/c-inline-record-issue1617.t
@@ -14,7 +14,9 @@
     "(Foo _)"
   ]
 
-FIXME: construct should work with inline records
+Construct also works with inline records
   $ $MERLIN single construct -position 7:15 \
   > -filename main.ml <main.ml | jq '.value[1]'
-  []
+  [
+    "(Bar _)"
+  ]


### PR DESCRIPTION
Type-checking failed because of the presence of a hole that was not handled correctly.

Fixes #1617 (cc @ddickstein )