### PR TITLE
Improve error messages for missing config reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+merlin 4.11
+===========
+unreleased
+
+  + merlin binary
+    - Improve error messages for missing configuration reader (#1669)
+
+
+
 merlin 4.10
 ==========
 Thu Aug 24 17:17:42 CEST 2023

--- a/tests/test-dirs/config/no-dune.t
+++ b/tests/test-dirs/config/no-dune.t
@@ -13,12 +13,9 @@
   $ PATH=bin ocamlmerlin single dump-configuration \
   > -filename main.ml <main.ml >output
 
-Not sure why merlin complains about an unknown flag here.
-Fixme: we could provide a better error message
   $ cat output | jq '.value.merlin.failures'
   [
-    "unknown flag main.ml",
-    "flag -filename: error, Unix.Unix_error(Unix.ENOENT, \"create_process\", \"dune\")"
+    "Merlin could not find `dune` in the PATH to get project configuration. If you do not rely on Dune, make sure `.merlin` files are present in the project's sources."
   ]
 
   $ cat >.merlin <<EOF
@@ -28,10 +25,7 @@ Fixme: we could provide a better error message
   $ PATH=bin ocamlmerlin single dump-configuration \
   > -filename main.ml <main.ml >output
 
-Not sure why merlin complains about an unknown flag here.
-Fixme: we could provide a better error message
   $ cat output | jq '.value.merlin.failures'
   [
-    "unknown flag main.ml",
-    "flag -filename: error, Unix.Unix_error(Unix.ENOENT, \"create_process\", \"dot-merlin-reader\")"
+    "Merlin could not find `dot-merlin-reader` in the PATH. Please make sure that `dot-merlin-reader` is installed and in the PATH."
   ]

--- a/tests/test-dirs/config/no-dune.t
+++ b/tests/test-dirs/config/no-dune.t
@@ -1,0 +1,37 @@
+  $ mkdir bin
+  $ cp ../../../../install/default/bin/ocamlmerlin bin/ocamlmerlin
+  $ cp ../../../../install/default/bin/ocamlmerlin-server bin/ocamlmerlin-server
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > print_endline "Hello world"
+  > EOF
+
+  $ PATH=bin ocamlmerlin single dump-configuration \
+  > -filename main.ml <main.ml >output
+
+Not sure why merlin complains about an unknown flag here.
+Fixme: we could provide a better error message
+  $ cat output | jq '.value.merlin.failures'
+  [
+    "unknown flag main.ml",
+    "flag -filename: error, Unix.Unix_error(Unix.ENOENT, \"create_process\", \"dune\")"
+  ]
+
+  $ cat >.merlin <<EOF
+  > S .
+  > EOF
+
+  $ PATH=bin ocamlmerlin single dump-configuration \
+  > -filename main.ml <main.ml >output
+
+Not sure why merlin complains about an unknown flag here.
+Fixme: we could provide a better error message
+  $ cat output | jq '.value.merlin.failures'
+  [
+    "unknown flag main.ml",
+    "flag -filename: error, Unix.Unix_error(Unix.ENOENT, \"create_process\", \"dot-merlin-reader\")"
+  ]


### PR DESCRIPTION
This PR correctly reset the state if the configuration reader (dune or dot-merlin-reader) failed to start and provide improved error messages than the current exception.

cc @ddickstein 