### PR TITLE
add test for dynamic python3 installation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+merlin NEXT_VERSION
+===================
+
+  + editor modes
+    - vim: load merlin when Vim is compiled with +python3/dyn (e.g. MacVim)
+
 merlin 4.12
 ===========
 Tue Sep 26 17:45:42 CEST 2023

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -1,7 +1,7 @@
 if !exists('g:merlin') | let g:merlin = {} | endif | let s:c = g:merlin
 
 if !exists('g:merlin_python_version')
-  if has('python3')
+  if has('python3') || has('python3_dynamic')
     let g:merlin_python_version = 3
   elseif has('python') || has('python2')
     let g:merlin_python_version = 2


### PR DESCRIPTION
MacVim comes with options +python3/dyn and -python3. This means currently merlin fails to load. This patch fixes that by testing for the dynamic python3.

I did not include the same for python/dyn because by now I think it's better not to support python 2.