### PR TITLE
Configurable cache retention period

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ merlin NEXT_VERSION
 
   + merlin binary
     - Fix a follow-up issue to the preference of non-ghost nodes introduced in #1660 (#1690, fixes #1689)
+    - Add `--cache-period` flag, that sets cache invalidation period. (#1698)
   + editor modes
     - vim: load merlin when Vim is compiled with +python3/dyn (e.g. MacVim)
 

--- a/doc/dev/CACHING.md
+++ b/doc/dev/CACHING.md
@@ -77,7 +77,8 @@ to be used anymore.
 
 `Mocaml.flush_caches` remove all files that have changed on disk or that
 haven't been used for some time.  By default, `ocamlmerlin_server` remove
-entries that haven't been used in the last 300 seconds.
+entries that haven't been used in the last 5 minutes. This behavior can be
+changed with `--cache-period` flag.
 
 Since this involve stating each entry, the check is done after answering.
 

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -194,6 +194,10 @@ a new window or not."
   "If non-nil, use this file for the log file (should be an absolute path)."
   :group 'merlin :type 'file)
 
+(defcustom merlin-cache-period nil
+  "If non-nil, use this value for cache period (measured in minutes)."
+  :group 'merlin :type 'natnum)
+
 (defcustom merlin-arrow-keys-type-enclosing t
   "If non-nil, after a type enclosing, C-up and C-down are used
 to go up and down the AST. In addition, C-w copies the type to the
@@ -550,6 +554,8 @@ argument (lookup appropriate binary, setup logging, pass global settings)"
                   (cons "-flags" merlin-buffer-flags))
                 (when filename
                   (cons "-filename" filename))
+                (when merlin-cache-period
+                  (cons "-cache-period" (number-to-string merlin-cache-period)))
                 args))
     ;; Log last commands
     (setq merlin-debug-last-commands

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -91,6 +91,8 @@ let run = function
         (* Start processing query *)
         Logger.with_log_file Mconfig.(config.merlin.log_file)
           ~sections:Mconfig.(config.merlin.log_sections) @@ fun () ->
+        Mocaml.flush_caches
+          ~older_than:(float_of_int (60 * Mconfig.(config.merlin.cache_period))) ();
         File_id.with_cache @@ fun () ->
         let source = Msource.make (Misc.string_of_file stdin) in
         let pipeline = Mpipeline.make config source in

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -33,7 +33,6 @@ module Server = struct
 
   let server_accept merlinid server =
     let rec loop total =
-      Mocaml.flush_caches ~older_than:300.0 ();
       let merlinid' = File_id.get Sys.executable_name in
       if total > merlin_timeout ||
          not (File_id.check merlinid merlinid') then

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -92,8 +92,9 @@ type merlin = {
   flags_applied : string list with_workdir list;
 
   failures : string list;
-  extension_to_reader : (string * string) list
+  extension_to_reader : (string * string) list;
 
+  cache_period : int
 }
 
 let dump_merlin x =
@@ -129,7 +130,8 @@ let dump_merlin x =
           "extension", `String suffix;
           "reader", `String reader;
         ]) x.extension_to_reader
-    )
+    );
+    "cache_period"   , Json.string (string_of_int x.cache_period)
   ]
 
 module Verbosity = struct
@@ -357,6 +359,15 @@ let merlin_flags = [
     "-ocamllib-path",
     marg_path (fun path merlin -> {merlin with stdlib = Some path}),
     "<path> Change path of ocaml standard library"
+  );
+  (
+    "-cache-period",
+    Marg.param "int" (fun prot merlin ->
+        try {merlin with cache_period = (int_of_string prot)}
+        with _ -> invalid_arg "Valid value is int";
+      ),
+    "Change file cache retention period. It's measured in minutes. \
+      Default value is 5."
   );
   (
     (* Legacy support for janestreet. Ignored. To be removed soon. *)
@@ -627,6 +638,7 @@ let initial = {
 
     failures = [];
     extension_to_reader = [(".re","reason");(".rei","reason")];
+    cache_period = 5;
   };
   query = {
     filename = "*buffer*";

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -49,7 +49,8 @@ type merlin = {
   flags_applied : string list with_workdir list;
 
   failures : string list;
-  extension_to_reader : (string * string) list
+  extension_to_reader : (string * string) list;
+  cache_period : int
 }
 
 val dump_merlin : merlin -> json

--- a/tests/test-dirs/config/dot-merlin-reader/quoting.t
+++ b/tests/test-dirs/config/dot-merlin-reader/quoting.t
@@ -66,7 +66,8 @@
         "extension": ".rei",
         "reader": "reason"
       }
-    ]
+    ],
+    "cache_period": "5"
   }
 
   $ rm .merlin

--- a/tests/test-dirs/server-tests/cache-time.t
+++ b/tests/test-dirs/server-tests/cache-time.t
@@ -1,0 +1,37 @@
+  $ $MERLIN server stop-server
+
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ cat >dune <<EOF
+  > 
+  > (executable
+  >  (name main)
+  >  (modules main)
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let () = print_int 0
+  > EOF
+
+Let's populate file cache
+  $ $MERLIN server errors -log-file merlin_logs -cache-period 45 \
+  > -filename main.ml 1> /dev/null <main.ml
+
+When cache time is set to large value, we keep the cache
+  $ $MERLIN server errors -log-file merlin_logs -cache-period 45 \
+  > -filename main.ml 1> /dev/null <main.ml
+  $ cat merlin_logs | grep -A1 "File_cache(Cmi_cache) - flush" \
+  > | tail -1 | sed 's/\ ".*\"//'
+  keeping
+
+When cache time is set to 0, file cache gets flushed
+  $ $MERLIN server errors -log-file merlin_logs -cache-period 0 \
+  > -filename main.ml 1> /dev/null <main.ml
+  $ cat merlin_logs | grep -A1 "File_cache(Cmi_cache) - flush" \
+  > | tail -1 | sed 's/\ ".*\"//'
+  removing
+
+Stop server
+  $ $MERLIN server stop-server


### PR DESCRIPTION
Second task from #1636

PoC:
The cache retention value was added to Mconfig. Call to `Mocaml.flush_caches` was moved to a place where Mconfig is available. Next step will be to create a flag that allows setting the config value from client. Last step is to use this flag from emacs/vim plugins.