### PR TITLE
uid_of_path can use the decl_id if shapes fail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ merlin NEXT_VERSION
   + merlin binary
     - Fix a follow-up issue to the preference of non-ghost nodes introduced in #1660 (#1690, fixes #1689)
     - Add `--cache-period` flag, that sets cache invalidation period. (#1698)
+    - Fix Merlin locate not fallbacking on the correct file in case of ambiguity
+      (@goldfirere, #1699)
   + editor modes
     - vim: load merlin when Vim is compiled with +python3/dyn (e.g. MacVim)
 

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -182,7 +182,9 @@ end = struct
   let reset () = state := None
 
   let move_to ~digest file =
-    log ~title:"File_switching.move_to" "%s" file;
+    log ~title:"File_switching.move_to" "file: %s\ndigest: %s" file
+    @@ Digest.to_hex digest;
+
     state := Some { last_file_visited = file ; digest }
 
   let where_am_i () = Option.map !state ~f:last_file_visited

--- a/tests/test-dirs/document/issue1513.t
+++ b/tests/test-dirs/document/issue1513.t
@@ -20,8 +20,8 @@ FIXME: We should not rely on "fallbacking". This requires a compiler change.
   $ $MERLIN single document -position 1:13 \
   > -log-file - -log-section locate \
   > -filename main.ml <main.ml 2>&1 | 
-  > grep "Uid not found in the cmt table"
-  Uid not found in the cmt table. Fallbacking to the node's location: File "naux.ml", line 2, characters 2-5
+  > grep "Uid not found in the table."
+  Uid not found in the table.
 
 FIXME: expected "B Comment"
   $ $MERLIN single document -position 2:13 \

--- a/tests/test-dirs/locate/local-build-scheme.t
+++ b/tests/test-dirs/locate/local-build-scheme.t
@@ -36,9 +36,10 @@
   $ $MERLIN single locate -position 2:12 -look-for implementation \
   > -build-path experimental -build-path unix \
   > -source-path . -source-path unix -source-path experimental \
-  > -filename hack.ml <hack.ml | jq '.value'
+  > -filename hack.ml <hack.ml | 
+  > sed 's/"file": ".*experimental.*"/"file": "experimental"/' | jq '.value'
   {
-    "file": "$TESTCASE_ROOT/experimental/m_intf.ml",
+    "file": "experimental",
     "pos": {
       "line": 1,
       "col": 20

--- a/tests/test-dirs/locate/local-build-scheme.t
+++ b/tests/test-dirs/locate/local-build-scheme.t
@@ -37,5 +37,11 @@
   > -build-path experimental -build-path unix \
   > -source-path . -source-path unix -source-path experimental \
   > -filename hack.ml <hack.ml | jq '.value'
-  "Several source files in your path have the same name, and merlin doesn't know which is the right one: $TESTCASE_ROOT/unix/m_intf.ml, $TESTCASE_ROOT/experimental/m_intf.ml"
+  {
+    "file": "$TESTCASE_ROOT/experimental/m_intf.ml",
+    "pos": {
+      "line": 1,
+      "col": 20
+    }
+  }
 

--- a/tests/test-dirs/locate/local-build-scheme.t
+++ b/tests/test-dirs/locate/local-build-scheme.t
@@ -1,0 +1,41 @@
+  $ mkdir experimental
+  $ mkdir unix
+
+  $ cat >experimental/m_intf.ml <<'EOF'
+  > module type S = sig val x : int end (* diff *)
+  > EOF
+
+  $ cat >experimental/exp.ml <<'EOF'
+  > module M_intf = M_intf
+  > EOF
+
+  $ cat >unix/m_intf.ml <<'EOF'
+  > module type S = sig val x : int end
+  > EOF
+
+  $ cat >unix/unix.ml <<'EOF'
+  > module M_intf = M_intf
+  > EOF
+
+  $ cat >hack.ml <<'EOF'
+  > let f (module R : Exp.M_intf.S) =
+  >   let _ = R.x in
+  >   ()
+  > EOF
+
+  $ cd experimental
+  $ $OCAMLC -keep-locs -bin-annot  m_intf.ml exp.ml
+  $ cd ..
+
+  $ cd unix
+  $ $OCAMLC -keep-locs -bin-annot  m_intf.ml unix.ml
+  $ cd ..
+
+  $ $OCAMLC -keep-locs -bin-annot -I experimental/ -I linux/ hack.ml
+ 
+  $ $MERLIN single locate -position 2:12 -look-for implementation \
+  > -build-path experimental -build-path unix \
+  > -source-path . -source-path unix -source-path experimental \
+  > -filename hack.ml <hack.ml | jq '.value'
+  "Several source files in your path have the same name, and merlin doesn't know which is the right one: $TESTCASE_ROOT/unix/m_intf.ml, $TESTCASE_ROOT/experimental/m_intf.ml"
+

--- a/tests/test-dirs/locate/non-local/ignore-kept-locs.t/run.t
+++ b/tests/test-dirs/locate/non-local/ignore-kept-locs.t/run.t
@@ -20,8 +20,8 @@ available:
   }
 
   $ grep -A1 from_uid log | grep -v from_uid | sed '/^--$/d'
-  Loading the shapes for unit "A"
-  Shapes successfully loaded, looking for A.0
+  Loading the cmt for unit "A"
+  Looking for A.0 in the uid_to_loc table
   Found location: File "a.ml", line 1, characters 4-9
 
   $ rm log
@@ -41,8 +41,8 @@ available:
   }
 
   $ grep -A1 from_uid log | grep -v from_uid | sed '/^--$/d'
-  Loading the shapes for unit "A"
-  Shapes successfully loaded, looking for A.0
+  Loading the cmt for unit "A"
+  Looking for A.0 in the uid_to_loc table
   Found location: File "a.ml", line 1, characters 4-9
 
   $ rm log
@@ -66,6 +66,9 @@ In the absence of cmt though, fallbacking to the cmi loc makes sense:
   }
 
   $ grep -A1 from_uid log | grep -v from_uid
-  No UID found, fallbacking to lookup location.
+  Loading the cmt for unit "A"
+  --
+  Failed to load the cmt file.
+  Fallbacking to lookup location: File "a.ml", line 1, characters 4-9
 
   $ rm log


### PR DESCRIPTION
Fixes #1699. Written with direction from @lpw25.