### PR TITLE
Ignore `-cmi-file` flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ merlin NEXT_VERSION
   + merlin binary
     - Fix a follow-up issue to the preference of non-ghost nodes introduced in #1660 (#1690, fixes #1689)
     - Add `--cache-period` flag, that sets cache invalidation period. (#1698)
+    - Ignore the new 5.1 `cmi-file` flag instead of rejecting it (#1710, fixes
+      #1703)
   + editor modes
     - vim: load merlin when Vim is compiled with +python3/dyn (e.g. MacVim)
 

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -427,7 +427,7 @@ let ocaml_ignored_parametrized_flags = [
   "-inline"; "-inline-prim-cost"; "-inline-toplevel"; "-intf";
   "-intf_suffix"; "-intf-suffix"; "-o"; "-rounds"; "-runtime-variant";
   "-unbox-closures-factor"; "-use-prims"; "-use_runtime"; "-use-runtime";
-  "-error-style"; "-dump-dir";
+  "-error-style"; "-dump-dir"; "-cmi-file";
 ]
 
 let ocaml_warnings_spec ~error =

--- a/tests/test-dirs/with-cmi.t
+++ b/tests/test-dirs/with-cmi.t
@@ -21,14 +21,7 @@ Since OCaml 5.1 the compiler support the -cmi-file flag:
 
   $ $OCAMLC -c -cmi-file main.cmi main.ml
 
-FIXME: Merlin should ignore the -cmi-file flag
+Merlin should ignore the -cmi-file flag
   $ $MERLIN single errors -cmi-file main.cmi -filename main.ml <main.ml |
   > jq '.value'
-  [
-    {
-      "type": "config",
-      "sub": [],
-      "valid": true,
-      "message": "unknown flag -cmi-file"
-    }
-  ]
+  []

--- a/tests/test-dirs/with-cmi.t
+++ b/tests/test-dirs/with-cmi.t
@@ -1,0 +1,34 @@
+Since OCaml 5.1 the compiler support the -cmi-file flag:
+> -cmi-file filename
+>     Use the given interface file to type-check the ML source file to compile.
+>     When this option is not specified, the compiler looks for a .mli file with
+>     the same base name than the implementation it is compiling and in the same
+>     directory. If such a file is found, the compiler looks for a corresponding
+>     .cmi file in the included directories and reports an error if it fails to
+>     find one. 
+
+  $ cat >main.mli <<'EOF'
+  > val f : unit -> int
+  > EOF
+
+  $ $OCAMLC -c main.mli
+  $ rm main.mli
+
+
+  $ cat >main.ml <<'EOF'
+  > let f () = 42
+  > EOF
+
+  $ $OCAMLC -c -cmi-file main.cmi main.ml
+
+FIXME: Merlin should ignore the -cmi-file flag
+  $ $MERLIN single errors -cmi-file main.cmi -filename main.ml <main.ml |
+  > jq '.value'
+  [
+    {
+      "type": "config",
+      "sub": [],
+      "valid": true,
+      "message": "unknown flag -cmi-file"
+    }
+  ]


### PR DESCRIPTION
Fixes #1703.

Merlin does not check the adequation between a module and its signature so there is no reason to handle that flag.