### PR TITLE
Report current heap usage on Merlin response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+merlin NEXT_VERSION
+===================
+
+  + merlin binary
+    - Add a "heap_mbytes" field to Merlin server responses to report heap usage (#1717)
+
 merlin 4.13
 ===========
 Fri Dec  1 15:00:42 CET 2023

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -120,6 +120,8 @@ let run = function
                 ("error", `String (Format.flush_str_formatter ()))
           in
           let cpu_time = Misc.time_spent () -. start_cpu in
+          let gc_stats = Gc.quick_stat () in
+          let heap_mbytes = gc_stats.heap_words * 8 / 1_000_000 in
           let clock_time = Unix.gettimeofday () *. 1000. -. start_clock in
           let timing = Mpipeline.timing_information pipeline in
           let pipeline_time =
@@ -134,7 +136,8 @@ let run = function
           `Assoc [
             "class", `String class_; "value", message;
             "notifications", `List (List.rev_map notify !notifications);
-            "timing", `Assoc (List.map format_timing timing)
+            "timing", `Assoc (List.map format_timing timing);
+            "heap_mbytes", `Int heap_mbytes
           ]
         in
         log ~title:"run(result)" "%a" Logger.json (fun () -> json);

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -121,7 +121,7 @@ let run = function
           in
           let cpu_time = Misc.time_spent () -. start_cpu in
           let gc_stats = Gc.quick_stat () in
-          let heap_mbytes = gc_stats.heap_words * 8 / 1_000_000 in
+          let heap_mbytes = gc_stats.heap_words * (Sys.word_size / 8) / 1_000_000 in
           let clock_time = Unix.gettimeofday () *. 1000. -. start_clock in
           let timing = Mpipeline.timing_information pipeline in
           let pipeline_time =

--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -10,6 +10,7 @@ fi
 
 ocamlmerlin "$@" \
     | jq 'del(.timing)' \
+    | jq 'del(.heap_mbytes)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \
     | sed -e 's:\\n:\
 :g'


### PR DESCRIPTION
This PR is a first step toward completing #1680

It enriches Merlin's responses with a new `heap_mbytes` field, that contains the total major heap size (in *megabytes*) after completing the request.

The implementation relies on using the `heap_words` field from  [Gc.stat](https://v2.ocaml.org/api/Gc.html).

This PR should be covering enough ground to satisfy the motivations 1 and 3 of the aforementined issue.
Motivation 2 maybe needs a finer grained solution with better granularity (ie. not only at the end of a request).

Let me know if there any refinement required, or if we need to add other fields, or if this is providing enough data as it is.