### PR TITLE
Allow jump to module type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ merlin NEXT_VERSION
     - Fix `FLG -pp ppx.exe -as-pp/-dump-ast` use of invalid shell redirection when 
     direct process launch on Windows. (#1723, fixes #1722)
     - Add a query_num field to the `ocamlmerlin` responses to detect server crashes (#1716)
+    - Jump to `module-type` (#1728, partially fixes #1656)
   + editor modes
     - vim: load merlin under the ocamlinterface and ocamllex filetypes (#1340)
     - Fix merlinpp not using binary file open (#1725, fixes #1724)

--- a/src/analysis/jump.ml
+++ b/src/analysis/jump.ml
@@ -89,6 +89,10 @@ let module_pred = function
   | _ -> None
 ;;
 
+let module_type_pred = function
+  | (Module_type_declaration _ as node) :: _ -> Some node
+  | _ -> None
+
 let match_pred = function
   | (Expression { exp_desc = Texp_match _ ; _ } as node) :: _ -> Some node
   | _ -> None
@@ -139,6 +143,7 @@ let get typed_tree pos target =
     "fun", fun_pred;
     "let", let_pred;
     "module", module_pred;
+    "module-type", module_type_pred;
     "match", match_pred;
   ] in
   let targets = Str.split (Str.regexp "[, ]") target in

--- a/src/frontend/ocamlmerlin/new/new_commands.ml
+++ b/src/frontend/ocamlmerlin/new/new_commands.ml
@@ -342,8 +342,8 @@ compiler settings in an IDE."
         (marg_position (fun pos (target,_pos) -> (target,pos)));
     ]
 ~doc:"This command can be used to assist navigation in a source code buffer.
-Target is a string that can contain one or more of the 'fun', 'let', 'module' \
-and 'match' words.
+Target is a string that can contain one or more of the 'fun', 'let', 'module', \
+'module-type' and 'match' words.
 It returns the starting position of the function, let definition, module or \
 match expression that contains the cursor
 "

--- a/tests/test-dirs/motion/jump.t
+++ b/tests/test-dirs/motion/jump.t
@@ -29,6 +29,21 @@
     "notifications": []
   }
 
+  $ $MERLIN single jump -target module-type -position 2:3 -filename test.ml <<EOF
+  > module type T = sig
+  >   type t
+  > end
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }
 
 
 Same line should fail:

--- a/tests/test-dirs/motion/jump.t
+++ b/tests/test-dirs/motion/jump.t
@@ -13,6 +13,24 @@
     "notifications": []
   }
 
+  $ $MERLIN single jump -target module -position 2:3 -filename test.ml <<EOF
+  > module T = struct
+  >   type t
+  > end
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }
+
+
+
 Same line should fail:
 
   $ $MERLIN single jump -target let -position 1:8 -filename test.ml <<EOF


### PR DESCRIPTION
This patch proposes to add the `module-type` parameter to the `jump` command.
Address partially #1656