### PR TITLE
destruct: destructing punned record field breaks syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ merlin NEXT_VERSION
 
   + merlin binary
     - destruct: Removal of residual patterns (#1737, fixes #1560)
+    - Do not erase fields' names when destructing punned record fields (#1734, 
+      fixes #1661)
 
 merlin 4.14
 ===========

--- a/tests/test-dirs/destruct/issue1661.t
+++ b/tests/test-dirs/destruct/issue1661.t
@@ -1,0 +1,46 @@
+  $ $MERLIN single case-analysis -start 2:9 -end 2:9 \
+  > -filename main.ml <<EOF
+  > type t = {a: int * int; b: string}
+  > let f ({a; b} : t) = assert false
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 9
+        }
+      },
+      "a = (_, _)"
+    ],
+    "notifications": []
+  }
+
+
+  $ $MERLIN single case-analysis -start 2:9 -end 2:9 \
+  > -filename main.ml <<EOF
+  > type t = {a: int option; b: string}
+  > let f ({a; b} : t) = assert false
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 13
+        }
+      },
+      "({ a = None; b } : t) | ({ a = Some _; b } : t)"
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Destructing a record punning field produced invalid OCaml syntax, as described in #1661, the case where we deconstruct on `a`, the `a` is substituted by the result of the deconstruction, whereas we would like to produce `a = destruct_result`. 

fix #1661 