### PR TITLE
add get/set contexts commands

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -486,6 +486,6 @@ let rec main () =
     write stdout directives;
     flush stdout;
     main ()
-  | Unknown -> main ()
+  | GetContexts | SetContext _ | Unknown -> main ()
 
 let () = main ()

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -79,7 +79,12 @@ type read_error =
   | Unexpected_output of string
   | Csexp_parse_error of string
 
-type command = File of string | Halt | Unknown
+type command =
+  | File of string
+  | GetContexts
+  | SetContext of string
+  | Halt
+  | Unknown
 
 module type S = sig
   type 'a io
@@ -98,6 +103,13 @@ module type S = sig
 
     val send_file : out_chan -> string -> unit io
 
+    (** [read_contexts] gets all Dune contexts under the given workspace *)
+    val read_contexts :
+    in_chan -> (string list, read_error) Merlin_utils.Std.Result.t io
+  
+    (** [set_context] sets the current Dune context that Merlin will query information from *)
+    val set_context : out_chan -> string -> unit io
+  
     val halt : out_chan -> unit io
   end
 end


### PR DESCRIPTION
Implements new additions to Dune protocol. The goal is to allow users to dynamically choose the Dune context to use for merlin information from their editor, rather than having to edit `dune-workspace` file. See https://github.com/ocamllabs/vscode-ocaml-platform/issues/1432 for added context.

Depends on https://github.com/ocaml/dune/pull/10324.