### PR TITLE
Ignore SIGPIPE in the Merlin server process

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ merlin NEXT_VERSION
     - destruct: Removal of residual patterns (#1737, fixes #1560)
     - Do not erase fields' names when destructing punned record fields (#1734, 
       fixes #1661)
+    - Ignore SIGPIPE in the Merlin server process (#1746)
 
 merlin 4.14
 ===========

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -65,7 +65,7 @@ module Server = struct
       Logger.log ~section:"server" ~title:"cannot setup listener" ""
     | Some server ->
       (* If the client closes its connection, don't let it kill us with a SIGPIPE. *)
-      let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
+      if Sys.unix then ignore @@ Sys.signal Sys.sigpipe Sys.Signal_ignore;
       loop (File_id.get Sys.executable_name) server;
       Os_ipc.server_close server
 end

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -64,6 +64,8 @@ module Server = struct
     | None ->
       Logger.log ~section:"server" ~title:"cannot setup listener" ""
     | Some server ->
+      (* If the client closes its connection, don't let it kill us with a SIGPIPE. *)
+      let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
       loop (File_id.get Sys.executable_name) server;
       Os_ipc.server_close server
 end

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -65,7 +65,7 @@ module Server = struct
       Logger.log ~section:"server" ~title:"cannot setup listener" ""
     | Some server ->
       (* If the client closes its connection, don't let it kill us with a SIGPIPE. *)
-      if Sys.unix then ignore @@ Sys.signal Sys.sigpipe Sys.Signal_ignore;
+      if Sys.unix then Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
       loop (File_id.get Sys.executable_name) server;
       Os_ipc.server_close server
 end


### PR DESCRIPTION
Bringing in changes from [merlin-jst](https://github.com/janestreet/merlin-jst/pull/49).

From @catern:

The merlin server writes to pipes received from the merlin client process. If the read end of those pipes is closed, e.g. because the merlin client process was killed, then when the server writes to the pipe it will generate a SIGPIPE. This kills the Merlin server. Ignore the SIGPIPE instead of unnecessarily dying.

The fact that you get SIGPIPE when you write to a closed pipe is a classic Unix footgun, and this is the usual resolution. Another solution is to avoid pipes (in favor of e.g. socketpairs), but we can't do that because we write directly to the file descriptors received from the client.