### PR TITLE
Adopt OCaml's code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct
+[enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+To report any violations, please contact:
+
+- Sonja Heinze <sonja [at] tarides [dot] com>
+- Ulysse Gérard <ulysse [at] tarides [dot] com>
+- Pizie Dust <pizie [at] tarides [dot] com>
+- Xavier Van de Woestyne <xavier [at] tarides [dot] com>


### PR DESCRIPTION
As mentioned, adopting the OCaml code of conduct seems to be a good practice!
Who should be listed as "moderators"? (cc @voodoos, @let-def, @trefis, @PizieDust)?