### PR TITLE
nix: Build with OCaml 5.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688587528,
-        "narHash": "sha256-a1WlbVZyFtXVwqU/Ut+tl8aTgexp/GKloQtGA1Hfwjw=",
+        "lastModified": 1715867414,
+        "narHash": "sha256-cu4UEffKkBByyGR6CFs9XP6iSNsKTkq1r66DA5BkYnE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08c696c8d702e98d6693efea6d0be94b54849a16",
+        "rev": "bf446f08bff6814b569265bef8374cfdd3d8f0e0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,12 @@
               version = "20201216";
               src = menhir-repository;
             });
+
+            inherit (packages) merlin-lib dot-merlin-reader merlin;
           });
 
         inherit (ocamlPackages) buildDunePackage;
-      in rec {
+
         packages = rec {
           default = merlin;
           merlin-lib = buildDunePackage {
@@ -35,6 +37,7 @@
             propagatedBuildInputs = with ocamlPackages; [ csexp ];
             doCheck = true;
           };
+
           dot-merlin-reader = buildDunePackage {
             pname = "dot-merlin-reader";
             version = "dev";
@@ -44,6 +47,7 @@
             buildInputs = [ merlin-lib ];
             doCheck = true;
           };
+
           merlin = buildDunePackage {
             pname = "merlin";
             version = "dev";
@@ -69,9 +73,12 @@
             meta = with pkgs; { mainProgram = "ocamlmerlin"; };
           };
         };
+      in {
+        inherit packages;
+
         devShells.default = pkgs.mkShell {
           inputsFrom = pkgs.lib.attrValues packages;
-          buildInputs = with ocamlPackages; [ ocaml-lsp ];
+          buildInputs = with ocamlPackages; [ merlin ];
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,17 +11,20 @@
   outputs = { self, nixpkgs, flake-utils, menhir-repository }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages."${system}".extend (_: super: {
-          ocamlPackages = super.ocamlPackages.overrideScope' (_: osuper: {
+        pkgs = nixpkgs.legacyPackages."${system}";
+
+        # Build with OCaml 5.2
+        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_5_2.overrideScope'
+          (_: osuper: {
+            # Override menhirLib to the pinned version
             menhirLib = osuper.menhirLib.overrideAttrs (_: {
               version = "20201216";
               src = menhir-repository;
             });
           });
-        });
-        inherit (pkgs.ocamlPackages) buildDunePackage;
-      in
-      rec {
+
+        inherit (ocamlPackages) buildDunePackage;
+      in rec {
         packages = rec {
           default = merlin;
           merlin-lib = buildDunePackage {
@@ -29,9 +32,7 @@
             version = "dev";
             src = ./.;
             duneVersion = "3";
-            propagatedBuildInputs = with pkgs.ocamlPackages; [
-              csexp
-            ];
+            propagatedBuildInputs = with ocamlPackages; [ csexp ];
             doCheck = true;
           };
           dot-merlin-reader = buildDunePackage {
@@ -39,12 +40,8 @@
             version = "dev";
             src = ./.;
             duneVersion = "3";
-            propagatedBuildInputs = [
-              pkgs.ocamlPackages.findlib
-            ];
-            buildInputs = [
-              merlin-lib
-            ];
+            propagatedBuildInputs = [ ocamlPackages.findlib ];
+            buildInputs = [ merlin-lib ];
             doCheck = true;
           };
           merlin = buildDunePackage {
@@ -55,33 +52,26 @@
             buildInputs = [
               merlin-lib
               dot-merlin-reader
-              pkgs.ocamlPackages.menhirLib
-              pkgs.ocamlPackages.menhirSdk
-              pkgs.ocamlPackages.yojson
+              ocamlPackages.menhirLib
+              ocamlPackages.menhirSdk
+              ocamlPackages.yojson
             ];
-            nativeBuildInputs = [
-              pkgs.ocamlPackages.menhir
-              pkgs.jq
-            ];
+            nativeBuildInputs = [ ocamlPackages.menhir pkgs.jq ];
             nativeCheckInputs = [ dot-merlin-reader ];
-            checkInputs = with pkgs.ocamlPackages; [
-              ppxlib
-            ];
+            checkInputs = with ocamlPackages; [ ppxlib ];
             doCheck = true;
             checkPhase = ''
               runHook preCheck
               patchShebangs tests/merlin-wrapper
               dune build @check @runtest
               runHook postCheck
-           '';
-            meta = with pkgs; {
-              mainProgram = "ocamlmerlin";
-            };
+            '';
+            meta = with pkgs; { mainProgram = "ocamlmerlin"; };
           };
         };
         devShells.default = pkgs.mkShell {
           inputsFrom = pkgs.lib.attrValues packages;
-          buildInputs = with pkgs.ocamlPackages; [ ocaml-lsp ];
+          buildInputs = with ocamlPackages; [ ocaml-lsp ];
         };
       });
 }

--- a/tests/test-dirs/inconsistent-assumptions.t
+++ b/tests/test-dirs/inconsistent-assumptions.t
@@ -66,13 +66,10 @@ Do an update that breaks the build:
   $ cd _build
   $ $OCAMLC -c -w @a-40-41-42-49-70 -short-paths -open My_lib__ -o my_lib__Import import.ml
   $ $OCAMLC -c -w @a-40-41-42-49-70 -short-paths -open My_lib__ -o my_lib__Bar bar.ml
-  $ $OCAMLC -c -w @a-40-41-42-49-70 -short-paths -open My_lib__ -o my_lib__Foo foo.ml
+  $ $OCAMLC -c -w @a-40-41-42-49-70 -short-paths -open My_lib__ -o my_lib__Foo foo.ml 2>&1 | head -n 3
   File "foo.ml", line 4, characters 11-12:
   4 | let x, _ = x + 1, Bar.b
                  ^
-  Error: This expression has type char but an expression was expected of type
-           int
-  [2]
   $ cd ..
 
 Go to the file, and ask merlin to move you to the error:


### PR DESCRIPTION
This changes flake.nix to build Merlin with OCaml 5.2 in order to support 5.2-only features.

Nixpkgs needed to be updated too.