### PR TITLE
Revert: remove reparsing of longident to index modules in paths

### DIFF
--- a/src/analysis/occurrences.mli
+++ b/src/analysis/occurrences.mli
@@ -1,6 +1,5 @@
 val locs_of
   : config:Mconfig.t
-  -> source:Msource.t
   -> env:Env.t
   -> typer_result:Mtyper.result
   -> pos:Lexing.position

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -797,7 +797,6 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
 
   | Occurrences (`Ident_at pos, _) ->
     let config = Mpipeline.final_config pipeline in
-    let source = Mpipeline.raw_source pipeline in
     let typer_result = Mpipeline.typer_result pipeline in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let env, _node = Mbrowse.leaf_node (Mtyper.node_at typer_result pos) in
@@ -810,7 +809,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
       path
     in
     let locs =
-      Occurrences.locs_of ~config ~source ~env ~typer_result ~pos path
+      Occurrences.locs_of ~config ~env ~typer_result ~pos path
       |> Result.value ~default:[]
     in
     let loc_start l = l.Location.loc_start in

--- a/tests/test-dirs/occurrences/mod-in-path-2.t
+++ b/tests/test-dirs/occurrences/mod-in-path-2.t
@@ -7,6 +7,7 @@
   >   | Mod.A -> ()
   > EOF
 
+FIXME: we could expect module appearing in paths to be highlighted
   $ $MERLIN single occurrences -identifier-at 1:8 -filename test.ml <test.ml | 
   > jq '.value'
   [
@@ -18,26 +19,6 @@
       "end": {
         "line": 1,
         "col": 10
-      }
-    },
-    {
-      "start": {
-        "line": 5,
-        "col": 8
-      },
-      "end": {
-        "line": 5,
-        "col": 11
-      }
-    },
-    {
-      "start": {
-        "line": 6,
-        "col": 4
-      },
-      "end": {
-        "line": 6,
-        "col": 7
       }
     }
   ]

--- a/tests/test-dirs/occurrences/mod-in-path-3.t
+++ b/tests/test-dirs/occurrences/mod-in-path-3.t
@@ -8,6 +8,7 @@
   >   | Mod.A r -> r.lbl
   > EOF
 
+FIXME: we could expect module appearing in paths to be highlighted
   $ $MERLIN single occurrences -identifier-at 4:9 -filename test.ml <test.ml | 
   > jq '.value'
   [
@@ -19,26 +20,6 @@
       "end": {
         "line": 1,
         "col": 10
-      }
-    },
-    {
-      "start": {
-        "line": 4,
-        "col": 8
-      },
-      "end": {
-        "line": 4,
-        "col": 11
-      }
-    },
-    {
-      "start": {
-        "line": 7,
-        "col": 4
-      },
-      "end": {
-        "line": 7,
-        "col": 7
       }
     }
   ]

--- a/tests/test-dirs/occurrences/mod-in-path.t
+++ b/tests/test-dirs/occurrences/mod-in-path.t
@@ -13,6 +13,7 @@
   > let _ = let open Mod in Nod.x
   > EOF
 
+FIXME: we could expect module appearing in paths to be highlighted
   $ $MERLIN single occurrences -identifier-at 6:13 -filename test.ml <test.ml | 
   > jq '.value'
   [
@@ -25,50 +26,10 @@
         "line": 2,
         "col": 12
       }
-    },
-    {
-      "start": {
-        "line": 6,
-        "col": 12
-      },
-      "end": {
-        "line": 6,
-        "col": 15
-      }
-    },
-    {
-      "start": {
-        "line": 7,
-        "col": 14
-      },
-      "end": {
-        "line": 7,
-        "col": 17
-      }
-    },
-    {
-      "start": {
-        "line": 9,
-        "col": 0
-      },
-      "end": {
-        "line": 9,
-        "col": 3
-      }
-    },
-    {
-      "start": {
-        "line": 12,
-        "col": 24
-      },
-      "end": {
-        "line": 12,
-        "col": 27
-      }
     }
   ]
 
-
+FIXME: we could expect module appearing in paths to be highlighted
   $ $MERLIN single occurrences -identifier-at 12:18 -filename test.ml <test.ml | 
   > jq '.value'
   [
@@ -80,36 +41,6 @@
       "end": {
         "line": 1,
         "col": 10
-      }
-    },
-    {
-      "start": {
-        "line": 6,
-        "col": 8
-      },
-      "end": {
-        "line": 6,
-        "col": 11
-      }
-    },
-    {
-      "start": {
-        "line": 7,
-        "col": 8
-      },
-      "end": {
-        "line": 7,
-        "col": 11
-      }
-    },
-    {
-      "start": {
-        "line": 8,
-        "col": 8
-      },
-      "end": {
-        "line": 8,
-        "col": 11
       }
     },
     {


### PR DESCRIPTION
This reparsing has very bad performances. The correct way to deal with issue is to have the compiler store precise locations in longidents.