### PR TITLE
Do not return PWO for defs in the current interface file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ UNRELEASED
     - Perform incremental indexation of the buffer when typing. (#1777)
     - `merlin-lib.commands`: Add a `find_command_opt`` alternative to
       `find_command` that does not raise (#1778)
+    - Prevent uid clashes by not returning PWO for defs located in the current
+      interface file (#1781)
   + editor modes
     - emacs: add basic support for project-wide occurrences (#1766)
     - vim: add basic support for project-wide occurrences (#1767, @Julow)

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -178,7 +178,12 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
           Lid_set.filter (fun {loc; _} ->
           (* We ignore external results that concern the current buffer *)
           let file = loc.Location.loc_start.Lexing.pos_fname in
-          if String.equal file current_buffer_path then false
+          let file, buf =
+            match config.merlin.source_root with
+            | Some root -> Filename.concat root file, current_buffer_path
+            | None -> file, config.query.filename
+          in
+          if String.equal file buf then false
           else begin
             (* We ignore external results if their source was modified *)
             let check = Stat_check.check stats ~file in

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -1,0 +1,108 @@
+  $ cat >main.mli <<'EOF'
+  > type t = unit
+  > val x : t
+  > EOF
+
+  $ cat >main.ml <<'EOF'
+  > let x = ()
+  > type t = unit
+  > EOF
+
+  $ ocamlc -bin-annot -bin-annot-occurrences -c main.mli main.ml
+
+  $ ocaml-index aggregate main.cmti main.cmt
+
+The indexer should not mixup uids from mli and ml files:
+  $ ocaml-index dump project.ocaml-index
+  2 uids:
+  {uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
+   uid: Main.1; locs: "t": File "main.ml", line 2, characters 5-6 },
+  0 approx shapes: {}, and shapes for CUS .
+
+FIXME: Merlin should not mixup uids from mli and ml files:
+  $ $MERLIN single occurrences -scope project -identifier-at 2:8 \
+  > -index-file project.ocaml-index \
+  > -filename main.mli <main.mli
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 1,
+          "col": 5
+        },
+        "end": {
+          "line": 1,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 1,
+          "col": 4
+        },
+        "end": {
+          "line": 1,
+          "col": 5
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 9
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME: same as previous case
+  $ $MERLIN single occurrences -scope project -identifier-at 1:5 \
+  > -index-file project.ocaml-index \
+  > -filename main.mli <main.mli
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 1,
+          "col": 5
+        },
+        "end": {
+          "line": 1,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 1,
+          "col": 4
+        },
+        "end": {
+          "line": 1,
+          "col": 5
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 9
+        }
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -19,7 +19,7 @@ The indexer should not mixup uids from mli and ml files:
    uid: Main.1; locs: "t": File "main.ml", line 2, characters 5-6 },
   0 approx shapes: {}, and shapes for CUS .
 
-FIXME: Merlin should not mixup uids from mli and ml files:
+Merlin should not mixup uids from mli and ml files:
   $ $MERLIN single occurrences -scope project -identifier-at 2:8 \
   > -index-file project.ocaml-index \
   > -filename main.mli <main.mli
@@ -38,17 +38,6 @@ FIXME: Merlin should not mixup uids from mli and ml files:
         }
       },
       {
-        "file": "$TESTCASE_ROOT/main.ml",
-        "start": {
-          "line": 1,
-          "col": 4
-        },
-        "end": {
-          "line": 1,
-          "col": 5
-        }
-      },
-      {
         "file": "$TESTCASE_ROOT/main.mli",
         "start": {
           "line": 2,
@@ -63,7 +52,7 @@ FIXME: Merlin should not mixup uids from mli and ml files:
     "notifications": []
   }
 
-FIXME: same as previous case
+Same when the cursor is at the origin:
   $ $MERLIN single occurrences -scope project -identifier-at 1:5 \
   > -index-file project.ocaml-index \
   > -filename main.mli <main.mli
@@ -79,17 +68,6 @@ FIXME: same as previous case
         "end": {
           "line": 1,
           "col": 6
-        }
-      },
-      {
-        "file": "$TESTCASE_ROOT/main.ml",
-        "start": {
-          "line": 1,
-          "col": 4
-        },
-        "end": {
-          "line": 1,
-          "col": 5
         }
       },
       {


### PR DESCRIPTION
Uids of the interface and implementation of a module might overlaps.

Until more information can be opbtain from the compiler we simply don't return external occurrences of types that are defined in the current interface file.