### PR TITLE
merlin.py: fix python-3.12 Syntax warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ unreleased
     - A new `WRAPPING_PREFIX` configuration directive that can be used to tell Merlin
       what to append to the current unit name in the presence of wrapping (#1788)
     - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (#1795, fixes #1794)
+  + editor modes
+    - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
 
 merlin 5.1
 ==========

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -823,19 +823,19 @@ def easy_matcher_wide(start, stop):
     startl = ""
     startc = ""
     if start['line'] > 0:
-        startl = "\%{0}l".format(start['line'])
+        startl = "\\%{0}l".format(start['line'])
     if start['col'] > 0:
-        startc = "\%{0}c".format(start['col'] + 1)
-    return '{0}{1}.*\%{2}l\%{3}c'.format(startl, startc, stop['line'], stop['col'] + 1)
+        startc = "\\%{0}c".format(start['col'] + 1)
+    return '{0}{1}.*\\%{2}l\\%{3}c'.format(startl, startc, stop['line'], stop['col'] + 1)
 
 def easy_matcher(start, stop):
     startl = ""
     startc = ""
     if start['line'] > 0:
-        startl = "\%>{0}l".format(start['line'] - 1)
+        startl = "\\%>{0}l".format(start['line'] - 1)
     if start['col'] > 0:
-        startc = "\%>{0}c".format(start['col'])
-    return '{0}{1}\%<{2}l\%<{3}c'.format(startl, startc, stop['line'] + 1, stop['col'] + 1)
+        startc = "\\%>{0}c".format(start['col'])
+    return '{0}{1}\\%<{2}l\\%<{3}c'.format(startl, startc, stop['line'] + 1, stop['col'] + 1)
 
 def hard_matcher(start, stop):
     first_start = {'line' : start['line'], 'col' : start['col']}
@@ -847,7 +847,7 @@ def hard_matcher(start, stop):
     last_start = {'line' : stop['line'], 'col' : 0}
     last_stop =  {'line' : stop['line'], 'col' : stop['col']}
     last_line = easy_matcher(last_start, last_stop)
-    return "{0}\|{1}\|{2}".format(first_line, middle, last_line)
+    return "{0}\\|{1}\\|{2}".format(first_line, middle, last_line)
 
 def make_matcher(start, stop):
     if start['line'] == stop['line']:


### PR DESCRIPTION
The python code for the vim plugin contains the strings `"\%"` and `"\|"` which generate SyntaxWarnings on python-3.12. Change the strings to `"\\%"` and `"\\|"` which produce the same output and silence the warning.

```
python 3.12.4 (main, Jun  6 2024, 18:26:44) [GCC 13.3.0] on linux
>>> print("\%\\%")
<stdin>:1: SyntaxWarning: invalid escape sequence '\%'
\%\%
>>> print("\|\\|")
<stdin>:1: SyntaxWarning: invalid escape sequence '\|'
\|\|
```