### PR TITLE
Fix deletion of preprocessor output file after usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ unreleased
     - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (#1795, fixes #1794)
   + editor modes
     - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
+    - Fix merlinpp not removing temporary files (#1801, partly fixes #1802)
 
 merlin 5.1
 ==========

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -180,6 +180,7 @@ let apply_pp ~workdir ~filename ~source ~pp =
     let ic = open_in_bin fn_out in
     let result = Misc.string_of_file ic in
     close_in ic;
+    Misc.remove_file fn_out;
     Ok result
 
 let decode_potential_ast source =


### PR DESCRIPTION
When correctly read, the temporary file used to store the result of the preprocessor on the input file is never deleted, which leads to accumulation of files in the `/tmp/` directory.