### PR TITLE
Fix ignorance of STDLIB in .merlin

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -356,8 +356,7 @@ let prepend_config ~cwd ~cfg =
       | Some p ->
         log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
       end;
-      { cfg with stdlib = Some canon_path;
-                 pass_forward = `STDLIB canon_path :: cfg.pass_forward }
+      { cfg with stdlib = Some canon_path }
     | `SOURCE_ROOT path ->
       let canon_path = canonicalize_filename ~cwd path in
       { cfg with source_root = Some canon_path }
@@ -428,6 +427,7 @@ let postprocess cfg =
         (dirs :> Merlin_dot_protocol.directive list)
       )
     ; (cfg.pass_forward :> Merlin_dot_protocol.directive list)
+    ; cfg.stdlib |> Option.map ~f:(fun stdlib -> `STDLIB stdlib) |> Option.to_list
     ; List.concat_map pkg_paths ~f:(fun p -> [ `B p; `S p ])
     ; ppx
     ; List.map failures ~f:(fun s -> `ERROR_MSG s)

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -356,7 +356,8 @@ let prepend_config ~cwd ~cfg =
       | Some p ->
         log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
       end;
-      { cfg with stdlib = Some canon_path }
+      { cfg with stdlib = Some canon_path;
+                 pass_forward = `STDLIB canon_path :: cfg.pass_forward }
     | `SOURCE_ROOT path ->
       let canon_path = canonicalize_filename ~cwd path in
       { cfg with source_root = Some canon_path }

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -5,12 +5,13 @@ This test comes from: https://github.com/janestreet/merlin-jst/pull/59
   > S source/dir
   > BH build-hidden/dir
   > SH source-hidden/dir
+  > STDLIB /stdlib
   > EOF
 
   $ FILE=$(pwd)/test.ml; dot-merlin-reader <<EOF | sed 's#[0-9]*:#?:#g'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir))
+  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir)(?:STDLIB?:/stdlib))
 
   $ echo | $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
   {
@@ -41,7 +42,7 @@ This test comes from: https://github.com/janestreet/merlin-jst/pull/59
         "intf": ".rei"
       }
     ],
-    "stdlib": null,
+    "stdlib": "/stdlib",
     "source_root": null,
     "unit_name": null,
     "wrapping_prefix": null,

--- a/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
@@ -1,0 +1,21 @@
+The STDLIB directive in .merlin is respected
+  $ cat > .merlin <<EOF
+  > STDLIB /stdlib1
+  > EOF
+
+  $ echo | $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib1"
+
+  $ rm .merlin
+
+The -ocamlib-path flag is respected
+  $ echo | $MERLIN single dump-configuration -ocamllib-path /stdlib2 -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib2"
+
+The STDLIB directive in .merlin takes priority over -ocamllib-path
+  $ cat > .merlin <<EOF
+  > STDLIB /stdlib-from-.merlin
+  > EOF
+
+  $ echo | $MERLIN single dump-configuration -ocamllib-path /stdlib-from-flag -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib-from-.merlin"


### PR DESCRIPTION
Currently, the directive `STDLIB` inside a `.merlin` file is ignored. This PR fixes this bug.