### PR TITLE
vim: remove references to MerlinPhrase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ unreleased
     - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (#1795, fixes #1794)
   + editor modes
     - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
+    - vim: Dead code / doc removal for previously deleted MerlinPhrase command (#1804)
 
 merlin 5.1
 ==========

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -680,20 +680,6 @@ function! merlin#setVisualSelection(a, b)
   call setpos("'b", markBSave)
 endfunction
 
-let s:phrase_counter = 0
-
-function! merlin#Phrase()
-  if s:phrase_counter
-      let s:phrase_counter = s:phrase_counter - 1
-  else
-    let [l1, c1] = getpos("'<")[1:2]
-    let [l2, c2] = getpos("'>")[1:2]
-    let s:phrase_counter = l2 - l1
-    MerlinPy merlin.vim_selectphrase("l1","c1","l2","c2")
-    call merlin#setVisualSelection([l1,c1],[l2,c2])
-  endif
-endfunction
-
 function! merlin#Register()
   if @% == ":merlin-type-history:"
     return
@@ -827,10 +813,6 @@ function! merlin#Register()
   command! -buffer -nargs=0 MerlinGotoDotMerlin call merlin#GotoDotMerlin()
   command! -buffer -nargs=0 MerlinEchoDotMerlin call merlin#EchoDotMerlin()
 
-  """ 'semantic movement'  -----------------------------------------------------
-  " TODO: bind (,),{,} ?
-  command! -buffer -nargs=0 MerlinPhrase call merlin#Phrase()
-
   """ Polarity search
   command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearch call merlin#PolaritySearch(0,<q-args>)
 
@@ -838,10 +820,6 @@ function! merlin#Register()
   command! -buffer -nargs=0 MerlinDebugLastCommands MerlinPy merlin.vim_last_commands()
   command! -buffer -nargs=0 MerlinDebugDisable call merlin#DebugDisable()
   command! -buffer -nargs=0 MerlinDebugEnable  call merlin#DebugEnable()
-
-  if !exists('g:merlin_disable_default_keybindings') || !g:merlin_disable_default_keybindings
-    vmap <silent><buffer> <TAB>         :<C-u>MerlinPhrase<return>
-  endif
 
   call merlin#LoadProject()
 endfunction

--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -147,12 +147,6 @@ environment which name matches the user input.
 
 Hitting enter will move you to the definition of the selected element.
 
-:MerlinPhrase                                                *:MerlinPhrase*
-Selects the current phrase.
-
-
-Bound to <TAB> by default in visual mode.
-
 :MerlinErrorCheck                                            *:MerlinErrorCheck*
 
 Perform a fast type check of the current file, displaying the error


### PR DESCRIPTION
MerlinPhrase calls an undefined function, vim_selectphrase, in the python code. This function was removed some years ago in change 8ebe7ff71ed367f814ca399cb1328f02f5c9d976. Remove all references to MerlinPhrase in the help docs, keybindings and vim functions which call it.

https://github.com/ocaml/merlin/commit/8ebe7ff71ed367f814ca399cb1328f02f5c9d976#diff-836f8a63886b2c63a113a107540d42a0b3a6272b016b2d45fb5bcffd99a708b4L754

it looks like it was re-implemented by https://github.com/ocaml/merlin/commit/89526e8e6ae19c07a628ca9fceb7f2f9cb98f894 with new (undocumented) vim bindings to `merlin#PhrasePrev` and `merlin#PhraseNext`