### PR TITLE
Produce a better error message when a flag spec appears multiple times

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -738,7 +738,8 @@ let () =
     args, (upd a b)
   in
   let add prj upd (name,flag,_doc) =
-    assert (not (Hashtbl.mem arguments_table name));
+    if Hashtbl.mem arguments_table name then
+      failwith ("Duplicate flag spec: " ^ name);
     Hashtbl.add arguments_table name (lens prj upd flag)
   in
   List.iter


### PR DESCRIPTION
As title: just a small change to make a better error message for devs that want to see the name of an incorrectly-duplicated flag spec.