### PR TITLE
Inlay hint upstreaming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ unreleased
     - Add `-unboxed-types` and `-no-unboxed-types` as ocaml ignored flags (#1795, fixes #1794)
     - destruct: Refinement in the presence of optional arguments (#1800 #1807, fixes #1770)
     - Implement new expand-node command for expanding PPX annotations (#1745)
+    - Implement new inlay-hints command for adding hints on a sourcetree (#1812)
   + editor modes
     - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
     - vim: Dead code / doc removal for previously deleted MerlinPhrase command (#1804)

--- a/src/analysis/inlay_hints.ml
+++ b/src/analysis/inlay_hints.ml
@@ -135,18 +135,11 @@ let structure_iterator
   in iterator.structure iterator typedtree
 
 type hint = Lexing.position * string
-
-let outline_type env typ =
-  let is_word_char = function
-    | ' ' | '\t' | '\n' -> false
-    | _ -> true
-  in
-  Ocaml_typing.Printtyp.wrap_printing_env env (fun () ->
-      Format.asprintf "@[<h>: %a@]" Ocaml_typing.Printtyp.type_scheme typ
-    ) |> String.extract_words ~is_word_char |> String.concat ~sep:" "
     
 let create_hint env typ loc =
-  let label = outline_type env typ in
+  let label =  Printtyp.wrap_printing_env env (fun () ->
+    Format.asprintf "%a" Printtyp.type_scheme typ)
+  in
   let position = loc.Location.loc_end in
   (position, label)
 

--- a/src/analysis/inlay_hints.ml
+++ b/src/analysis/inlay_hints.ml
@@ -4,11 +4,6 @@ let {Logger.log} = Logger.for_section "inlay-hints"
 
 module Iterator = Ocaml_typing.Tast_iterator
 
-let overlap_with_loc (start, stop) loc =
-  let a = Lexing.compare_pos start loc.Location.loc_end
-  and b = Lexing.compare_pos stop loc.Location.loc_start in
-  a <= 0 && b >= 0 || a >= 0 && b <= 0
-
 let is_ghost_location avoid_ghost loc =
   loc.Location.loc_ghost && avoid_ghost
 
@@ -20,7 +15,6 @@ let pattern_has_constraint (type a) (pattern: a Typedtree.general_pattern) =
       | Typedtree.Tpat_open (_, _, _)
       | Typedtree.Tpat_unpack -> false
     ) pattern.pat_extra
-
 
 let structure_iterator
     hint_let_binding
@@ -46,7 +40,7 @@ let structure_iterator
           (Printtyped.pattern 0) vb.Typedtree.vb_pat
       )
     in
-    if overlap_with_loc range vb.Typedtree.vb_loc then
+    if Location_aux.overlap_with_range range vb.Typedtree.vb_loc then
       if hint_lhs then
         let () = log ~title:"value_binding" "overlap" in
         match vb.vb_expr.exp_desc with
@@ -61,7 +55,7 @@ let structure_iterator
           Printtyped.expression expr
         )
     in
-    if overlap_with_loc range expr.Typedtree.exp_loc then
+    if Location_aux.overlap_with_range range expr.Typedtree.exp_loc then
       let () = log ~title:"expression" "overlap" in
       match expr.exp_desc with
       | Texp_let (_, bindings, body) ->
@@ -92,7 +86,7 @@ let structure_iterator
   in
 
   let structure_item_iterator (iterator : Iterator.iterator) item =
-    if overlap_with_loc range item.Typedtree.str_loc then
+    if Location_aux.overlap_with_range range item.Typedtree.str_loc then
       let () = log ~title:"structure_item" "overlap" in
       match item.str_desc with
       | Tstr_value (_, bindings) ->
@@ -113,7 +107,7 @@ let structure_iterator
           (Printtyped.pattern 0) pattern
       )
     in
-    if overlap_with_loc range pattern.pat_loc
+    if Location_aux.overlap_with_range range pattern.pat_loc
        && not (pattern_has_constraint pattern)
     then
       let () = log ~title:"pattern" "overlap" in

--- a/src/analysis/inlay_hints.ml
+++ b/src/analysis/inlay_hints.ml
@@ -1,0 +1,190 @@
+open Std
+
+let {Logger.log} = Logger.for_section "inlay-hints"
+
+module Iterator = Ocaml_typing.Tast_iterator
+
+let overlap_with_loc (start, stop) loc =
+  let a = Lexing.compare_pos start loc.Location.loc_end
+  and b = Lexing.compare_pos stop loc.Location.loc_start in
+  a <= 0 && b >= 0 || a >= 0 && b <= 0
+
+let is_ghost_location avoid_ghost loc =
+  loc.Location.loc_ghost && avoid_ghost
+
+let pattern_has_constraint (type a) (pattern: a Typedtree.general_pattern) =
+  List.exists ~f:(fun (extra, _, _) ->
+      match extra with
+      | Typedtree.Tpat_constraint _ -> true
+      | Typedtree.Tpat_type (_, _)
+      | Typedtree.Tpat_open (_, _, _)
+      | Typedtree.Tpat_unpack -> false
+    ) pattern.pat_extra
+
+
+let structure_iterator
+    hint_let_binding
+    hint_pattern_binding
+    avoid_ghost_location
+    typedtree
+    range
+    callback =
+  
+  let case_iterator hint_lhs (iterator : Iterator.iterator) case =
+    let () = log ~title:"case" "on case" in
+    let () =
+      if hint_lhs then
+        iterator.pat iterator case.Typedtree.c_lhs
+    in
+    let () = Option.iter ~f:(iterator.expr iterator) case.c_guard in
+    iterator.expr iterator case.c_rhs
+  in
+
+  let value_binding_iterator hint_lhs (iterator : Iterator.iterator) vb =
+    let () = log ~title:"value_binding" "%a" Logger.fmt (fun fmt ->
+        Format.fprintf fmt "On value binding %a"
+          (Printtyped.pattern 0) vb.Typedtree.vb_pat
+      )
+    in
+    if overlap_with_loc range vb.Typedtree.vb_loc then
+      if hint_lhs then
+        let () = log ~title:"value_binding" "overlap" in
+        match vb.vb_expr.exp_desc with
+        | Texp_function _ -> iterator.expr iterator vb.vb_expr
+        | _ -> Iterator.default_iterator.value_binding iterator vb
+      else iterator.expr iterator vb.vb_expr
+  in
+
+  let expr_iterator (iterator : Iterator.iterator) expr =
+    let () = log ~title:"expression" "%a" Logger.fmt (fun fmt ->
+        Format.fprintf fmt "On expression %a"
+          Printtyped.expression expr
+        )
+    in
+    if overlap_with_loc range expr.Typedtree.exp_loc then
+      let () = log ~title:"expression" "overlap" in
+      match expr.exp_desc with
+      | Texp_let (_, bindings, body) ->
+        let () = log ~title:"expression" "on let" in
+        let () =
+          List.iter
+            ~f:(value_binding_iterator hint_let_binding iterator)
+            bindings
+        in iterator.expr iterator body
+      | Texp_letop { body; _ } ->
+        let () = log ~title:"expression" "on let-op" in
+        case_iterator hint_let_binding iterator body
+      | Texp_match (expr, cases, _) ->
+        let () = log ~title:"expression" "on match" in
+        let () = iterator.expr iterator expr in
+        List.iter ~f:(case_iterator hint_pattern_binding iterator) cases
+      | Texp_function (_, Tfunction_cases {cases = [
+          { c_rhs = { exp_desc = Texp_let (_, [ {vb_pat; _} ], body); _ }; _ }
+        ]; _}) ->
+        let () = log ~title:"expression" "on function" in
+        let () = iterator.pat iterator vb_pat in
+        iterator.expr iterator body
+      | _ when is_ghost_location avoid_ghost_location expr.exp_loc ->
+        (* Stop iterating when we see a ghost location to avoid
+           annotating generated code *)
+        log ~title:"ghost" "ghost-location found"
+      | _ -> Iterator.default_iterator.expr iterator expr
+  in
+
+  let structure_item_iterator (iterator : Iterator.iterator) item =
+    if overlap_with_loc range item.Typedtree.str_loc then
+      let () = log ~title:"structure_item" "overlap" in
+      match item.str_desc with
+      | Tstr_value (_, bindings) ->
+        List.iter ~f:(fun binding ->
+            expr_iterator iterator binding.Typedtree.vb_expr)
+          bindings
+      | _ when is_ghost_location avoid_ghost_location item.str_loc ->
+        (* Stop iterating when we see a ghost location to avoid
+           annotating generated code *)
+        log ~title:"ghost" "ghost-location found"
+      | _ -> Iterator.default_iterator.structure_item iterator item
+  in
+
+  let pattern_iterator
+      (type a) iterator (pattern : a Typedtree.general_pattern) =
+    let () = log ~title:"pattern" "%a" Logger.fmt (fun fmt ->
+        Format.fprintf fmt "On pattern %a"
+          (Printtyped.pattern 0) pattern
+      )
+    in
+    if overlap_with_loc range pattern.pat_loc
+       && not (pattern_has_constraint pattern)
+    then
+      let () = log ~title:"pattern" "overlap" in
+      let () = Iterator.default_iterator.pat iterator pattern in
+      match pattern.pat_desc with
+      | Tpat_var _ when not pattern.pat_loc.loc_ghost ->
+        let () = log ~title:"pattern" "found" in
+        callback pattern.pat_env pattern.pat_type pattern.pat_loc
+      | _ -> log ~title:"pattern" "not a var"
+  in
+    
+  let iterator = {
+    Ocaml_typing.Tast_iterator.default_iterator with
+    expr = expr_iterator;
+    structure_item = structure_item_iterator;
+    pat = pattern_iterator;
+    value_binding = value_binding_iterator true
+  }
+  in iterator.structure iterator typedtree
+
+type hint = Lexing.position * string
+
+let outline_type env typ =
+  let is_word_char = function
+    | ' ' | '\t' | '\n' -> false
+    | _ -> true
+  in
+  Ocaml_typing.Printtyp.wrap_printing_env env (fun () ->
+      Format.asprintf "@[<h>: %a@]" Ocaml_typing.Printtyp.type_scheme typ
+    ) |> String.extract_words ~is_word_char |> String.concat ~sep:" "
+    
+let create_hint env typ loc =
+  let label = outline_type env typ in
+  let position = loc.Location.loc_end in
+  (position, label)
+
+let run
+    ~hint_let_binding
+    ~hint_pattern_binding
+    ~avoid_ghost_location
+    ~start
+    ~stop
+    pipeline =
+  let () = log ~title:"start" "%a" Logger.fmt (fun fmt ->
+      Format.fprintf fmt "Start on %s to %s with : let: %b, pat: %b, ghost: %b"
+        (Lexing.print_position () start)
+        (Lexing.print_position () stop)
+        hint_let_binding
+        hint_pattern_binding
+        avoid_ghost_location)
+  in
+  let typer_result = Mpipeline.typer_result pipeline in
+  match Mtyper.get_typedtree typer_result with
+  | `Interface _ -> []
+  | `Implementation structure ->
+    let range = (start, stop) in
+    let hints = ref [] in
+    let () =
+      structure_iterator
+        hint_let_binding
+        hint_pattern_binding
+        avoid_ghost_location
+        structure
+        range
+        (fun env typ loc ->
+           let () = log ~title:"hint" "Find hint %a" Logger.fmt (fun fmt ->
+             Format.fprintf fmt "%s - %a"
+               (Location_aux.print () loc)
+               (Printtyp.type_expr) typ)
+           in
+           let hint = create_hint env typ loc in
+           hints := hint :: !hints)
+    in
+    !hints

--- a/src/analysis/inlay_hints.ml
+++ b/src/analysis/inlay_hints.ml
@@ -137,13 +137,13 @@ let create_hint env typ loc =
   let position = loc.Location.loc_end in
   (position, label)
 
-let run
+let of_structure
     ~hint_let_binding
     ~hint_pattern_binding
     ~avoid_ghost_location
     ~start
     ~stop
-    pipeline =
+    structure =
   let () = log ~title:"start" "%a" Logger.fmt (fun fmt ->
       Format.fprintf fmt "Start on %s to %s with : let: %b, pat: %b, ghost: %b"
         (Lexing.print_position () start)
@@ -152,26 +152,22 @@ let run
         hint_pattern_binding
         avoid_ghost_location)
   in
-  let typer_result = Mpipeline.typer_result pipeline in
-  match Mtyper.get_typedtree typer_result with
-  | `Interface _ -> []
-  | `Implementation structure ->
-    let range = (start, stop) in
-    let hints = ref [] in
-    let () =
-      structure_iterator
-        hint_let_binding
-        hint_pattern_binding
-        avoid_ghost_location
-        structure
-        range
-        (fun env typ loc ->
-           let () = log ~title:"hint" "Find hint %a" Logger.fmt (fun fmt ->
-             Format.fprintf fmt "%s - %a"
-               (Location_aux.print () loc)
-               (Printtyp.type_expr) typ)
-           in
-           let hint = create_hint env typ loc in
-           hints := hint :: !hints)
-    in
-    !hints
+  let range = (start, stop) in
+  let hints = ref [] in
+  let () =
+    structure_iterator
+      hint_let_binding
+      hint_pattern_binding
+      avoid_ghost_location
+      structure
+      range
+      (fun env typ loc ->
+          let () = log ~title:"hint" "Find hint %a" Logger.fmt (fun fmt ->
+            Format.fprintf fmt "%s - %a"
+              (Location_aux.print () loc)
+              (Printtyp.type_expr) typ)
+          in
+          let hint = create_hint env typ loc in
+          hints := hint :: !hints)
+  in
+  !hints

--- a/src/analysis/inlay_hints.mli
+++ b/src/analysis/inlay_hints.mli
@@ -2,11 +2,11 @@
 
 type hint = Lexing.position * string
 
-val run :
+val of_structure :
   hint_let_binding:bool
   -> hint_pattern_binding:bool
   -> avoid_ghost_location:bool
   -> start:Lexing.position
   -> stop:Lexing.position
-  -> Mpipeline.t
+  -> Typedtree.structure
   -> hint list

--- a/src/analysis/inlay_hints.mli
+++ b/src/analysis/inlay_hints.mli
@@ -1,0 +1,12 @@
+(** Builds the list of inlay hints to be displayed on a document. *)
+
+type hint = Lexing.position * string
+
+val run :
+  hint_let_binding:bool
+  -> hint_pattern_binding:bool
+  -> avoid_ghost_location:bool
+  -> start:Lexing.position
+  -> stop:Lexing.position
+  -> Mpipeline.t
+  -> hint list

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -154,6 +154,14 @@ let dump (type a) : a t -> json =
       );
       "depth", `Int depth
     ]
+  | Inlay_hints (start, stop, hint_let_binding, hint_pattern_var, ghost) ->
+    mk "inlay-hints" [
+      "start", mk_position start;
+      "stop", mk_position stop;
+      "hint-let-binding", `Bool hint_let_binding;
+      "hint-pattern-variable", `Bool hint_pattern_var;
+      "avoid-ghost-location", `Bool ghost
+    ]
   | Outline -> mk "outline" []
   | Errors { lexing; parsing; typing } ->
     let args =
@@ -351,6 +359,14 @@ let json_of_locate resp =
   | `Found (Some file,pos) ->
     `Assoc ["file",`String file; "pos", Lexing.json_of_position pos]
 
+let json_of_inlay_hints hints =
+  let json_of_hint (position, label) =
+     `Assoc [
+       "pos", Lexing.json_of_position position;
+       "label", `String label
+     ]
+  in `List (List.map ~f:json_of_hint hints)
+
 let json_of_response (type a) (query : a t) (response : a) : json =
   match query, response with
   | Type_expr _, str -> `String str
@@ -441,6 +457,8 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     `List (json_of_outline outlines)
   | Shape _, shapes ->
     `List (List.map ~f:json_of_shape shapes)
+  | Inlay_hints _, result ->
+    json_of_inlay_hints result
   | Errors _, errors ->
     `List (List.map ~f:json_of_error errors)
   | Dump _, json -> json

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -825,6 +825,24 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     in
     locs, status
 
+  | Inlay_hints (
+      start,
+      stop,
+      hint_let_binding,
+      hint_pattern_binding,
+      avoid_ghost_location
+    ) ->
+    let start = Mpipeline.get_lexing_pos pipeline start
+    and stop = Mpipeline.get_lexing_pos pipeline stop in
+    Inlay_hints.run
+      ~hint_let_binding
+      ~hint_pattern_binding
+      ~avoid_ghost_location
+      ~start
+      ~stop
+      pipeline
+      
   | Version ->
     Printf.sprintf "The Merlin toolkit version %s, for Ocaml %s\n"
       Merlin_config.version Sys.ocaml_version;
+

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -834,14 +834,19 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     ) ->
     let start = Mpipeline.get_lexing_pos pipeline start
     and stop = Mpipeline.get_lexing_pos pipeline stop in
-    Inlay_hints.run
-      ~hint_let_binding
-      ~hint_pattern_binding
-      ~avoid_ghost_location
-      ~start
-      ~stop
-      pipeline
-      
+    let typer_result = Mpipeline.typer_result pipeline in
+    begin match Mtyper.get_typedtree typer_result with
+    | `Interface _ -> []
+    | `Implementation structure ->
+      Inlay_hints.of_structure
+        ~hint_let_binding
+        ~hint_pattern_binding
+        ~avoid_ghost_location
+        ~start
+        ~stop
+        structure
+    end
+ 
   | Version ->
     Printf.sprintf "The Merlin toolkit version %s, for Ocaml %s\n"
       Merlin_config.version Sys.ocaml_version;

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -199,6 +199,9 @@ type _ t =
   | Construct
     : Msource.position * [`None | `Local] option * int option
     -> (Location.t * string list) t
+  | Inlay_hints
+    : Msource.position * Msource.position * bool * bool * bool
+    -> (Lexing.position * string) list t
   | Outline(* *)
     :  outline t
   | Shape(* *)

--- a/src/ocaml/parsing/location_aux.ml
+++ b/src/ocaml/parsing/location_aux.ml
@@ -50,6 +50,11 @@ let included ~into:parent_loc child_loc =
 Lexing.compare_pos child_loc.loc_start parent_loc.loc_start >= 0 &&
   Lexing.compare_pos parent_loc.loc_end child_loc.loc_end >= 0
 
+let overlap_with_range (start, stop) loc =
+  let a = Lexing.compare_pos start loc.loc_end
+  and b = Lexing.compare_pos stop loc.loc_start in
+  a <= 0 && b >= 0 || a >= 0 && b <= 0
+
 let union l1 l2 =
   if l1 = Location.none then l2
   else if l2 = Location.none then l1

--- a/src/ocaml/parsing/location_aux.mli
+++ b/src/ocaml/parsing/location_aux.mli
@@ -46,6 +46,10 @@ val extend : t -> t -> t
     in [parent]. Otherwise returns [false]. *)
 val included : into:t -> t -> bool
 
+(** [overlap_with_range (pos_start, pos_end) loc] returns [true] if 
+    [loc] overlap with the range defined by [pos_start] and [pos_end]. *)
+val overlap_with_range : (Lexing.position * Lexing.position) -> t -> bool
+
 (** Filter valid errors, log invalid ones *)
 val prepare_errors : exn list -> Location.error list
 

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -520,22 +520,6 @@ module String = struct
         in
         aux 0 j0;
         Buffer.contents buffer
-
-  let extract_words ~is_word_char s =
-    let rec skip_blanks i =
-      if i = length s
-      then []
-      else if is_word_char s.[i]
-      then parse_word i (i + 1)
-      else skip_blanks (i + 1)
-    and parse_word i j =
-      if j = length s
-      then [ sub s ~pos:i ~len:(j - i) ]
-      else if is_word_char s.[j]
-      then parse_word i (j + 1)
-      else sub s ~pos:i ~len:(j - i) :: skip_blanks (j + 1)
-    in
-    skip_blanks 0
 end
 
 let sprintf = Printf.sprintf

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -398,6 +398,7 @@ module String = struct
 
   (* Drop characters from beginning of string *)
   let drop n s = sub s ~pos:n ~len:(length s - n)
+    
 
   module Set = struct
     include MoreLabels.Set.Make (struct type t = string let compare = compare end)
@@ -519,6 +520,22 @@ module String = struct
         in
         aux 0 j0;
         Buffer.contents buffer
+
+  let extract_words ~is_word_char s =
+    let rec skip_blanks i =
+      if i = length s
+      then []
+      else if is_word_char s.[i]
+      then parse_word i (i + 1)
+      else skip_blanks (i + 1)
+    and parse_word i j =
+      if j = length s
+      then [ sub s ~pos:i ~len:(j - i) ]
+      else if is_word_char s.[j]
+      then parse_word i (j + 1)
+      else sub s ~pos:i ~len:(j - i) :: skip_blanks (j + 1)
+    in
+    skip_blanks 0
 end
 
 let sprintf = Printf.sprintf

--- a/tests/test-dirs/inlay-hint/samples.t
+++ b/tests/test-dirs/inlay-hint/samples.t
@@ -12,7 +12,7 @@ Optional argument
           "line": 1,
           "col": 8
         },
-        "label": ": 'a option"
+        "label": "'a option"
       }
     ],
     "notifications": []
@@ -32,7 +32,7 @@ Optional argument with value
           "line": 1,
           "col": 9
         },
-        "label": ": int"
+        "label": "int"
       }
     ],
     "notifications": []
@@ -52,7 +52,7 @@ Labeled argument
           "line": 1,
           "col": 8
         },
-        "label": ": int"
+        "label": "int"
       }
     ],
     "notifications": []
@@ -72,7 +72,7 @@ Case argument
           "line": 1,
           "col": 13
         },
-        "label": ": int"
+        "label": "int"
       }
     ],
     "notifications": []
@@ -95,7 +95,7 @@ Pattern variables without pattern-binding hint
           "line": 1,
           "col": 7
         },
-        "label": ": int option"
+        "label": "int option"
       }
     ],
     "notifications": []
@@ -119,14 +119,14 @@ Pattern variables with pattern-binding hint
           "line": 3,
           "col": 10
         },
-        "label": ": int"
+        "label": "int"
       },
       {
         "pos": {
           "line": 1,
           "col": 7
         },
-        "label": ": int option"
+        "label": "int option"
       }
     ],
     "notifications": []
@@ -162,7 +162,7 @@ Let bindings with let hinting
           "line": 1,
           "col": 16
         },
-        "label": ": int"
+        "label": "int"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/inlay-hint/samples.t
+++ b/tests/test-dirs/inlay-hint/samples.t
@@ -1,0 +1,169 @@
+Optional argument
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  > -filename inlay.ml <<EOF
+  > let f ?x () = x ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 8
+        },
+        "label": ": 'a option"
+      }
+    ],
+    "notifications": []
+  }
+
+Optional argument with value
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  > -filename inlay.ml <<EOF
+  > let f ?(x = 1) () = x
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 9
+        },
+        "label": ": int"
+      }
+    ],
+    "notifications": []
+  }
+
+Labeled argument
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  > -filename inlay.ml <<EOF
+  > let f ~x = x + 1
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 8
+        },
+        "label": ": int"
+      }
+    ],
+    "notifications": []
+  }
+
+Case argument
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  > -filename inlay.ml <<EOF
+  > let f (Some x) = x + 1
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 13
+        },
+        "label": ": int"
+      }
+    ],
+    "notifications": []
+  }
+
+Pattern variables without pattern-binding hint
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  > -filename inlay.ml <<EOF
+  > let f x =
+  >   match x with
+  >   | Some x -> x
+  >   | None -> 0
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 7
+        },
+        "label": ": int option"
+      }
+    ],
+    "notifications": []
+  }
+
+Pattern variables with pattern-binding hint
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  > -pattern-binding true \
+  > -filename inlay.ml <<EOF
+  > let f x =
+  >   match x with
+  >   | Some x -> x
+  >   | None -> 0
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 3,
+          "col": 10
+        },
+        "label": ": int"
+      },
+      {
+        "pos": {
+          "line": 1,
+          "col": 7
+        },
+        "label": ": int option"
+      }
+    ],
+    "notifications": []
+  }
+
+
+Let bindings without let hinting
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  > -let-binding false \
+  > -filename inlay.ml <<EOF
+  > let f () = let y = 0 in y
+  > EOF
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }
+
+
+Let bindings with let hinting
+
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  > -let-binding true \
+  > -filename inlay.ml <<EOF
+  > let f () = let y = 0 in y
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "pos": {
+          "line": 1,
+          "col": 16
+        },
+        "label": ": int"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/inlay-hint/spec.t
+++ b/tests/test-dirs/inlay-hint/spec.t
@@ -1,0 +1,26 @@
+Start and end should be mandatory
+
+  $ $MERLIN single inlay-hints
+  {
+    "class": "failure",
+    "value": "-start <pos> and -end are mandatory",
+    "notifications": []
+  }
+
+Start should be mandatory
+
+  $ $MERLIN single inlay-hints -end 1
+  {
+    "class": "failure",
+    "value": "-start <pos> is mandatory",
+    "notifications": []
+  }
+
+Stop should be mandatory
+
+  $ $MERLIN single inlay-hints -start 1
+  {
+    "class": "failure",
+    "value": "-end <pos> is mandatory",
+    "notifications": []
+  }


### PR DESCRIPTION
Currently, the command returns a list of `postion * label` and the label is _computed_ in the sense of `lsp` : `: type_expr` but I guess we can just return the type without any formatting and let's the LSP server prefixing it? WDYT @voodoos?