### PR TITLE
Some UI improvement for `emacs/merlin-search`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ unreleased
   + editor modes
     - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
     - vim: Dead code / doc removal for previously deleted MerlinPhrase command (#1804)
+    - emacs: Improve the way that result of polarity search is displayed (#1814)
 
 merlin 5.1
 ==========

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -137,6 +137,10 @@ a call to `merlin-occurrences'."
 See `merlin-debug'."
   :group 'merlin :type 'string)
 
+(defcustom merlin-polarity-search-buffer-name "*merlin-polarity-search-result*"
+  "The name of the buffer displaying result of polarity search."
+  :group 'merlin :type 'string)
+
 (defcustom merlin-favourite-caml-mode nil
   "The OCaml mode to use for the *merlin-types* buffer."
   :group 'merlin :type 'symbol)
@@ -1099,17 +1103,44 @@ An ocaml atom is any string containing [a-z_0-9A-Z`.]."
                "-query" query
                "-position" (merlin-unmake-point (point))))
 
+(defun merlin--get-polarity-buff ()
+  (get-buffer-create merlin-polarity-search-buffer-name))
+
+
 (defun merlin-search (query)
   (interactive "sSearch pattern: ")
   (let* ((result (merlin--search query))
          (entries (cdr (assoc 'entries result)))
-         (transform
-          (lambda (entry)
-            (let ((text (merlin-completion-entry-text "" entry))
-                  (desc (merlin-completion-entry-short-description entry)))
-              (vector (concat text " : " desc)
-                      `(lambda () (insert ,text)))))))
-    (popup-menu (easy-menu-create-menu "Results" (mapcar transform entries)))))
+         (previous-buff (current-buffer)))
+    (let ((pol-buff (merlin--get-polarity-buff))
+          (to-entry
+           (lambda (entry)
+             (let ((text (merlin-completion-entry-text "" entry))
+                   (type (merlin-completion-entry-short-description entry)))
+               (list
+                text
+                (vector
+                 (concat
+                  (propertize "val " 'face (intern "font-lock-keyword-face"))
+                  (propertize
+                   (string-remove-prefix "Stdlib__" text)
+                   'face (intern "font-lock-function-name-face"))
+                  " : "
+                  (propertize type 'face (intern "font-lock-doc-face"))))))))
+          (inhibit-read-only t))
+      (with-current-buffer pol-buff
+        (switch-to-buffer-other-window pol-buff)
+        (goto-char 1)
+        (tabulated-list-mode)
+        (setq tabulated-list-format [("functions" 100 t)])
+        (setq tabulated-list-entries (mapcar to-entry entries))
+        (setq tabulated-list-padding 2)
+
+        (face-spec-set 'header-line '((t :weight bold :height 1.2)))
+        (tabulated-list-init-header)
+        (tabulated-list-print t)
+        (setq buffer-read-only t)
+        (switch-to-buffer-other-window previous-buff)))))
 
 ;;;;;;;;;;;;;;;;;
 ;; TYPE BUFFER ;;

--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1131,7 +1131,7 @@ An ocaml atom is any string containing [a-z_0-9A-Z`.]."
         (switch-to-buffer-other-window pol-buff)
         (goto-char 1)
         (tabulated-list-mode)
-        (setq tabulated-list-format [("functions" 100 t)])
+        (setq tabulated-list-format [("Polarity Search Result" 100 t)])
         (setq tabulated-list-entries (mapcar 'merlin--polarity-result-to-list entries))
         (setq tabulated-list-padding 2)
         (face-spec-set 'header-line '((t :weight bold :height 1.2)))


### PR DESCRIPTION
Since polarity research output a result in a popup that take the focus, the user experience was a little bit complicated. So the patch returns the result inside a dedicated buffer:

![image](https://github.com/user-attachments/assets/96dce000-7fde-48d4-901d-5a8ec206d278)

(I was not able to take a screenshot about the "before", because the popup was taking the focus...)