### PR TITLE
Add `-H` flag to `ocaml-index`

### DIFF
--- a/src/ocaml-index/bin/dune
+++ b/src/ocaml-index/bin/dune
@@ -2,8 +2,9 @@
  (name ocaml_index)
  (public_name ocaml-index)
  (package ocaml-index)
- (libraries lib ocaml_typing merlin_index_format)
+ (libraries lib ocaml_typing ocaml_utils merlin_index_format)
  (flags
   :standard
   -open Ocaml_typing
+  -open Ocaml_utils
   -open Merlin_index_format))

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -8,7 +8,7 @@ let usage_msg =
 let verbose = ref false
 let debug = ref false
 let input_files = ref []
-let build_path = ref []
+let build_path_rev = ref ({ visible = []; hidden = [] } : Load_path.paths)
 let output_file = ref "project.ocaml-index"
 let root = ref ""
 let rewrite_root = ref false
@@ -50,8 +50,15 @@ let speclist =
       Arg.Set store_shapes,
       "Aggregate input-indexes shapes and store them in the new index" );
     ( "-I",
-      Arg.String (fun arg -> build_path := arg :: !build_path),
+      Arg.String (fun arg ->
+        build_path_rev := { !build_path_rev with
+                            visible = arg :: !build_path_rev.visible }),
       "An extra directory to add to the load path" );
+    ( "-H",
+      Arg.String (fun arg ->
+        build_path_rev := { !build_path_rev with
+                            hidden = arg :: !build_path_rev.hidden }),
+      "An extra hidden directory to add to the load path" );
     ( "--no-cmt-load-path",
       Arg.Set do_not_use_cmt_loadpath,
       "Do not initialize the load path with the paths found in the first input \
@@ -71,7 +78,8 @@ let () =
       let root = if String.equal "" !root then None else Some !root in
       Index.from_files ~store_shapes:!store_shapes ~root
         ~rewrite_root:!rewrite_root ~output_file:!output_file
-        ~build_path:!build_path
+        ~build_path:{ visible = List.rev !build_path_rev.visible;
+                      hidden = List.rev !build_path_rev.hidden }
         ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files
   | Some Dump ->
       List.iter

--- a/src/ocaml-index/lib/index.ml
+++ b/src/ocaml-index/lib/index.ml
@@ -61,14 +61,15 @@ end
 
 let init_load_path_once ~do_not_use_cmt_loadpath =
   let loaded = ref false in
-  fun ~dirs cmt_loadpath ->
+  fun ~(dirs : Load_path.paths) cmt_loadpath ->
     if not !loaded then (
       let cmt_visible, cmt_hidden =
         if do_not_use_cmt_loadpath then ([], [])
         else (cmt_loadpath.Load_path.visible, cmt_loadpath.Load_path.hidden)
       in
-      let visible = List.concat [ cmt_visible; dirs ] in
-      Load_path.(init ~auto_include:no_auto_include ~visible ~hidden:cmt_hidden);
+      let visible = List.concat [ cmt_visible; dirs.visible ] in
+      let hidden = List.concat [ cmt_hidden; dirs.hidden ] in
+      Load_path.(init ~auto_include:no_auto_include ~visible ~hidden);
       loaded := true)
 
 let index_of_cmt ~root ~rewrite_root ~build_path ~do_not_use_cmt_loadpath

--- a/src/ocaml-index/tests/tests-dirs/cmd.t
+++ b/src/ocaml-index/tests/tests-dirs/cmd.t
@@ -11,6 +11,7 @@
     --rewrite-root Rewrite locations paths using the provided root
     --store-shapes Aggregate input-indexes shapes and store them in the new index
     -I An extra directory to add to the load path
+    -H An extra hidden directory to add to the load path
     --no-cmt-load-path Do not initialize the load path with the paths found in the first input cmt file
     -help  Display this list of options
     --help  Display this list of options

--- a/src/ocaml-index/tests/tests-dirs/transitive-deps.t
+++ b/src/ocaml-index/tests/tests-dirs/transitive-deps.t
@@ -16,7 +16,7 @@
   $ ocamlc -bin-annot -bin-annot-occurrences -c lib1/foo.ml -I lib2
 
 # Here we have an implicit transitive dependency on lib2:
-  $ ocamlc -bin-annot -bin-annot-occurrences -c main.ml -I lib1 -I /Users/ulysse/tmp/occurrences/_opam/lib/fpath
+  $ ocamlc -bin-annot -bin-annot-occurrences -c main.ml -I lib1
 
 # We pass explicitely the implicit transitive dependency over lib2:
   $ ocaml-index aggregate -o main.uideps main.cmt -I lib2


### PR DESCRIPTION
This is a change we made in [merlin-jst](https://github.com/janestreet/merlin-jst/pull/88). Currently, ocaml-index takes a `-I` flag that enables adding paths to the load path to find cmt files to use for reducing shapes. This PR adds a `-H` flag that does the same thing, except it adds paths to the hidden load path.

When working with cms files (which merlin-jst does), the load paths must always be specified because cms files do not include the load path in them. This is not-so-useful when working with cmt files, which do include the loadpath, and so ocaml-index doesn't need to be explicitly passed the load path. However, this still seems like a nice feature to have incase it becomes important in the future.