### PR TITLE
Add missing `(require 'ert)` for `ert-deftest`

### DIFF
--- a/emacs/merlin-cap.el
+++ b/emacs/merlin-cap.el
@@ -15,6 +15,7 @@
 
 ;;; Code:
 
+(require 'ert)
 (require 'merlin)
 (require 'subr-x)
 


### PR DESCRIPTION
Although the `ert-deftest` macro is autoloaded, the `ert-set-test` function used in its expansion is not, leading to `Lisp error: (void-function ert-set-test)` when using byte-compiled configs.

```
Debugger entered--Lisp error: (void-function ert-set-test)
  ert-set-test(test-merlin-cap--bounds #s(ert-test test-merlin-cap--bounds nil #[0 "\301C\3021\23\0\303\30\304\305\306\")\307D0\202\36\0\1\310\240\210\211@\1AD\262\1\311C\312C\313\314\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204<\0\316\1\242!\210\266\4\301C\3171Q\0\303\30\304\320\321\")\322D0\202\\\0\1\310\240\210\211@\1AD\262\1\323C\312C\313\324\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204z\0\316\1\242!\210\266\4\301C\3251\217\0\303\30\304\326\327\")\330D0\202\232\0\1\310\240\210\211@\1AD\262\1\331C\312C\313\332\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\270\0\316\1\242!\210\266\4\301C\3331\315\0\303\30\304\320\334\")\335D0\202\330\0\1\310\240\210\211@\1AD\262\1\336C\312C\313\337\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\366\0\316\1\242!\210\266\4\301C\3401\13\1\303\30\304\341\342\")\343D0\202\26\1\1\310\240\210\211@\1AD\262\1\344C\312C\313\345\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\2044\1\316\1\242!\210\266\4\301C\3461I\1\303\30\304\320\347\")\350D0\202T\1\1\310\240\210\211@\1AD\262\1\351C\312C\313\352\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204r\1\316\1\242!\210\266\4\301C\3531\207\1\303\30\304\327\326\")\354D0\202\222\1\1\310\240\210\211@\1AD\262\1\355C\312C\313\356\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\260\1\316\1\242!\210\266\4\301C\3571\305\1\303\30\304\326\360\")\361D0\202\320\1\1\310\240\210\211@\1AD\262\1\362C\312C\313\363\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\356\1\316\1\242!\210\266\4\301C\3641\3\2\303\30\304\326\365\")\366D0\202\16\2\1\310\240\210\211@\1AD\262\1\367C\312C\313\370\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204,\2\316\1\242!\210\266\4\301C\3711A\2\303\30\304\372\373\")\374D0\202L\2\1\310\240\210\211@\1AD\262\1\375C\312C\313\376\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204j\2\316\1\242!\210\266\4\301C\3771\203\2\303\30\304\201@\0\326\")\201A\0D0\202\216\2\1\310\240\210\211@\1AD\262\1\201B\0C\312C\313\201C\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\260\2\316\1\242!\210\266\4\301C\201D\0001\315\2\303\30\304\201E\0\201F\0\")\201G\0D0\202\330\2\1\310\240\210\211@\1AD\262\1\201H\0C\312C\313\201I\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\372\2\316\1\242!\210\266\4\301C\201J\0001\27\3\303\30\304\201K\0\201L\0\")\201M\0D0\202\"\3\1\310\240\210\211@\1AD\262\1\201N\0C\312C\313\201O\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204D\3\316\1\242!\210\266\4\301C\201P\0001a\3\303\30\304\201Q\0\201L\0\")\201R\0D0\202l\3\1\310\240\210\211@\1AD\262\1\201S\0C\312C\313\201T\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\216\3\316\1\242!\210\266\4\301C\201U\0001\253\3\303\30\304\201V\0\201L\0\")\201W\0D0\202\266\3\1\310\240\210\211@\1AD\262\1\201X\0C\312C\313\201Y\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\330\3\316\1\242!\210\266\4\301C\201Z\0001\365\3\303\30\304\201[\0\201\\\0\")\201]\0D0\202\0\4\1\310\240\210\211@\1AD\262\1\201^\0C\312C\313\201_\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\"\4\316\1\242!\210\266\4\301C\201`\0001?\4\303\30\304\201a\0\201\\\0\")\201b\0D0\202J\4\1\310\240\210\211@\1AD\262\1\201c\0C\312C\313\201d\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204l\4\316\1\242!\210\266\4\301C\201e\0001\211\4\303\30\304\201f\0\201\\\0\")\201g\0D0\202\224\4\1\310\240\210\211@\1AD\262\1\201h\0C\312C\313\201i\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\266\4\316\1\242!\210\266\4\301C\201j\0001\323\4\303\30\304\201k\0\201\\\0\")\201l\0D0\202\336\4\1\310\240\210\211@\1AD\262\1\201m\0C\312C\313\201n\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\0\5\316\1\242!\210\266\4\301C\201o\0001\33\5\303\30\304\201p\0\326\")\201q\0D0\202&\5\1\310\240\210\211@\1AD\262\1\201r\0C\312C\313\201s\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204H\5\316\1\242!\210\266\4\301C\201t\0001c\5\303\30\304\201u\0\326\")\201v\0D0\202n\5\1\310\240\210\211@\1AD\262\1\201w\0C\312C\313\201x\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\220\5\316\1\242!\210\266\4\301C\201y\0001\253\5\303\30\304\201z\0\326\")\201{\0D0\202\266\5\1\310\240\210\211@\1AD\262\1\201|\0C\312C\313\201}\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204\330\5\316\1\242!\210\266\4\301C\201~\0001\363\5\303\30\304\201\177\0\326\")\201\200\0D0\202\376\5\1\310\240\210\211@\1AD\262\1\201\201\0C\312C\313\201\202\0\2\4\6\6\6\10%\216\1\315\5\242\5\"\240)\204 \6\316\1\242!\210\210\211\242\207" [signal-hook-function equal ... ert--should-signal-hook merlin-cap--regions "Aaa.bbb.c" "cc.ddd" ... signal ert-form-evaluation-aborted-212 nil make-closure #[0 "\300\304C\305\303\242\302BD\244\301\242\306=?\205\26\0\307\301\242D\244\301\242\306=?\205.\0\310\311!\211\205,\0\312\313\2\302\"D\262\1\244\240\210\314\300\242!\207" [V0 V1 V2 V3 ... :form ert-form-evaluation-aborted-212 :value ert--get-explainer equal :explanation apply ert--signal-should-execution] 7] apply ert-fail ... "~fo" "o.bar" ... ert-form-evaluation-aborted-217 ...] 10] nil :passed nil "/nix/store/b4n6h95vay4xnn79rk4ld5rm122ia6xm-emacs-merlin-20240911.1448/share/emacs/site-lisp/elpa/merlin-20240911.1448/merlin-cap.el"))
  byte-code("\300\301\302\303\301\304\305\304\306\304\307&\10\"\207" [ert-set-test test-merlin-cap--bounds record ert-test nil #f(compiled-function () #<bytecode 0x1a772f8fc6c123e0>) :passed "/nix/store/b4n6h95vay4xnn79rk4ld5rm122ia6xm-emacs-..."] 11)
  require(merlin-cap)
  byte-code("\301\302N\204\f\0\303\301\302\304#\210\303\301\305\306#\210\303\301\307\310C#\210\311\312\313\10\310\211%\210\314\315!\210\316\317!\210\316\320!\207" [merlin-mode-map merlin-mode-hook variable-documentation put "Hook run after entering or leaving `merlin-mode'.\n..." custom-type hook standard-value nil add-minor-mode merlin-mode (:eval (merlin-lighter)) provide merlin require merlin-cap merlin-xref] 6)
  require(merlin)
```