### PR TITLE
Re-enable Github actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master; 500 ]
+    branches: [ main ]
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -16,7 +16,7 @@ on:
       - 'vim/**'
       - '**/emacs-lint.yml'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -38,7 +38,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          # - windows-latest
+          - windows-latest
         ocaml-compiler:
           - 5.2.x
     # The type of runner that the job will run on

--- a/tests/test-dirs/config/dot-merlin-reader/dune
+++ b/tests/test-dirs/config/dot-merlin-reader/dune
@@ -1,4 +1,4 @@
 (cram
- (applies_to erroneous-config quoting)
+ (applies_to erroneous-config quoting load-config)
  (enabled_if
   (<> %{os_type} Win32)))

--- a/tests/test-dirs/config/dune
+++ b/tests/test-dirs/config/dune
@@ -1,5 +1,5 @@
 (cram
- (applies_to path-expansion)
+ (applies_to path-expansion hidden-deps)
  (enabled_if
   (<> %{os_type} Win32)))
 

--- a/tests/test-dirs/hidden-deps/dune
+++ b/tests/test-dirs/hidden-deps/dune
@@ -1,0 +1,4 @@
+(cram
+ (applies_to hd-directives)
+ (enabled_if
+  (<> %{os_type} Win32)))

--- a/tests/test-dirs/locate/dune
+++ b/tests/test-dirs/locate/dune
@@ -1,7 +1,8 @@
 (cram
  (applies_to looping-substitution mutually-recursive partial-cmt includes
    issue802 issue845 issue1199 issue1524 sig-substs l-413-features
-   module-aliases locate-constrs without-implem without-sig module-decl-aliases)
+   module-aliases locate-constrs without-implem without-sig module-decl-aliases
+   in-implicit-trans-dep)
  (enabled_if
   (<> %{os_type} Win32)))
 

--- a/tests/test-dirs/occurrences/project-wide/dune
+++ b/tests/test-dirs/occurrences/project-wide/dune
@@ -7,6 +7,12 @@
  (applies_to pwo-ml-gen)
  (enabled_if (>= %{read:version/dune.txt} "3.16")))
 
+(cram
+ (applies_to :whole_subtree)
+ (enabled_if
+  (<> %{os_type} Win32)))
+
 (subdir
  version
  (rule (action (with-stdout-to dune.txt (run dune --version)))))
+

--- a/tests/test-dirs/server-tests/dune
+++ b/tests/test-dirs/server-tests/dune
@@ -5,10 +5,13 @@
  (locks merlin_server))
 
 (cram
- (applies_to chdir_to_root)
+ (applies_to chdir_to_root incremental-index)
  (enabled_if
   (<> %{os_type} Win32)))
 
 (cram
- (applies_to pwo-uid-stability)
- (enabled_if %{bin-available:ocaml-index}))
+ (applies_to pwo-uid-stability )
+ (enabled_if
+ (and
+  %{bin-available:ocaml-index}
+  (<> %{os_type} Win32))))


### PR DESCRIPTION
We cannot rely on OCaml-CI if we OCamlformat the codebase. This PR re-enables Github Action-based CI