### PR TITLE
Fix ignorace of `SOURCE_ROOT` directive

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -428,6 +428,9 @@ let postprocess cfg =
       )
     ; (cfg.pass_forward :> Merlin_dot_protocol.directive list)
     ; cfg.stdlib |> Option.map ~f:(fun stdlib -> `STDLIB stdlib) |> Option.to_list
+    ; cfg.source_root
+        |> Option.map ~f:(fun source_root -> `SOURCE_ROOT source_root)
+        |> Option.to_list
     ; List.concat_map pkg_paths ~f:(fun p -> [ `B p; `S p ])
     ; ppx
     ; List.map failures ~f:(fun s -> `ERROR_MSG s)

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -6,12 +6,13 @@ This test comes from: https://github.com/janestreet/merlin-jst/pull/59
   > BH build-hidden/dir
   > SH source-hidden/dir
   > STDLIB /stdlib
+  > SOURCE_ROOT /root
   > EOF
 
   $ FILE=$(pwd)/test.ml; dot-merlin-reader <<EOF | sed 's#[0-9]*:#?:#g'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir)(?:STDLIB?:/stdlib))
+  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir)(?:STDLIB?:/stdlib)(?:SOURCE_ROOT?:/root))
 
   $ echo | $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
   {
@@ -43,7 +44,7 @@ This test comes from: https://github.com/janestreet/merlin-jst/pull/59
       }
     ],
     "stdlib": "/stdlib",
-    "source_root": null,
+    "source_root": "/root",
     "unit_name": null,
     "wrapping_prefix": null,
     "reader": [],


### PR DESCRIPTION
At the moment, the `SOURCE_ROOT` directive is not properly read from `.merlin` files. This PR fixes the issue by ensuring the `dot_merlin_reader.ml` passes on the directive.