### PR TITLE
Canonicalize paths when finding occurrences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ unreleased
     - Implement new expand-node command for expanding PPX annotations (#1745)
     - Implement new inlay-hints command for adding hints on a sourcetree (#1812)
     - Implement new search-by-type command for searching values by types (#1828)
+    - Canonicalize paths in occurrences. This helps deduplicate the results and
+      show more user-friendly paths. (#1840)
   + editor modes
     - vim: fix python-3.12 syntax warnings in merlin.py (#1798)
     - vim: Dead code / doc removal for previously deleted MerlinPhrase command (#1804)

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -208,6 +208,8 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
                           (Filename.concat root file, current_buffer_path)
                         | None -> (file, config.query.filename)
                       in
+                      let file = Misc.canonicalize_filename file in
+                      let buf = Misc.canonicalize_filename buf in
                       if String.equal file buf then false
                       else begin
                         (* We ignore external results if their source was modified *)
@@ -228,6 +230,22 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
         external_locs
     in
     let locs = Lid_set.union buffer_locs external_locs in
+    (* Some of the paths may have redundant `.`s or `..`s in them. Although canonicalizing
+       is not necessary for correctness, it makes the output a bit nicer. *)
+    let canonicalize_file_in_loc ({ txt; loc } : 'a Location.loc) :
+        'a Location.loc =
+      let canonicalize_pos (pos : Lexing.position) =
+        { pos with pos_fname = Misc.canonicalize_filename pos.pos_fname }
+      in
+      let loc : Location.t =
+        { loc_start = canonicalize_pos loc.loc_start;
+          loc_end = canonicalize_pos loc.loc_end;
+          loc_ghost = loc.loc_ghost
+        }
+      in
+      { txt; loc }
+    in
+    let locs = Lid_set.map canonicalize_file_in_loc locs in
     let locs =
       log ~title:"occurrences" "Found %i locs" (Lid_set.cardinal locs);
       Lid_set.elements locs

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -234,16 +234,8 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
        is not necessary for correctness, it makes the output a bit nicer. *)
     let canonicalize_file_in_loc ({ txt; loc } : 'a Location.loc) :
         'a Location.loc =
-      let canonicalize_pos (pos : Lexing.position) =
-        { pos with pos_fname = Misc.canonicalize_filename pos.pos_fname }
-      in
-      let loc : Location.t =
-        { loc_start = canonicalize_pos loc.loc_start;
-          loc_end = canonicalize_pos loc.loc_end;
-          loc_ghost = loc.loc_ghost
-        }
-      in
-      { txt; loc }
+      let file = Misc.canonicalize_filename loc.loc_start.pos_fname in
+      { txt; loc = set_fname ~file loc }
     in
     let locs = Lid_set.map canonicalize_file_in_loc locs in
     let locs =

--- a/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
@@ -1,0 +1,68 @@
+  $ cat > lib.ml << EOF
+  > let foo = "bar"
+  > let () = print_string foo
+  > EOF
+
+  $ cat > main.ml << EOF
+  > let () = print_string Lib.foo
+  > EOF
+
+  $ cat > .merlin << EOF
+  > INDEX project.ocaml-index
+  > SOURCE_ROOT .
+  > EOF
+
+  $ ocamlc -bin-annot -bin-annot-occurrences -c lib.ml main.ml
+  $ ocaml-index aggregate main.cmt lib.cmt --root . --rewrite-root
+
+TODO: definition is duplicated
+TODO: result paths have a . in them
+
+  $ ocamlmerlin single occurrences -scope project -identifier-at 1:4 \
+  > -filename lib.ml < lib.ml | jq .value
+  [
+    {
+      "file": "$TESTCASE_ROOT/lib.ml",
+      "start": {
+        "line": 1,
+        "col": 4
+      },
+      "end": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    {
+      "file": "$TESTCASE_ROOT/./lib.ml",
+      "start": {
+        "line": 1,
+        "col": 4
+      },
+      "end": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    {
+      "file": "$TESTCASE_ROOT/./lib.ml",
+      "start": {
+        "line": 2,
+        "col": 22
+      },
+      "end": {
+        "line": 2,
+        "col": 25
+      }
+    },
+    {
+      "file": "$TESTCASE_ROOT/./main.ml",
+      "start": {
+        "line": 1,
+        "col": 26
+      },
+      "end": {
+        "line": 1,
+        "col": 29
+      }
+    }
+  ]

--- a/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
@@ -15,9 +15,6 @@
   $ ocamlc -bin-annot -bin-annot-occurrences -c lib.ml main.ml
   $ ocaml-index aggregate main.cmt lib.cmt --root . --rewrite-root
 
-TODO: definition is duplicated
-TODO: result paths have a . in them
-
   $ ocamlmerlin single occurrences -scope project -identifier-at 1:4 \
   > -filename lib.ml < lib.ml | jq .value
   [
@@ -33,18 +30,7 @@ TODO: result paths have a . in them
       }
     },
     {
-      "file": "$TESTCASE_ROOT/./lib.ml",
-      "start": {
-        "line": 1,
-        "col": 4
-      },
-      "end": {
-        "line": 1,
-        "col": 7
-      }
-    },
-    {
-      "file": "$TESTCASE_ROOT/./lib.ml",
+      "file": "$TESTCASE_ROOT/lib.ml",
       "start": {
         "line": 2,
         "col": 22
@@ -55,7 +41,7 @@ TODO: result paths have a . in them
       }
     },
     {
-      "file": "$TESTCASE_ROOT/./main.ml",
+      "file": "$TESTCASE_ROOT/main.ml",
       "start": {
         "line": 1,
         "col": 26


### PR DESCRIPTION
This fixes a minor bug in occurrences. See the test in the first commit (5fb1560f522617ef4d80f30166dda5ae84561a90), which demonstrates the issue.