### PR TITLE
vim: Expose the search-by-type feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+unreleased
+==========
+
+  + vim plugin
+    - Added support for search-by-type (#1846)
+      This is exposed through the existing `:MerlinSearch` command, that
+      switches between search-by-type and polarity search depending on the
+      first character of the query.
+
 merlin 5.3
 ==========
 Tue Nov 26 17:30:42 CET 2024

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -301,6 +301,16 @@ function! merlin#SearchByType(debug,query)
   endif
 endfunction
 
+" Do a polarity search or a search by type depending on the first character of
+" the query.
+function! merlin#Search(debug, query)
+  if a:query =~ "^[-+]"
+    call merlin#PolaritySearch(a:debug, a:query)
+  else
+    call merlin#SearchByType(a:debug, a:query)
+  endif
+endfunction
+
 function! s:StopHighlight()
   if exists('w:enclosing_zone') && w:enclosing_zone != -1
     call matchdelete(w:enclosing_zone)
@@ -821,11 +831,10 @@ function! merlin#Register()
   command! -buffer -nargs=0 MerlinGotoDotMerlin call merlin#GotoDotMerlin()
   command! -buffer -nargs=0 MerlinEchoDotMerlin call merlin#EchoDotMerlin()
 
-  """ Polarity search
-  command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearch call merlin#PolaritySearch(0,<q-args>)
-
-  """ Search by type
+  """ Search
+  command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearchPolarity call merlin#PolaritySearch(0,<q-args>)
   command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearchType call merlin#SearchByType(0,<q-args>)
+  command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearch call merlin#Search(0,<q-args>)
 
   """ debug --------------------------------------------------------------------
   command! -buffer -nargs=0 MerlinDebugLastCommands MerlinPy merlin.vim_last_commands()

--- a/vim/merlin/autoload/merlin.vim
+++ b/vim/merlin/autoload/merlin.vim
@@ -284,13 +284,21 @@ function! merlin#PolaritySearch(debug,query)
   let s:search_result = []
   MerlinPy merlin.vim_polarity_search(vim.eval("a:query"), "s:search_result")
   if a:debug != 1 && s:search_result != []
-    call feedkeys("i=merlin#PolarityComplete()\<CR>","n")
+    call feedkeys("i=merlin#SearchComplete()\<CR>","n")
   endif
 endfunction
 
-function! merlin#PolarityComplete()
+function! merlin#SearchComplete()
   call complete(col('.'), s:search_result)
   return ''
+endfunction
+
+function! merlin#SearchByType(debug,query)
+  let s:search_result = []
+  MerlinPy merlin.vim_search_by_type(vim.eval("a:query"), "s:search_result")
+  if a:debug != 1 && s:search_result != []
+    call feedkeys("i=merlin#SearchComplete()\<CR>","n")
+  endif
 endfunction
 
 function! s:StopHighlight()
@@ -815,6 +823,9 @@ function! merlin#Register()
 
   """ Polarity search
   command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearch call merlin#PolaritySearch(0,<q-args>)
+
+  """ Search by type
+  command! -buffer -complete=customlist,merlin#ExpandTypePrefix -nargs=+ MerlinSearchType call merlin#SearchByType(0,<q-args>)
 
   """ debug --------------------------------------------------------------------
   command! -buffer -nargs=0 MerlinDebugLastCommands MerlinPy merlin.vim_last_commands()

--- a/vim/merlin/doc/merlin.txt
+++ b/vim/merlin/doc/merlin.txt
@@ -158,6 +158,44 @@ Act either as *:py* or *:py3* depending on the version of python is used
 by the vim plugin.
 This is only useful if you want to write custom merlin extensions. 
 
+:MerlinSearch                                                  *:MerlinSearch*
+
+Act either as :MerlinSearchPolarity or :MerlinSearchType depending on the first
+character of the query. If the query starts with '-' or '+', then
+:MerlinSearchPolarity is used, otherwise, :MerlinSearchType is used.
+
+>
+  :MerlinSearch -int +string
+  :MerlinSearch int -> string
+<
+
+:MerlinSearchPolarity                                  *:MerlinSearchPolarity*
+
+Search for values in the current scope that have a type matching the query.
+The results are displayed in a completion menu.
+
+The query language is simply a list of path identifiers prefixed by `+` or `-`,
+e.g. `-int`, `-int +string`, `-Hashtbl.t +int`.
+
+`-` is interpreted as "consuming" and `+` as "producing": `-int +string` looks
+for functions consuming an `int` and producing a `string`.
+
+>
+  :MerlinSearchPolarity -int +string
+<
+
+:MerlinSearchType                                          *:MerlinSearchType*
+
+Works similarly to :MerlinSearchPolarity but uses a different query language.
+The results are displayed in a completion menu.
+
+The query language is a list of type constructors separated by '->'.
+Type parameters and functions are allowed: `('a -> bool) -> 'a list -> bool`.
+
+>
+  :MerlinSearchType int -> string
+<
+
 ==============================================================================
 OPTIONS                                                       *merlin-options*
 


### PR DESCRIPTION
This adds the `:MerlinSearchType` command to query for a value with a matching type. It works like the previous `:MerlinSearch` but uses the new search feature added in https://github.com/ocaml/merlin/pull/1828, the search results are shown in the completion menu.

`:MerlinSearch` switches between polarity search and search by type depending on the first character of the query, like is done in the emacs plugin.

Documentation about the three search functions is added.
