### PR TITLE
[503] Use source information in uids to jump to the correct file and provide occurrences in both the interface and the implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
 
   + merlin binary
     - Support for OCaml 5.3
+    - Use new 5.3 features to improve locate behavior in some cases. Merlin no
+      longer confuses uids from interfaces and implementations. (#1857)
   + vim plugin
     - Added support for search-by-type (#1846)
       This is exposed through the existing `:MerlinSearch` command, that

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -507,7 +507,7 @@ let loc_of_decl ~uid def =
   | Some loc ->
     log ~title "Found location: %a" Logger.fmt (fun fmt ->
         Location.print_loc fmt loc.loc);
-    Some (uid, loc.loc)
+    Some loc
   | None ->
     log ~title "The declaration has no location.";
     None
@@ -572,7 +572,9 @@ let find_loc_of_uid ~config ~local_defs uid comp_unit =
         (fun fmt -> Shape.Uid.print fmt uid);
       begin
         match Shape.Uid.Tbl.find_opt cmt.cmt_uid_to_decl uid with
-        | Some decl -> loc_of_decl ~uid decl
+        | Some decl ->
+          loc_of_decl ~uid decl
+          |> Option.map ~f:(fun { Location.loc; _ } -> (uid, loc))
         | None ->
           log ~title "Uid not found in the cmt's table.";
           None

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -510,9 +510,15 @@ let find_loc_of_uid ~config ~local_defs uid comp_unit =
   end
   else begin
     log ~title "Loading the cmt file for unit %S" comp_unit;
+    let ml_or_mli =
+      match uid with
+      | Item { from = Intf; _ } -> `MLI
+      | _ -> config.ml_or_mli
+    in
+    let config = { config with ml_or_mli } in
     match load_cmt ~config comp_unit with
     | Ok (_pos_fname, cmt) ->
-      log ~title "Shapes successfully loaded, looking for %a" Logger.fmt
+      log ~title "Cmt successfully loaded, looking for %a" Logger.fmt
         (fun fmt -> Shape.Uid.print fmt uid);
       begin
         match Shape.Uid.Tbl.find_opt cmt.cmt_uid_to_decl uid with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -501,17 +501,6 @@ let find_source ~config loc path =
           doesn't know which is the right one: %s"
          matches)
 
-let loc_of_decl ~uid def =
-  let title = "loc_of_decl" in
-  match Typedtree_utils.location_of_declaration ~uid def with
-  | Some loc ->
-    log ~title "Found location: %a" Logger.fmt (fun fmt ->
-        Location.print_loc fmt loc.loc);
-    Some loc
-  | None ->
-    log ~title "The declaration has no location.";
-    None
-
 (** uid's location are given by tables stored int he cmt files for external
     compilation units or computed by Merlin for the current buffer.
     [find_loc_of_uid] function lookups a uid's location in the appropriate
@@ -544,7 +533,7 @@ let find_loc_of_item ~config ~local_defs uid comp_unit =
         (fun fmt -> Shape.Uid.print fmt uid);
       begin
         match Shape.Uid.Tbl.find_opt cmt.cmt_uid_to_decl uid with
-        | Some decl -> loc_of_decl ~uid decl
+        | Some decl -> Typedtree_utils.location_of_declaration ~uid decl
         | None ->
           log ~title "Uid not found in the cmt's table.";
           None

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -48,6 +48,12 @@ type result =
 val uid_of_result :
   traverse_aliases:bool -> Shape_reduce.result -> Shape.Uid.t option * bool
 
+(** [get_linked_uids] queries the [cmt_declaration_dependencies] table and
+  returns udis related to the one passed as argument. TODO right now this
+  function only returns simple links tagged with [Definition_to_declaration] *)
+val get_linked_uids :
+  config:config -> comp_unit:string -> Shape.Uid.t -> Shape.Uid.t list
+
 val find_source :
   config:Mconfig.t ->
   Warnings.loc ->

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -29,7 +29,13 @@
 val log : 'a Logger.printf
 
 type config =
-  { mconfig : Mconfig.t; ml_or_mli : [ `ML | `MLI ]; traverse_aliases : bool }
+  { mconfig : Mconfig.t;
+    ml_or_mli : [ `ML | `Smart | `MLI ];
+        (** When [ml_or_mli] is [`Smart], if locate blocks on an interface uid,
+            it will use the [cmt_declaration_dependencies] to try finding a
+            unique corresponding definition in the implementation. *)
+    traverse_aliases : bool
+  }
 
 type result =
   { uid : Shape.Uid.t;

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -48,6 +48,10 @@ type result =
 val uid_of_result :
   traverse_aliases:bool -> Shape_reduce.result -> Shape.Uid.t option * bool
 
+(** Lookup the delcaration of the given Uid in the appropriate cmt file *)
+val lookup_uid_decl :
+  config:Mconfig.t -> Shape.Uid.t -> Typedtree.item_declaration option
+
 (** [get_linked_uids] queries the [cmt_declaration_dependencies] table and
   returns udis related to the one passed as argument. TODO right now this
   function only returns simple links tagged with [Definition_to_declaration] *)

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -509,6 +509,11 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     in
     if path = "" then `Invalid_context
     else
+      let ml_or_mli =
+        match ml_or_mli with
+        | `ML -> `Smart
+        | `MLI -> `MLI
+      in
       let config =
         Locate.
           { mconfig = Mpipeline.final_config pipeline;

--- a/src/ocaml-index/lib/index.ml
+++ b/src/ocaml-index/lib/index.ml
@@ -89,10 +89,8 @@ let index_of_cmt ~root ~rewrite_root ~build_path ~do_not_use_cmt_loadpath
   init_load_path_once ~do_not_use_cmt_loadpath ~dirs:build_path cmt_loadpath;
   let module Reduce = Shape_reduce.Make (Reduce_conf) in
   let defs =
-    if Option.is_none cmt_impl_shape then Shape.Uid.Map.empty
-    else
-      gather_locs_from_fragments ~root ~rewrite_root Shape.Uid.Map.empty
-        cmt_uid_to_decl
+    gather_locs_from_fragments ~root ~rewrite_root Shape.Uid.Map.empty
+      cmt_uid_to_decl
   in
   (* The list [cmt_ident_occurrences] associate each ident usage location in the
      module with its (partially) reduced shape. We finish the reduction and
@@ -104,11 +102,6 @@ let index_of_cmt ~root ~rewrite_root ~build_path ~do_not_use_cmt_loadpath
         let resolved =
           match item with
           | Unresolved shape -> Reduce.reduce_for_uid cmt_initial_env shape
-          | Resolved _ when Option.is_none cmt_impl_shape ->
-            (* Right now, without additional information we cannot take the
-               risk to mix uids from interfaces with the ones from
-               implementations. We simply ignore items defined in an interface. *)
-            Internal_error_missing_uid
           | result -> result
         in
         match Locate.uid_of_result ~traverse_aliases:false resolved with

--- a/src/ocaml-index/tests/tests-dirs/interfaces.t
+++ b/src/ocaml-index/tests/tests-dirs/interfaces.t
@@ -17,7 +17,8 @@
   $ ocaml-index aggregate main.cmti -o main.index
 
   $ ocaml-index dump main.index
-  1 uids:
-  {uid: Stdlib__Float.81; locs:
+  2 uids:
+  {uid: [intf]Main.0; locs: "t": File "main.mli", line 1, characters 5-6
+   uid: Stdlib__Float.81; locs:
      "Float.t": File "main.mli", line 1, characters 9-16
    }, 0 approx shapes: {}, and shapes for CUS .

--- a/src/ocaml/typing/cmt_format.ml
+++ b/src/ocaml/typing/cmt_format.ml
@@ -454,6 +454,8 @@ let add_saved_type b = saved_types := b :: !saved_types
 let get_saved_types () = !saved_types
 let set_saved_types l = saved_types := l
 
+let get_declaration_dependencies () = !uids_deps
+
 let record_declaration_dependency (rk, uid1, uid2) =
   if not (Uid.equal uid1 uid2) then
     uids_deps := (rk, uid1, uid2) :: !uids_deps

--- a/src/ocaml/typing/cmt_format.mli
+++ b/src/ocaml/typing/cmt_format.mli
@@ -109,6 +109,7 @@ val add_saved_type : binary_part -> unit
 val get_saved_types : unit -> binary_part list
 val set_saved_types : binary_part list -> unit
 
+val get_declaration_dependencies : unit -> (dependency_kind * Uid.t * Uid.t) list
 val record_declaration_dependency: dependency_kind * Uid.t * Uid.t -> unit
 
 (*

--- a/tests/test-dirs/locate/context-detection/cd-test.t/run.t
+++ b/tests/test-dirs/locate/context-detection/cd-test.t/run.t
@@ -32,7 +32,7 @@ Trying them all:
     "value": {
       "file": "$TESTCASE_ROOT/test.ml",
       "pos": {
-        "line": 7,
+        "line": 3,
         "col": 12
       }
     },

--- a/tests/test-dirs/locate/dune
+++ b/tests/test-dirs/locate/dune
@@ -1,6 +1,6 @@
 (cram
  (applies_to looping-substitution mutually-recursive partial-cmt includes
-   issue802 issue845 issue1199 issue1524 sig-substs l-413-features
+   issue802 issue845 issue1848 issue1199 issue1524 sig-substs l-413-features
    module-aliases locate-constrs without-implem without-sig module-decl-aliases
    in-implicit-trans-dep)
  (enabled_if

--- a/tests/test-dirs/locate/issue1848.t
+++ b/tests/test-dirs/locate/issue1848.t
@@ -1,0 +1,71 @@
+Create a module with an mli file
+  $ cat > foo.ml << EOF
+  > type t = Foo
+  > module Bar = struct
+  >   type t = Bar
+  > end
+  > EOF
+
+  $ cat > foo.mli << EOF
+  > module Bar : sig
+  >   type t
+  > end
+  > type t
+  > EOF
+
+  $ $OCAMLC -c -bin-annot foo.mli
+  $ $OCAMLC -c -bin-annot foo.ml
+
+Locate the Bar on line 4
+  $ cat > test1.ml << EOF
+  > module type Foo = sig
+  >   include module type of Foo
+  >   module Bar : sig
+  >     include module type of Bar
+  >   end
+  > end
+  > EOF
+
+The expected location is 2:7 of foo.ml, but it instead goes to 1:9, which is the
+constructor Foo
+  $ $MERLIN single locate -position 4:28 -look-for ml \
+  > -filename test1.ml < test1.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/foo.ml",
+    "pos": {
+      "line": 1,
+      "col": 9
+    }
+  }
+
+Locate the Bar on line 3
+  $ cat > test2.ml << EOF
+  > include Foo
+  > module Bar = struct
+  >   include Bar
+  > end
+  > EOF
+
+Correctly returns 2:7
+  $ $MERLIN single locate -position 3:12 -look-for ml -filename test2.ml < test2.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/foo.ml",
+    "pos": {
+      "line": 2,
+      "col": 7
+    }
+  }
+
+Locate the Foo.Bar on line 1
+  $ cat > test3.ml << EOF
+  > include module type of Foo.Bar
+  > EOF
+Correctly returns 2:7
+  $ $MERLIN single locate -position 1:28 -look-for ml -filename test3.ml < test3.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/foo.ml",
+    "pos": {
+      "line": 2,
+      "col": 7
+    }
+  }

--- a/tests/test-dirs/locate/issue1848.t
+++ b/tests/test-dirs/locate/issue1848.t
@@ -26,6 +26,17 @@ Locate the Bar on line 4
   > end
   > EOF
 
+
+  $ $MERLIN single locate -position 4:28 -look-for mli \
+  > -filename test1.ml < test1.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/foo.mli",
+    "pos": {
+      "line": 1,
+      "col": 7
+    }
+  }
+
 FIXME Module type Bar in foo.mli is a correct answer, but since there is only
 one corresponding implementation we could jump there instead.
   $ $MERLIN single locate -position 4:28 -look-for ml \

--- a/tests/test-dirs/locate/issue1848.t
+++ b/tests/test-dirs/locate/issue1848.t
@@ -26,15 +26,15 @@ Locate the Bar on line 4
   > end
   > EOF
 
-The expected location is 2:7 of foo.ml, but it instead goes to 1:9, which is the
-constructor Foo
+FIXME Module type Bar in foo.mli is a correct answer, but since there is only
+one corresponding implementation we could jump there instead.
   $ $MERLIN single locate -position 4:28 -look-for ml \
   > -filename test1.ml < test1.ml | jq .value
   {
-    "file": "$TESTCASE_ROOT/foo.ml",
+    "file": "$TESTCASE_ROOT/foo.mli",
     "pos": {
       "line": 1,
-      "col": 9
+      "col": 7
     }
   }
 

--- a/tests/test-dirs/locate/issue1848.t
+++ b/tests/test-dirs/locate/issue1848.t
@@ -37,14 +37,14 @@ Locate the Bar on line 4
     }
   }
 
-FIXME Module type Bar in foo.mli is a correct answer, but since there is only
-one corresponding implementation we could jump there instead.
+Module Bar in foo.mli is a correct answer, but since there is only
+one corresponding implementation we can jump there instead.
   $ $MERLIN single locate -position 4:28 -look-for ml \
   > -filename test1.ml < test1.ml | jq .value
   {
-    "file": "$TESTCASE_ROOT/foo.mli",
+    "file": "$TESTCASE_ROOT/foo.ml",
     "pos": {
-      "line": 1,
+      "line": 2,
       "col": 7
     }
   }

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -6,6 +6,7 @@
   $ cat >main.ml <<'EOF'
   > let x = ()
   > type t = unit
+  > let _ : t = ()
   > EOF
 
   $ ocamlc -bin-annot -bin-annot-occurrences -c main.mli main.ml
@@ -16,10 +17,13 @@ The indexer should not mixup uids from mli and ml files:
   $ ocaml-index dump project.ocaml-index
   2 uids:
   {uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
-   uid: Main.1; locs: "t": File "main.ml", line 2, characters 5-6 },
-  0 approx shapes: {}, and shapes for CUS .
+   uid: Main.1; locs:
+     "t": File "main.ml", line 2, characters 5-6;
+     "t": File "main.ml", line 3, characters 8-9
+   }, 0 approx shapes: {}, and shapes for CUS .
 
-Merlin should not mixup uids from mli and ml files:
+Merlin should not mixup uids from mli and ml files, and return results in both
+the interface and the implementation.
   $ $MERLIN single occurrences -scope project -identifier-at 2:8 \
   > -index-file project.ocaml-index \
   > -filename main.mli <main.mli
@@ -54,7 +58,7 @@ Merlin should not mixup uids from mli and ml files:
 
 Same when the cursor is at the origin:
   $ $MERLIN single occurrences -scope project -identifier-at 1:5 \
-  > -index-file project.ocaml-index \
+  > -index-file project.ocaml-index  \
   > -filename main.mli <main.mli
   {
     "class": "return",
@@ -79,6 +83,84 @@ Same when the cursor is at the origin:
         "end": {
           "line": 2,
           "col": 9
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+It also works when querying for t from the implementation:
+  $ $MERLIN single occurrences -scope project -identifier-at 3:8 \
+  > -index-file project.ocaml-index \
+  > -filename main.ml <main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 2,
+          "col": 5
+        },
+        "end": {
+          "line": 2,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
+          "col": 9
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+
+It also works when querying for x from the implementation:
+  $ $MERLIN single occurrences -scope project -identifier-at 1:4 \
+  > -index-file project.ocaml-index \
+  > -filename main.ml <main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 1,
+          "col": 4
+        },
+        "end": {
+          "line": 1,
+          "col": 5
+        }
+      }
+    ],
+    "notifications": []
+  }
+
+It also works when querying for x from the interface:
+  $ $MERLIN single occurrences -scope project -identifier-at 2:4 \
+  > -index-file project.ocaml-index \
+  > -filename main.mli <main.mli
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 4
+        },
+        "end": {
+          "line": 2,
+          "col": 5
         }
       }
     ],

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -258,3 +258,55 @@ It also works when querying for x from the interface:
     ],
     "notifications": []
   }
+
+If we switch lines without rebuilding...
+  $ cat >main.ml <<'EOF'
+  > type t = unit
+  > let x = ()
+  > let _ : t = ()
+  > EOF
+
+FIXME: Merlin would get confused and return an occurrence of `x` in the
+interface when asked from occurrences of `t` in the implementation.
+  $ $MERLIN single occurrences -scope project -identifier-at 1:5 \
+  > -index-file project.ocaml-index \
+  > -filename main.ml <main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 1,
+          "col": 5
+        },
+        "end": {
+          "line": 1,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
+          "col": 9
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 4
+        },
+        "end": {
+          "line": 2,
+          "col": 5
+        }
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -266,8 +266,11 @@ If we switch lines without rebuilding...
   > let _ : t = ()
   > EOF
 
-FIXME: Merlin would get confused and return an occurrence of `x` in the
-interface when asked from occurrences of `t` in the implementation.
+Merlin should not get confused and return an occurrence of `x` in the interface
+when asked from occurrences of `t` in the implementation. 
+
+FIXME: this is based on a heuristic that compares the identifiers it could still
+get confused if both identifers are the same.
   $ $MERLIN single occurrences -scope project -identifier-at 1:5 \
   > -index-file project.ocaml-index \
   > -filename main.ml <main.ml
@@ -294,17 +297,6 @@ interface when asked from occurrences of `t` in the implementation.
         "end": {
           "line": 3,
           "col": 9
-        }
-      },
-      {
-        "file": "$TESTCASE_ROOT/main.mli",
-        "start": {
-          "line": 2,
-          "col": 4
-        },
-        "end": {
-          "line": 2,
-          "col": 5
         }
       }
     ],

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -15,8 +15,12 @@
 
 The indexer should not mixup uids from mli and ml files:
   $ ocaml-index dump project.ocaml-index
-  2 uids:
-  {uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
+  4 uids:
+  {uid: [intf]Main.0; locs:
+     "t": File "main.mli", line 1, characters 5-6;
+     "t": File "main.mli", line 2, characters 8-9
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
+   uid: [intf]Main.1; locs: "x": File "main.mli", line 2, characters 4-5
    uid: Main.1; locs:
      "t": File "main.ml", line 2, characters 5-6;
      "t": File "main.ml", line 3, characters 8-9
@@ -39,6 +43,28 @@ the interface and the implementation.
         "end": {
           "line": 1,
           "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 2,
+          "col": 5
+        },
+        "end": {
+          "line": 2,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
+          "col": 9
         }
       },
       {
@@ -72,6 +98,28 @@ Same when the cursor is at the origin:
         "end": {
           "line": 1,
           "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 2,
+          "col": 5
+        },
+        "end": {
+          "line": 2,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
+          "col": 9
         }
       },
       {
@@ -117,6 +165,28 @@ It also works when querying for t from the implementation:
           "line": 3,
           "col": 9
         }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 1,
+          "col": 5
+        },
+        "end": {
+          "line": 1,
+          "col": 6
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 9
+        }
       }
     ],
     "notifications": []
@@ -140,6 +210,17 @@ It also works when querying for x from the implementation:
           "line": 1,
           "col": 5
         }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.mli",
+        "start": {
+          "line": 2,
+          "col": 4
+        },
+        "end": {
+          "line": 2,
+          "col": 5
+        }
       }
     ],
     "notifications": []
@@ -160,6 +241,17 @@ It also works when querying for x from the interface:
         },
         "end": {
           "line": 2,
+          "col": 5
+        }
+      },
+      {
+        "file": "$TESTCASE_ROOT/main.ml",
+        "start": {
+          "line": 1,
+          "col": 4
+        },
+        "end": {
+          "line": 1,
           "col": 5
         }
       }


### PR DESCRIPTION
In OCaml 5.3's cmts the uids contain information indicating there origin (an implementation or an interface). In this PR we use that information to jump to interface files when needed.

- This fixes issue #1848 
- This allows us to return occurrences in both the interface and implementation

This is sensible to the freshness of the cmt file for the current module. An heuristic based on identifiers is used to alleviate the risk of Merlin giving wrong answers when the cmts are out-of-date. If this proves insufficient we can make it stricter by checking the creation time of the artifacts.
