### PR TITLE
Fix issue with jump to "fun" after upgrade to 5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ unreleased
     - Fix occurrences bug in which relative paths in index files are resolved against the
       PWD rather than the SOURCE_ROOT (#1855)
     - Fix exception in polarity search (#1858 fixes #1113)
+    - Fix jump to `fun` targets not working (#1863, fixes #1862)
 
 merlin 5.2.1
 ============

--- a/src/analysis/jump.ml
+++ b/src/analysis/jump.ml
@@ -42,10 +42,6 @@ let is_node_let = function
   | Value_binding _ -> true
   | _ -> false
 
-let is_node_pattern = function
-  | Case _ -> true
-  | _ -> false
-
 let fun_pred all =
   (* For:
      `let f x y z = ...` jump to f
@@ -54,15 +50,13 @@ let fun_pred all =
      For
      `List.map l ~f:(fun x -> ...)` jump to fun
 
-     Every fun is immediately followed by pattern in the typed tree.
      Invariant: head is a fun.
   *)
   let rec normalize_fun = function
     (* fun pat fun something *)
-    | node1 :: node2 :: node3 :: tail when is_node_fun node3 ->
+    | node1 :: node2 :: tail when is_node_fun node2 ->
       assert (is_node_fun node1);
-      assert (is_node_pattern node2);
-      normalize_fun (node3 :: tail)
+      normalize_fun (node2 :: tail)
     (* fun let something *)
     | node1 :: node2 :: _ when is_node_let node2 ->
       assert (is_node_fun node1);

--- a/tests/test-dirs/jump-issue1862.t
+++ b/tests/test-dirs/jump-issue1862.t
@@ -6,26 +6,27 @@
   > let f = fun x -> fun y -> fun z -> 
   >   ()
   > EOF
-FIXME: Jump to `fun` should not raise an exception and jump to 1:25
+
+Jump to `fun` should not raise an exception and jump to 1:20
   $ $MERLIN single jump -target fun -position 2:4 \
-  > -filename main.ml <main.ml | tr '\n' ' ' | jq '.class'
-  "exception"
+  > -filename main.ml <main.ml | jq '.value.pos'
+  {
+    "line": 1,
+    "col": 20
+  }
 
 Shoud jump to line 3
   $ $MERLIN single jump -target fun -position 4:4 \
-  > -filename main.ml <main.ml 
+  > -filename main.ml <main.ml | jq '.value.pos'
   {
-    "class": "return",
-    "value": {
-      "pos": {
-        "line": 3,
-        "col": 0
-      }
-    },
-    "notifications": []
+    "line": 3,
+    "col": 0
   }
 
-FIXME shoud jump to line 5
+Shoud jump to line 5
   $ $MERLIN single jump -target fun -position 6:4 \
-  > -filename main.ml <main.ml  | tr '\n' ' ' | jq '.class'
-  "exception"
+  > -filename main.ml <main.ml | jq '.value.pos'
+  {
+    "line": 5,
+    "col": 0
+  }

--- a/tests/test-dirs/jump-issue1862.t
+++ b/tests/test-dirs/jump-issue1862.t
@@ -1,0 +1,31 @@
+  $ cat >main.ml <<EOF
+  > let f () = List.map (fun _ -> 
+  >   ())
+  > let f x y z = 
+  >   ()
+  > let f = fun x -> fun y -> fun z -> 
+  >   ()
+  > EOF
+FIXME: Jump to `fun` should not raise an exception and jump to 1:25
+  $ $MERLIN single jump -target fun -position 2:4 \
+  > -filename main.ml <main.ml | tr '\n' ' ' | jq '.class'
+  "exception"
+
+Shoud jump to line 3
+  $ $MERLIN single jump -target fun -position 4:4 \
+  > -filename main.ml <main.ml 
+  {
+    "class": "return",
+    "value": {
+      "pos": {
+        "line": 3,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }
+
+FIXME shoud jump to line 5
+  $ $MERLIN single jump -target fun -position 6:4 \
+  > -filename main.ml <main.ml  | tr '\n' ' ' | jq '.class'
+  "exception"


### PR DESCRIPTION
Changes in the representation of functions in the `Typedtree` broke invariants in the jump-to-fun features.