### PR TITLE
Fix type enclosing deduplication

### DIFF
--- a/src/analysis/misc_utils.mli
+++ b/src/analysis/misc_utils.mli
@@ -31,3 +31,11 @@ val parenthesize_name : string -> string
     the location of each of its components. *)
 val parse_identifier :
   Mconfig.t * Msource.t -> Lexing.position -> modname Location.loc list
+
+(** [reconstruct_identifier pipeline pos] returns growing ranges around [pos] and the
+  associated identifier. *)
+val reconstruct_identifier :
+  Mpipeline.t ->
+  Lexing.position ->
+  (string * int) option ->
+  string Location.loc list

--- a/src/analysis/type_enclosing.mli
+++ b/src/analysis/type_enclosing.mli
@@ -38,10 +38,13 @@ type type_info =
   | Modtype of Env.t * Types.module_type
   | Type of Env.t * Types.type_expr
   | Type_decl of Env.t * Ident.t * Types.type_declaration
+  | Type_constr of Env.t * Types.constructor_description
   | String of string
 
 type typed_enclosings =
   (Location.t * type_info * Query_protocol.is_tail_position) list
+
+val print_type : verbosity:Mconfig.Verbosity.t -> type_info -> string
 
 val from_nodes :
   path:(Env.t * Browse_raw.node * Query_protocol.is_tail_position) list ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -278,6 +278,15 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       in
       concat_dedup [] small_enclosings enclosing_nodes
     in
+    let index =
+      (* Clamp the index to [0; number_of_results[ *)
+      let number_of_results = List.length all_results in
+      match index with
+      | Some index when index < 0 -> Some 0
+      | Some index when index >= number_of_results ->
+        Some (number_of_results - 1)
+      | index -> index
+    in
     List.mapi all_results ~f:(fun i (loc, text, tail) ->
         let print =
           match index with

--- a/tests/test-dirs/hidden-deps/dash-h.t
+++ b/tests/test-dirs/hidden-deps/dash-h.t
@@ -62,6 +62,18 @@ Check the type of `x`, should work.
         },
         "end": {
           "line": 3,
+          "col": 9
+        },
+        "type": "t",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
           "col": 14
         },
         "type": "int",

--- a/tests/test-dirs/issue1109.t/run.t
+++ b/tests/test-dirs/issue1109.t/run.t
@@ -20,9 +20,9 @@
       },
       "end": {
         "line": 5,
-        "col": 16
+        "col": 14
       },
-      "type": "'a",
+      "type": "'a -> 'a",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/misc/load_path.t
+++ b/tests/test-dirs/misc/load_path.t
@@ -27,6 +27,18 @@ Here is what merlin sees:
         },
         "type": "int",
         "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": "int",
+        "tail": "no"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
+++ b/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
@@ -15,6 +15,18 @@ Various parts of the cons.ml:
       },
       "type": "t",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 4,
+        "col": 13
+      },
+      "end": {
+        "line": 4,
+        "col": 14
+      },
+      "type": "t",
+      "tail": "no"
     }
   ]
 
@@ -37,14 +49,14 @@ Various parts of the cons.ml:
     },
     {
       "start": {
-        "line": 7,
-        "col": 2
+        "line": 8,
+        "col": 4
       },
       "end": {
         "line": 8,
-        "col": 11
+        "col": 5
       },
-      "type": "unit",
+      "type": "t",
       "tail": "no"
     }
   ]
@@ -127,13 +139,13 @@ Various parts of the cons.ml:
     {
       "start": {
         "line": 15,
-        "col": 6
+        "col": 12
       },
       "end": {
         "line": 15,
-        "col": 22
+        "col": 15
       },
-      "type": "unit -> M.t",
+      "type": "M.t",
       "tail": "no"
     }
   ]
@@ -233,6 +245,18 @@ the expression reconstructed from  (M|.A 3).
   $ $MERLIN single type-enclosing -position 26:11 -verbosity 0 \
   > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
   [
+    {
+      "start": {
+        "line": 26,
+        "col": 8
+      },
+      "end": {
+        "line": 26,
+        "col": 11
+      },
+      "type": "int",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 26,

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -26,7 +26,7 @@ With index 0 only the first type is shown:
       "line": 1,
       "col": 16
     },
-    "type": 1,
+    "type": "(int -> int) -> int list -> int list",
     "tail": "no"
   }
 
@@ -183,21 +183,9 @@ next type was not rendered.
         },
         "end": {
           "line": 2,
-          "col": 16
-        },
-        "type": 1,
-        "tail": "no"
-      },
-      {
-        "start": {
-          "line": 2,
-          "col": 8
-        },
-        "end": {
-          "line": 2,
           "col": 27
         },
-        "type": 2,
+        "type": 1,
         "tail": "no"
       }
     ],
@@ -232,7 +220,7 @@ should have been shorter earlier.
           "line": 2,
           "col": 27
         },
-        "type": 2,
+        "type": "int list",
         "tail": "no"
       }
     ],

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -1,0 +1,240 @@
+  $ cat >main.ml <<'EOF'
+  > let _ = List.map Fun.id [3]
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 1:14 -index 0 \
+  > -filename ./main.ml < ./main.ml | jq '.value[0,1]'
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "('a -> 'b) -> 'a list -> 'b list",
+    "tail": "no"
+  }
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": 1,
+    "tail": "no"
+  }
+
+With index 1 only the second is shown (the first is a string so it is always shown):
+  $ $MERLIN single type-enclosing -position 1:14 -index 1 \
+  > -filename ./main.ml < ./main.ml  | jq '.value[0,1]'
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "('a -> 'b) -> 'a list -> 'b list",
+    "tail": "no"
+  }
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "(int -> int) -> int list -> int list",
+    "tail": "no"
+  }
+
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 1:10 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 12
+        },
+        "type": "(module Stdlib__List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+With index 1 only the second is shown (the first is a string so it is always shown):
+FIXME? We don't see the generic version
+  $ $MERLIN single type-enclosing -position 1:10 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 12
+        },
+        "type": "(module Stdlib__List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ cat >main.ml <<'EOF'
+  > module List = struct let map : (int -> int) -> int list -> int list = List.map end
+  > let _ = List.map Fun.id [3]
+  > EOF
+
+FIXME With index 0 only the first type is shown but deduplication failed becauser the
+next type was not rendered.
+  $ $MERLIN single type-enclosing -position 2:14 -index 0 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME With index 1 the list is shorter and the numbering is wrong ! In fact, it
+should have been shorter earlier.
+  $ $MERLIN single type-enclosing -position 2:14 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -26,7 +26,7 @@ With index 0 only the first type is shown:
       "line": 1,
       "col": 16
     },
-    "type": "(int -> int) -> int list -> int list",
+    "type": 1,
     "tail": "no"
   }
 
@@ -107,7 +107,7 @@ With index 0 only the first type is shown:
 
 With index 1 only the second is shown (the first is a string so it is always shown):
 FIXME? We don't see the generic version
-  $ $MERLIN single type-enclosing -position 1:10 -index 1 \
+  $ $MERLIN single type-enclosing -short-paths -position 1:10 -index 1 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",
@@ -121,7 +121,7 @@ FIXME? We don't see the generic version
           "line": 1,
           "col": 12
         },
-        "type": "(module Stdlib__List)",
+        "type": "(module List)",
         "tail": "no"
       },
       {
@@ -157,7 +157,8 @@ FIXME? We don't see the generic version
   > let _ = List.map Fun.id [3]
   > EOF
 
-With index 0 only the first type is shown and deduplication id working
+With index 0 only the first type is shown. The next enclosing is not
+deduplicated as intended, this should be done by the client.
   $ $MERLIN single type-enclosing -position 2:14 -index 0 \
   > -filename ./main.ml < ./main.ml 
   {
@@ -182,9 +183,21 @@ With index 0 only the first type is shown and deduplication id working
         },
         "end": {
           "line": 2,
-          "col": 27
+          "col": 16
         },
         "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
         "tail": "no"
       }
     ],
@@ -216,17 +229,29 @@ And with index=1 the correct type is shown
         },
         "end": {
           "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
           "col": 27
         },
-        "type": "int list",
+        "type": 2,
         "tail": "no"
       }
     ],
     "notifications": []
   }
 
-And with index>=2 Merlin sticks to the last item
-  $ $MERLIN single type-enclosing -position 2:14 -index 2 \
+And with index>=3 Merlin sticks to the last item
+  $ $MERLIN single type-enclosing -position 2:14 -index 7 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",
@@ -241,6 +266,18 @@ And with index>=2 Merlin sticks to the last item
           "col": 16
         },
         "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": 1,
         "tail": "no"
       },
       {

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -157,8 +157,7 @@ FIXME? We don't see the generic version
   > let _ = List.map Fun.id [3]
   > EOF
 
-FIXME With index 0 only the first type is shown but deduplication failed becauser the
-next type was not rendered.
+With index 0 only the first type is shown and deduplication id working
   $ $MERLIN single type-enclosing -position 2:14 -index 0 \
   > -filename ./main.ml < ./main.ml 
   {
@@ -192,9 +191,42 @@ next type was not rendered.
     "notifications": []
   }
 
-FIXME With index 1 the list is shorter and the numbering is wrong ! In fact, it
-should have been shorter earlier.
+And with index=1 the correct type is shown
   $ $MERLIN single type-enclosing -position 2:14 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": "int list",
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+And with index>=2 Merlin sticks to the last item
+  $ $MERLIN single type-enclosing -position 2:14 -index 2 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",

--- a/tests/test-dirs/type-enclosing/github1003.t/run.t
+++ b/tests/test-dirs/type-enclosing/github1003.t/run.t
@@ -12,6 +12,18 @@
       },
       "type": "int",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 8
+      },
+      "end": {
+        "line": 5,
+        "col": 16
+      },
+      "type": "int",
+      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/issue1477.t
+++ b/tests/test-dirs/type-enclosing/issue1477.t
@@ -26,6 +26,18 @@
       },
       "end": {
         "line": 2,
+        "col": 9
+      },
+      "type": "int -> int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
         "col": 11
       },
       "type": "int",

--- a/tests/test-dirs/type-enclosing/letop.t/run.t
+++ b/tests/test-dirs/type-enclosing/letop.t/run.t
@@ -86,9 +86,9 @@ Various parts of the letop:
       },
       "end": {
         "line": 4,
-        "col": 37
+        "col": 29
       },
-      "type": "'a option",
+      "type": "('a, 'b) Hashtbl.t -> 'a -> 'b option",
       "tail": "no"
     }
   ]
@@ -111,13 +111,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 13
+        "col": 30
       },
       "end": {
         "line": 4,
-        "col": 37
+        "col": 33
       },
-      "type": "'a option",
+      "type": "('a, 'b) Hashtbl.t",
       "tail": "no"
     }
   ]
@@ -140,13 +140,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 13
+        "col": 34
       },
       "end": {
         "line": 4,
         "col": 37
       },
-      "type": "'a option",
+      "type": "'a",
       "tail": "no"
     }
   ]
@@ -175,7 +175,7 @@ Various parts of the letop:
       },
       "end": {
         "line": 5,
-        "col": 9
+        "col": 5
       },
       "type": "int",
       "tail": "no"

--- a/tests/test-dirs/type-enclosing/mod-type.t/run.t
+++ b/tests/test-dirs/type-enclosing/mod-type.t/run.t
@@ -43,6 +43,18 @@ Get the type of a module type with the same name as a module:
       },
       "type": "sig type a end",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 8
+      },
+      "end": {
+        "line": 5,
+        "col": 9
+      },
+      "type": "sig type a end",
+      "tail": "no"
     }
   ]
 
@@ -64,7 +76,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 8
+        "col": 23
       },
       "end": {
         "line": 7,
@@ -93,7 +105,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 8
+        "col": 23
       },
       "end": {
         "line": 7,

--- a/tests/test-dirs/type-enclosing/objects.t/run.t
+++ b/tests/test-dirs/type-enclosing/objects.t/run.t
@@ -112,9 +112,9 @@
       },
       "end": {
         "line": 14,
-        "col": 14
+        "col": 9
       },
-      "type": "int -> unit",
+      "type": "< pop : int option; push : int -> unit >",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/record.t/run.t
+++ b/tests/test-dirs/type-enclosing/record.t/run.t
@@ -95,9 +95,9 @@
       },
       "end": {
         "line": 8,
-        "col": 17
+        "col": 9
       },
-      "type": "unit",
+      "type": "t",
       "tail": "no"
     }
   ]
@@ -124,9 +124,9 @@
       },
       "end": {
         "line": 8,
-        "col": 17
+        "col": 9
       },
-      "type": "type unit = ()",
+      "type": "type t = { mutable b : float; }",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/te-413-features.t
+++ b/tests/test-dirs/type-enclosing/te-413-features.t
@@ -21,13 +21,13 @@ Named existentials in patterns
     {
       "start": {
         "line": 3,
-        "col": 51
+        "col": 59
       },
       "end": {
         "line": 3,
-        "col": 65
+        "col": 60
       },
-      "type": "unit",
+      "type": "a",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/te-modules.t
+++ b/tests/test-dirs/type-enclosing/te-modules.t
@@ -1,0 +1,238 @@
+  $ cat >main.ml <<'EOF'
+  > module M = struct module N = struct let x = () let y = () end end
+  > module B = M.N
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 2:7 -verbosity 0 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 8
+        },
+        "type": "(module M.N)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single type-enclosing -position 2:7 -verbosity 1 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 8
+        },
+        "type": "sig val x : unit val y : unit end",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ cat >main.ml <<'EOF'
+  > module M = struct module N = List end
+  > module B = M.N
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 2:13 -verbosity 0 -index 0 \
+  > -filename ./main.ml < ./main.ml  
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": "(module List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single type-enclosing -position 2:13 -verbosity 1 -index 0 \
+  > -filename ./main.ml < ./main.ml  
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": "sig
+    type 'a t = 'a list = [] | (::) of 'a * 'a list
+    val length : 'a list -> int
+    val compare_lengths : 'a list -> 'b list -> int
+    val compare_length_with : 'a list -> int -> int
+    val is_empty : 'a list -> bool
+    val cons : 'a -> 'a list -> 'a list
+    val hd : 'a list -> 'a
+    val tl : 'a list -> 'a list
+    val nth : 'a list -> int -> 'a
+    val nth_opt : 'a list -> int -> 'a option
+    val rev : 'a list -> 'a list
+    val init : int -> (int -> 'a) -> 'a list
+    val append : 'a list -> 'a list -> 'a list
+    val rev_append : 'a list -> 'a list -> 'a list
+    val concat : 'a list list -> 'a list
+    val flatten : 'a list list -> 'a list
+    val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+    val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+    val iter : ('a -> unit) -> 'a list -> unit
+    val iteri : (int -> 'a -> unit) -> 'a list -> unit
+    val map : ('a -> 'b) -> 'a list -> 'b list
+    val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+    val rev_map : ('a -> 'b) -> 'a list -> 'b list
+    val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+    val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+    val fold_left_map :
+      ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+    val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc
+    val fold_right : ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
+    val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+    val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    val fold_left2 :
+      ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a list -> 'b list -> 'acc
+    val fold_right2 :
+      ('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> 'acc -> 'acc
+    val for_all : ('a -> bool) -> 'a list -> bool
+    val exists : ('a -> bool) -> 'a list -> bool
+    val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    val mem : 'a -> 'a list -> bool
+    val memq : 'a -> 'a list -> bool
+    val find : ('a -> bool) -> 'a list -> 'a
+    val find_opt : ('a -> bool) -> 'a list -> 'a option
+    val find_index : ('a -> bool) -> 'a list -> int option
+    val find_map : ('a -> 'b option) -> 'a list -> 'b option
+    val find_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b option
+    val filter : ('a -> bool) -> 'a list -> 'a list
+    val find_all : ('a -> bool) -> 'a list -> 'a list
+    val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
+    val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
+    val partition_map :
+      ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+    val assoc : 'a -> ('a * 'b) list -> 'b
+    val assoc_opt : 'a -> ('a * 'b) list -> 'b option
+    val assq : 'a -> ('a * 'b) list -> 'b
+    val assq_opt : 'a -> ('a * 'b) list -> 'b option
+    val mem_assoc : 'a -> ('a * 'b) list -> bool
+    val mem_assq : 'a -> ('a * 'b) list -> bool
+    val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+    val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+    val split : ('a * 'b) list -> 'a list * 'b list
+    val combine : 'a list -> 'b list -> ('a * 'b) list
+    val sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list
+    val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+    val to_seq : 'a list -> 'a Seq.t
+    val of_seq : 'a Seq.t -> 'a list
+  end",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -41,6 +41,18 @@
       },
       "type": "type x = Foo",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 10
+      },
+      "end": {
+        "line": 5,
+        "col": 11
+      },
+      "type": "type x = Foo",
+      "tail": "no"
     }
   ]
 


### PR DESCRIPTION
Deduplication can only be done if the type have been printed which is an expensive process. We perform that printing only at the junction between the reconstructed identifier's enclosings and the ones from the tree nodes because we often want to keep both (often this gives the generic type and then its specialized version). All other duplicated ranges are removed.