### PR TITLE
Report stale occurrences

### DIFF
--- a/.github/workflows/ocaml-lsp-compat.yml
+++ b/.github/workflows/ocaml-lsp-compat.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Check that Merlin and OCaml-LSP are co-installable
         run: |
-          opam --cli=2.1 pin --with-version=dev --no-action https://github.com/liam923/ocaml-lsp.git#rename-holes
+          opam --cli=2.1 pin --with-version=dev --no-action https://github.com/liam923/ocaml-lsp.git#stale-occurrences
           opam --cli=2.1 pin --with-version=5.4-503 --no-action .
           opam install ocaml-lsp-server --ignore-constraints-on=ocamlformat
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Fri Jan 10 17:55:42 CET 2025
     - Perform less merges in the indexer (#1881)
     - Add initial support for project-wide renaming: occurrences can now return
       all usages of all related definitions. (#1877)
+    - Stale occurrences are flagged as such
   + vim plugin
     - Added support for search-by-type (#1846)
       This is exposed through the existing `:MerlinSearch` command, that

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ unreleased
       (#1888)
     - `locate` can now disambiguate between files with identical names and contents
       (#1882)
+    - `occurrences` now reports stale files (#1885)
   + ocaml-index
     - Improve the granularity of index reading by segmenting the marshalization
       of the involved data-structures. (#1889)

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -36,12 +36,12 @@ end = struct
   let to_list = Lid_map.to_list
 
   let of_filtered_lid_set lid_set ~f:get_staleness =
-    let maybe_add_lid lid acc =
+    let maybe_add_lid acc lid =
       match get_staleness lid with
       | Some staleness -> Lid_map.add lid staleness acc
       | None -> acc
     in
-    Lid_set.fold maybe_add_lid lid_set empty
+    Lid_set.fold maybe_add_lid empty lid_set
 
   let either_fresh a b =
     let open Staleness in

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -4,7 +4,53 @@ module Lid_set = Index_format.Lid_set
 let { Logger.log } = Logger.for_section "occurrences"
 
 type t =
-  { locs : Warnings.loc list; status : Query_protocol.occurrences_status }
+  { occurrences : Query_protocol.occurrence list;
+    status : Query_protocol.occurrences_status
+  }
+
+module Staleness = struct
+  type t = Stale | Fresh
+
+  let is_stale = function
+    | Stale -> true
+    | Fresh -> false
+end
+
+module Occurrence_set : sig
+  type t
+
+  val empty : t
+
+  (** Filter an [Lid_set.t]. [Lid.t]s that are kept must be assigned a staleness *)
+  val of_filtered_lid_set :
+    Lid_set.t -> f:(Index_format.Lid.t -> Staleness.t option) -> t
+
+  val to_list : t -> (Index_format.Lid.t * Staleness.t) list
+  val union : t -> t -> t
+end = struct
+  module Lid_map = Map.Make (Index_format.Lid)
+
+  type t = Staleness.t Lid_map.t
+
+  let empty = Lid_map.empty
+  let to_list = Lid_map.to_list
+
+  let of_filtered_lid_set lid_set ~f:get_staleness =
+    let maybe_add_lid lid acc =
+      match get_staleness lid with
+      | Some staleness -> Lid_map.add lid staleness acc
+      | None -> acc
+    in
+    Lid_set.fold maybe_add_lid lid_set empty
+
+  let either_fresh a b =
+    let open Staleness in
+    match (a, b) with
+    | Fresh, _ | _, Fresh -> Fresh
+    | Stale, Stale -> Stale
+
+  let union a b = Lid_map.union (fun _ a b -> Some (either_fresh a b)) a b
+end
 
 let () = Mtyper.set_index_items Index_occurrences.items
 
@@ -118,7 +164,8 @@ let get_buffer_locs result uid =
       else acc)
     (Mtyper.get_index result) Lid_set.empty
 
-let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid =
+let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid :
+    (Occurrence_set.t * Std.String.Set.t) list =
   let title = "get_external_locs" in
   List.filter_map config.merlin.index_files ~f:(fun index_file ->
       log ~title "Lookin for occurrences of %a in index %s" Logger.fmt
@@ -135,8 +182,7 @@ let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid =
       in
       Option.map external_locs ~f:(fun (index, locs) ->
           let stats = Stat_check.create ~cache_size:128 index in
-          ( Lid_set.filter
-              (fun lid ->
+          ( Occurrence_set.of_filtered_lid_set locs ~f:(fun lid ->
                 let { Location.loc; _ } = Index_format.Lid.to_lid lid in
                 (* We ignore external results that concern the current buffer *)
                 let file_rel_to_root =
@@ -150,15 +196,21 @@ let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid =
                 in
                 let file = Misc.canonicalize_filename file_uncanon in
                 let buf = Misc.canonicalize_filename buf_uncanon in
-                if String.equal file buf then false
+                if String.equal file buf then None
                 else begin
                   (* We ignore external results if their source was modified *)
-                  let check = Stat_check.check stats ~file:file_rel_to_root in
-                  if not check then
-                    log ~title "File %s might be out-of-sync." file;
-                  check
-                end)
-              locs,
+                  let is_fresh =
+                    Stat_check.check stats ~file:file_rel_to_root
+                  in
+                  if not is_fresh then
+                    log ~title:"locs_of" "File %s might be out-of-sync." file;
+                  let staleness : Staleness.t =
+                    match is_fresh with
+                    | true -> Fresh
+                    | false -> Stale
+                  in
+                  Some staleness
+                end),
             Stat_check.get_outdated_files stats )))
 
 let lookup_related_uids_in_indexes ~(config : Mconfig.t) uid =
@@ -258,7 +310,10 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
       (fun fmt -> Location.print_loc fmt def_loc);
     log ~title:"locs_of" "Indexing current buffer";
     let buffer_locs = get_buffer_locs typer_result def_uid in
-    let external_locs =
+    let buffer_occurrences =
+      Occurrence_set.of_filtered_lid_set buffer_locs ~f:(fun _ -> Some Fresh)
+    in
+    let external_occurrences =
       if scope = `Buffer then []
       else
         let name =
@@ -269,48 +324,51 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
           (def_uid :: additional_uids)
           ~f:(get_external_locs ~config ~current_buffer_path)
     in
-    let external_locs, out_of_sync_files =
+    let external_occurrences, out_of_sync_files =
       List.fold_left
-        ~init:(Lid_set.empty, String.Set.empty)
+        ~init:(Occurrence_set.empty, String.Set.empty)
         ~f:(fun (acc_locs, acc_files) (locs, files) ->
-          (Lid_set.union acc_locs locs, String.Set.union acc_files files))
-        external_locs
+          (Occurrence_set.union acc_locs locs, String.Set.union acc_files files))
+        external_occurrences
     in
-    let locs = Lid_set.union buffer_locs external_locs in
-    (* Some of the paths may have redundant `.`s or `..`s in them. Although canonicalizing
-       is not necessary for correctness, it makes the output a bit nicer. *)
-    let canonicalize_file_in_loc lid =
-      let ({ txt; loc } : 'a Location.loc) = Index_format.Lid.to_lid lid in
-      let file =
-        Misc.canonicalize_filename ?cwd:config.merlin.source_root
-          loc.loc_start.pos_fname
-      in
-      Index_format.Lid.of_lid { txt; loc = set_fname ~file loc }
+    let occurrences =
+      Occurrence_set.union buffer_occurrences external_occurrences
     in
-    let locs = Lid_set.map canonicalize_file_in_loc locs in
-    let locs =
-      log ~title:"occurrences" "Found %i locs" (Lid_set.cardinal locs);
-      Lid_set.elements locs
-      |> List.filter_map ~f:(fun lid ->
-             let { Location.txt; loc } = Index_format.Lid.to_lid lid in
-             let lid = try Longident.head txt with _ -> "not flat lid" in
-             log ~title:"occurrences" "Found occ: %s %a" lid Logger.fmt
-               (Fun.flip Location.print_loc loc);
-             let loc = last_loc loc txt in
-             let fname = loc.Location.loc_start.Lexing.pos_fname in
-             if not (Filename.is_relative fname) then Some loc
-             else
-               match config.merlin.source_root with
-               | Some path ->
-                 let file = Filename.concat path loc.loc_start.pos_fname in
-                 Some (set_fname ~file loc)
-               | None -> begin
-                 match Locate.find_source ~config loc fname with
-                 | `Found (file, _) -> Some (set_fname ~file loc)
-                 | `File_not_found msg ->
-                   log ~title:"occurrences" "%s" msg;
-                   None
-               end)
+    let occurrences = Occurrence_set.to_list occurrences in
+    log ~title:"occurrences" "Found %i locs" (List.length occurrences);
+    let occurrences =
+      List.filter_map occurrences ~f:(fun (lid, staleness) ->
+          let ({ txt; loc } : 'a Location.loc) = Index_format.Lid.to_lid lid in
+          (* Canonoicalize filenames. Some of the paths may have redundant `.`s or `..`s in
+             them. Although canonicalizing is not necessary for correctness, it makes the
+             output a bit nicer. *)
+          let file =
+            Misc.canonicalize_filename ?cwd:config.merlin.source_root
+              loc.loc_start.pos_fname
+          in
+          let loc = set_fname ~file loc in
+          let lid = try Longident.head txt with _ -> "not flat lid" in
+          log ~title:"occurrences" "Found occ: %s %a" lid Logger.fmt
+            (Fun.flip Location.print_loc loc);
+          let loc = last_loc loc txt in
+          let fname = loc.Location.loc_start.Lexing.pos_fname in
+          let loc =
+            if not (Filename.is_relative fname) then Some loc
+            else
+              match config.merlin.source_root with
+              | Some path ->
+                let file = Filename.concat path loc.loc_start.pos_fname in
+                Some (set_fname ~file loc)
+              | None -> begin
+                match Locate.find_source ~config loc fname with
+                | `Found (file, _) -> Some (set_fname ~file loc)
+                | `File_not_found msg ->
+                  log ~title:"occurrences" "%s" msg;
+                  None
+              end
+          in
+          Option.map loc ~f:(fun loc : Query_protocol.occurrence ->
+              { loc; is_stale = Staleness.is_stale staleness }))
     in
     let def_uid_is_in_current_unit =
       let uid_comp_unit = comp_unit_of_uid def_uid in
@@ -323,8 +381,11 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
       | _, [] -> `Included
       | _, l -> `Out_of_sync l
     in
-    if not def_uid_is_in_current_unit then { locs; status }
+    if not def_uid_is_in_current_unit then { occurrences; status }
     else
-      let locs = set_fname ~file:current_buffer_path def_loc :: locs in
-      { locs; status }
-  | None -> { locs = []; status = `No_def }
+      let definition_occurrence : Query_protocol.occurrence =
+        { loc = set_fname ~file:current_buffer_path def_loc; is_stale = false }
+      in
+      let occurrences = definition_occurrence :: occurrences in
+      { occurrences; status }
+  | None -> { occurrences = []; status = `No_def }

--- a/src/analysis/occurrences.mli
+++ b/src/analysis/occurrences.mli
@@ -1,5 +1,7 @@
 type t =
-  { locs : Warnings.loc list; status : Query_protocol.occurrences_status }
+  { occurrences : Query_protocol.occurrence list;
+    status : Query_protocol.occurrences_status
+  }
 
 val locs_of :
   config:Mconfig.t ->

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -488,8 +488,15 @@ let json_of_response (type a) (query : a t) (response : a) : json =
   | Findlib_list, strs -> `List (List.map ~f:Json.string strs)
   | Extension_list _, strs -> `List (List.map ~f:Json.string strs)
   | Path_list _, strs -> `List (List.map ~f:Json.string strs)
-  | Occurrences (_, scope), (locations, _project) ->
+  | Occurrences (_, scope), (occurrences, _project) ->
     let with_file = scope = `Project || scope = `Renaming in
-    `List (List.map locations ~f:(fun loc -> with_location ~with_file loc []))
+    `List
+      (List.map occurrences ~f:(fun occurrence ->
+           let without_location =
+             match occurrence.is_stale with
+             | true -> [ ("stale", Json.bool true) ]
+             | false -> []
+           in
+           with_location ~with_file occurrence.loc without_location))
   | Signature_help _, s -> json_of_signature_help s
   | Version, version -> `String version

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -492,11 +492,7 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     let with_file = scope = `Project || scope = `Renaming in
     `List
       (List.map occurrences ~f:(fun occurrence ->
-           let without_location =
-             match occurrence.is_stale with
-             | true -> [ ("stale", Json.bool true) ]
-             | false -> []
-           in
-           with_location ~with_file occurrence.loc without_location))
+           with_location ~with_file occurrence.loc
+             [ ("stale", Json.bool occurrence.is_stale) ]))
   | Signature_help _, s -> json_of_signature_help s
   | Version, version -> `String version

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -791,10 +791,10 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       Locate.log ~title:"reconstructed identifier" "%s" path;
       path
     in
-    let { Occurrences.locs; status } =
+    let { Occurrences.occurrences; status } =
       Occurrences.locs_of ~config ~env ~typer_result ~pos ~scope path
     in
-    (locs, status)
+    (occurrences, status)
   | Inlay_hints
       (start, stop, hint_let_binding, hint_pattern_binding, avoid_ghost_location)
     ->

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -129,6 +129,8 @@ type _ _bool = bool
 type occurrences_status =
   [ `Not_requested | `Out_of_sync of string list | `No_def | `Included ]
 
+type occurrence = { loc : Location.t; is_stale : bool }
+
 type _ t =
   | Type_expr (* *) : string * Msource.position -> string t
   | Type_enclosing (* *) :
@@ -213,7 +215,7 @@ type _ t =
   | Path_list : [ `Build | `Source ] -> string list t
   | Occurrences (* *) :
       [ `Ident_at of Msource.position ] * [ `Project | `Buffer | `Renaming ]
-      -> (Location.t list * occurrences_status) t
+      -> (occurrence list * occurrences_status) t
   | Signature_help : signature_help -> signature_help_result option t
       (** In current version, Merlin only uses the parameter [position] to answer
         signature_help queries. The additionnal parameters are described in the

--- a/src/index-format/granular_set.ml
+++ b/src/index-format/granular_set.ml
@@ -31,6 +31,7 @@ module type S = sig
   val iter : (elt -> unit) -> t -> unit
   val cardinal : t -> int
   val elements : t -> elt list
+  val fold : ('acc -> elt -> 'acc) -> 'acc -> t -> 'acc
   val schema :
     Granular_marshal.iter -> (Granular_marshal.iter -> elt -> unit) -> t -> unit
 end
@@ -234,12 +235,12 @@ module Make (Ord : Set.OrderedType) = struct
     | Empty -> 0
     | Node { l; r; _ } -> cardinal l + 1 + cardinal r
 
-  let rec elements_aux accu t =
+  let rec fold f acc t =
     match fetch t with
-    | Empty -> accu
-    | Node { l; v; r; _ } -> elements_aux (v :: elements_aux accu r) l
+    | Empty -> acc
+    | Node { l; v; r; _ } -> fold f (f (fold f acc r) v) l
 
-  let elements s = elements_aux [] s
+  let elements s = fold (fun acc v -> v :: acc) [] s
 
   let try_join l v r =
     if

--- a/src/index-format/granular_set.mli
+++ b/src/index-format/granular_set.mli
@@ -29,6 +29,7 @@ module type S = sig
   val iter : (elt -> unit) -> t -> unit
   val cardinal : t -> int
   val elements : t -> elt list
+  val fold : ('acc -> elt -> 'acc) -> 'acc -> t -> 'acc
   val schema :
     Granular_marshal.iter -> (Granular_marshal.iter -> elt -> unit) -> t -> unit
 end

--- a/tests/test-dirs/occurrences/basic.t/run.t
+++ b/tests/test-dirs/occurrences/basic.t/run.t
@@ -12,7 +12,8 @@ Test getting occurrences of a function arg:
         "end": {
           "line": 1,
           "col": 15
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -22,7 +23,8 @@ Test getting occurrences of a function arg:
         "end": {
           "line": 2,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -32,7 +34,8 @@ Test getting occurrences of a function arg:
         "end": {
           "line": 2,
           "col": 13
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -52,7 +55,8 @@ Test getting occurrences of a function arg annotated with a type:
         "end": {
           "line": 4,
           "col": 23
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -62,7 +66,8 @@ Test getting occurrences of a function arg annotated with a type:
         "end": {
           "line": 5,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -72,7 +77,8 @@ Test getting occurrences of a function arg annotated with a type:
         "end": {
           "line": 5,
           "col": 13
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -92,7 +98,8 @@ Test getting occurrences of a record pattern in a function arg:
         "end": {
           "line": 9,
           "col": 28
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -102,7 +109,8 @@ Test getting occurrences of a record pattern in a function arg:
         "end": {
           "line": 10,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -112,7 +120,8 @@ Test getting occurrences of a record pattern in a function arg:
         "end": {
           "line": 10,
           "col": 15
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -132,7 +141,8 @@ Test getting occurrences of a function arg then used in record literal:
         "end": {
           "line": 12,
           "col": 25
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -142,7 +152,8 @@ Test getting occurrences of a function arg then used in record literal:
         "end": {
           "line": 13,
           "col": 14
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -162,7 +173,8 @@ Test getting occurrences of a function arg then used in record literal punned:
         "end": {
           "line": 15,
           "col": 33
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -172,7 +184,8 @@ Test getting occurrences of a function arg then used in record literal punned:
         "end": {
           "line": 16,
           "col": 8
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -192,7 +205,8 @@ Test getting occurrences of a function arg alias then used in record literal:
         "end": {
           "line": 18,
           "col": 27
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -202,7 +216,8 @@ Test getting occurrences of a function arg alias then used in record literal:
         "end": {
           "line": 19,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -212,7 +227,8 @@ Test getting occurrences of a function arg alias then used in record literal:
         "end": {
           "line": 19,
           "col": 11
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/ext-variant.t
+++ b/tests/test-dirs/occurrences/ext-variant.t
@@ -20,7 +20,8 @@ See issue #1185 on vscode-ocaml-platform
       "end": {
         "line": 2,
         "col": 11
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -30,7 +31,8 @@ See issue #1185 on vscode-ocaml-platform
       "end": {
         "line": 5,
         "col": 3
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -56,7 +58,8 @@ FIXME: we can do better than that
       "end": {
         "line": 2,
         "col": 11
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -66,7 +69,8 @@ FIXME: we can do better than that
       "end": {
         "line": 5,
         "col": 3
-      }
+      },
+      "stale": false
     }
   ]
 

--- a/tests/test-dirs/occurrences/issue1398.t/run.t
+++ b/tests/test-dirs/occurrences/issue1398.t/run.t
@@ -11,7 +11,8 @@ Test finding occurrences of let-based binding operator, from reified syntax:
         "end": {
           "line": 1,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -21,7 +22,8 @@ Test finding occurrences of let-based binding operator, from reified syntax:
         "end": {
           "line": 3,
           "col": 17
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -31,7 +33,8 @@ Test finding occurrences of let-based binding operator, from reified syntax:
         "end": {
           "line": 4,
           "col": 5
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -51,7 +54,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 2,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -61,7 +65,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 3,
           "col": 26
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -71,7 +76,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 4,
           "col": 17
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -89,7 +95,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 1,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -99,7 +106,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 3,
           "col": 17
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -109,7 +117,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 4,
           "col": 5
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -127,7 +136,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 2,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -137,7 +147,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 3,
           "col": 26
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -147,7 +158,8 @@ Test finding occurrences of and-based binding operator, from reified syntax:
         "end": {
           "line": 4,
           "col": 17
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/issue1404.t
+++ b/tests/test-dirs/occurrences/issue1404.t
@@ -16,7 +16,8 @@ occurrences identifier-at 2:0 returns the occurrences of [x]
       "end": {
         "line": 1,
         "col": 5
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -26,7 +27,8 @@ occurrences identifier-at 2:0 returns the occurrences of [x]
       "end": {
         "line": 2,
         "col": 1
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -45,7 +47,8 @@ occurrences identifier-at 2:1 returns the occurrences of [+]
       "end": {
         "line": 1,
         "col": 21
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -55,7 +58,8 @@ occurrences identifier-at 2:1 returns the occurrences of [+]
       "end": {
         "line": 2,
         "col": 2
-      }
+      },
+      "stale": false
     }
   ]
 

--- a/tests/test-dirs/occurrences/issue1410.t
+++ b/tests/test-dirs/occurrences/issue1410.t
@@ -13,7 +13,8 @@
       "end": {
         "line": 3,
         "col": 4
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -32,6 +33,7 @@
       "end": {
         "line": 3,
         "col": 4
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/issue827.t/run.t
+++ b/tests/test-dirs/occurrences/issue827.t/run.t
@@ -12,7 +12,8 @@ Reproduction case:
         "end": {
           "line": 2,
           "col": 15
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -22,7 +23,8 @@ Reproduction case:
         "end": {
           "line": 4,
           "col": 12
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -40,7 +42,8 @@ Reproduction case:
         "end": {
           "line": 2,
           "col": 20
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -50,7 +53,8 @@ Reproduction case:
         "end": {
           "line": 5,
           "col": 24
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -71,7 +75,8 @@ work:
         "end": {
           "line": 2,
           "col": 15
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -81,7 +86,8 @@ work:
         "end": {
           "line": 4,
           "col": 12
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -99,7 +105,8 @@ work:
         "end": {
           "line": 2,
           "col": 20
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -109,7 +116,8 @@ work:
         "end": {
           "line": 5,
           "col": 24
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/lid-locs.t
+++ b/tests/test-dirs/occurrences/lid-locs.t
@@ -25,7 +25,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 2,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -35,7 +36,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 4,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -45,7 +47,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 5,
           "col": 12
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -55,7 +58,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 6,
           "col": 13
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -65,7 +69,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 7,
           "col": 15
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -75,7 +80,8 @@ The parenthesis are typed as an open statement
         "end": {
           "line": 9,
           "col": 3
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -107,7 +113,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 2,
           "col": 10
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -117,7 +124,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 4,
           "col": 14
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -127,7 +135,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 5,
           "col": 16
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -137,7 +146,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 6,
           "col": 16
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -147,7 +157,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 8,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -157,7 +168,8 @@ We don't have enough information to safely shrink the enclosing
         "end": {
           "line": 9,
           "col": 28
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -187,7 +199,8 @@ Same for an ident that requires both parenthesis and spaces:
         "end": {
           "line": 2,
           "col": 11
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -197,7 +210,8 @@ Same for an ident that requires both parenthesis and spaces:
         "end": {
           "line": 4,
           "col": 15
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -207,7 +221,8 @@ Same for an ident that requires both parenthesis and spaces:
         "end": {
           "line": 5,
           "col": 17
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -217,7 +232,8 @@ Same for an ident that requires both parenthesis and spaces:
         "end": {
           "line": 6,
           "col": 14
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -227,7 +243,8 @@ Same for an ident that requires both parenthesis and spaces:
         "end": {
           "line": 8,
           "col": 4
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/mod-in-path-2.t
+++ b/tests/test-dirs/occurrences/mod-in-path-2.t
@@ -19,7 +19,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 1,
         "col": 10
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -34,7 +35,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 2,
         "col": 12
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -44,7 +46,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 5,
         "col": 13
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -54,6 +57,7 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 6,
         "col": 9
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/mod-in-path-3.t
+++ b/tests/test-dirs/occurrences/mod-in-path-3.t
@@ -20,7 +20,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 1,
         "col": 10
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -35,7 +36,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 2,
         "col": 12
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -45,7 +47,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 4,
         "col": 13
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -55,7 +58,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 7,
         "col": 9
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -70,7 +74,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 2,
         "col": 21
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -80,7 +85,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 4,
         "col": 19
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -90,6 +96,7 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 7,
         "col": 20
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/mod-in-path.t
+++ b/tests/test-dirs/occurrences/mod-in-path.t
@@ -25,7 +25,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 2,
         "col": 12
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -41,7 +42,8 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 1,
         "col": 10
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -51,6 +53,7 @@ FIXME: we could expect module appearing in paths to be highlighted
       "end": {
         "line": 12,
         "col": 20
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/no-def-mli-only.t
+++ b/tests/test-dirs/occurrences/no-def-mli-only.t
@@ -30,7 +30,8 @@ We still expect occurrences of definitions in hidden source files to work
         "end": {
           "line": 1,
           "col": 14
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -40,7 +41,8 @@ We still expect occurrences of definitions in hidden source files to work
         "end": {
           "line": 2,
           "col": 14
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/occ-types.t
+++ b/tests/test-dirs/occurrences/occ-types.t
@@ -13,7 +13,8 @@
       "end": {
         "line": 1,
         "col": 6
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -23,7 +24,8 @@
       "end": {
         "line": 2,
         "col": 10
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -40,7 +42,8 @@
       "end": {
         "line": 1,
         "col": 19
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -50,7 +53,8 @@
       "end": {
         "line": 1,
         "col": 29
-      }
+      },
+      "stale": false
     },
     {
       "start": {
@@ -60,6 +64,7 @@
       "end": {
         "line": 1,
         "col": 49
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/pattern.t
+++ b/tests/test-dirs/occurrences/pattern.t
@@ -19,7 +19,8 @@ This test demonstrates the handling of location of patterns. For a pattern like
         "end": {
           "line": 3,
           "col": 13
-        }
+        },
+        "stale": false
       },
       {
         "start": {
@@ -29,7 +30,8 @@ This test demonstrates the handling of location of patterns. For a pattern like
         "end": {
           "line": 3,
           "col": 21
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/project-wide/for-renaming/r-modules-and-types.t
+++ b/tests/test-dirs/occurrences/project-wide/for-renaming/r-modules-and-types.t
@@ -50,7 +50,8 @@
         "end": {
           "line": 2,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/lib.ml",
@@ -61,7 +62,8 @@
         "end": {
           "line": 2,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/lib.mli",
@@ -72,7 +74,8 @@
         "end": {
           "line": 2,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -83,7 +86,8 @@
         "end": {
           "line": 4,
           "col": 12
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
+++ b/tests/test-dirs/occurrences/project-wide/mli-vs-ml.t
@@ -44,7 +44,8 @@ the interface and the implementation.
         "end": {
           "line": 1,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -55,7 +56,8 @@ the interface and the implementation.
         "end": {
           "line": 2,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -66,7 +68,8 @@ the interface and the implementation.
         "end": {
           "line": 3,
           "col": 9
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.mli",
@@ -77,7 +80,8 @@ the interface and the implementation.
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -99,7 +103,8 @@ Same when the cursor is at the origin:
         "end": {
           "line": 1,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -110,7 +115,8 @@ Same when the cursor is at the origin:
         "end": {
           "line": 2,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -121,7 +127,8 @@ Same when the cursor is at the origin:
         "end": {
           "line": 3,
           "col": 9
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.mli",
@@ -132,7 +139,8 @@ Same when the cursor is at the origin:
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -154,7 +162,8 @@ It also works when querying for t from the implementation:
         "end": {
           "line": 2,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -165,7 +174,8 @@ It also works when querying for t from the implementation:
         "end": {
           "line": 3,
           "col": 9
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.mli",
@@ -176,7 +186,8 @@ It also works when querying for t from the implementation:
         "end": {
           "line": 1,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.mli",
@@ -187,7 +198,8 @@ It also works when querying for t from the implementation:
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -210,7 +222,8 @@ It also works when querying for x from the implementation:
         "end": {
           "line": 1,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.mli",
@@ -221,7 +234,8 @@ It also works when querying for x from the implementation:
         "end": {
           "line": 2,
           "col": 5
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -243,7 +257,8 @@ It also works when querying for x from the interface:
         "end": {
           "line": 2,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -254,7 +269,8 @@ It also works when querying for x from the interface:
         "end": {
           "line": 1,
           "col": 5
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -287,7 +303,8 @@ get confused if both identifers are the same.
         "end": {
           "line": 1,
           "col": 6
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -298,7 +315,8 @@ get confused if both identifers are the same.
         "end": {
           "line": 3,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/project-wide/prefix.t/run.t
+++ b/tests/test-dirs/occurrences/project-wide/prefix.t/run.t
@@ -56,7 +56,8 @@ Merlin fails to find occurrences outside of file because of the module prefixes
         "end": {
           "line": 1,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/b.ml",
@@ -67,7 +68,8 @@ Merlin fails to find occurrences outside of file because of the module prefixes
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -93,7 +95,8 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "end": {
           "line": 1,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/a.ml",
@@ -104,7 +107,8 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "end": {
           "line": 1,
           "col": 13
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/a.ml",
@@ -115,7 +119,8 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "end": {
           "line": 2,
           "col": 19
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/b.ml",
@@ -126,7 +131,8 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []
@@ -152,7 +158,8 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "end": {
           "line": 1,
           "col": 5
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/a.ml",
@@ -163,7 +170,8 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "end": {
           "line": 1,
           "col": 13
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/a.ml",
@@ -174,7 +182,8 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "end": {
           "line": 2,
           "col": 19
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/b.ml",
@@ -185,7 +194,8 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "end": {
           "line": 2,
           "col": 9
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/project-wide/pwo-basic.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-basic.t
@@ -37,7 +37,8 @@
         "end": {
           "line": 1,
           "col": 7
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/lib.ml",
@@ -48,7 +49,8 @@
         "end": {
           "line": 2,
           "col": 25
-        }
+        },
+        "stale": false
       },
       {
         "file": "$TESTCASE_ROOT/main.ml",
@@ -59,7 +61,8 @@
         "end": {
           "line": 1,
           "col": 29
-        }
+        },
+        "stale": false
       }
     ],
     "notifications": []

--- a/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
@@ -27,7 +27,8 @@
       "end": {
         "line": 1,
         "col": 7
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/lib.ml",
@@ -38,7 +39,8 @@
       "end": {
         "line": 2,
         "col": 25
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main.ml",
@@ -49,6 +51,7 @@
       "end": {
         "line": 1,
         "col": 29
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/project-wide/pwo-relative.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-relative.t
@@ -58,7 +58,8 @@ Perform the occurrences query
       "end": {
         "line": 1,
         "col": 7
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/lib/foo.ml",
@@ -69,7 +70,8 @@ Perform the occurrences query
       "end": {
         "line": 2,
         "col": 25
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main/main.ml",
@@ -80,7 +82,8 @@ Perform the occurrences query
       "end": {
         "line": 1,
         "col": 15
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main/main.ml",
@@ -91,6 +94,7 @@ Perform the occurrences query
       "end": {
         "line": 2,
         "col": 29
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/occurrences/project-wide/stale-index.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index.t
@@ -16,22 +16,11 @@ Foo was defined on line 2 when the index was built, but is now defined on line 1
   > let foo = "bar"
   > EOF
 
-TODO: the occurrence on line 2 of lib.ml is stale
+TODO: Report the stale occurrence too
   $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
   > -index-file project.ocaml-index \
   > -filename main.ml < main.ml | jq .value
   [
-    {
-      "file": "$TESTCASE_ROOT/lib.ml",
-      "start": {
-        "line": 2,
-        "col": 4
-      },
-      "end": {
-        "line": 2,
-        "col": 7
-      }
-    },
     {
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {

--- a/tests/test-dirs/occurrences/project-wide/stale-index.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index.t
@@ -1,0 +1,46 @@
+  $ cat >lib.ml <<'EOF'
+  > (* blah *)
+  > let foo = "bar"
+  > EOF
+
+  $ cat >main.ml <<'EOF'
+  > let () = print_string Lib.foo
+  > EOF
+
+  $ $OCAMLC -bin-annot -bin-annot-occurrences -c lib.ml main.ml
+
+  $ ocaml-index aggregate main.cmt lib.cmt
+
+Foo was defined on line 2 when the index was built, but is now defined on line 1
+  $ cat >lib.ml <<'EOF'
+  > let foo = "bar"
+  > EOF
+
+TODO: the occurrence on line 2 of lib.ml is stale
+  $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
+  > -index-file project.ocaml-index \
+  > -filename main.ml < main.ml | jq .value
+  [
+    {
+      "file": "$TESTCASE_ROOT/lib.ml",
+      "start": {
+        "line": 2,
+        "col": 4
+      },
+      "end": {
+        "line": 2,
+        "col": 7
+      }
+    },
+    {
+      "file": "$TESTCASE_ROOT/main.ml",
+      "start": {
+        "line": 1,
+        "col": 26
+      },
+      "end": {
+        "line": 1,
+        "col": 29
+      }
+    }
+  ]

--- a/tests/test-dirs/occurrences/project-wide/stale-index.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index.t
@@ -16,11 +16,22 @@ Foo was defined on line 2 when the index was built, but is now defined on line 1
   > let foo = "bar"
   > EOF
 
-TODO: Report the stale occurrence too
   $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
   > -index-file project.ocaml-index \
   > -filename main.ml < main.ml | jq .value
   [
+    {
+      "file": "$TESTCASE_ROOT/lib.ml",
+      "start": {
+        "line": 2,
+        "col": 4
+      },
+      "end": {
+        "line": 2,
+        "col": 7
+      },
+      "stale": true
+    },
     {
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {

--- a/tests/test-dirs/occurrences/project-wide/stale-index.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index.t
@@ -41,6 +41,7 @@ Foo was defined on line 2 when the index was built, but is now defined on line 1
       "end": {
         "line": 1,
         "col": 29
-      }
+      },
+      "stale": false
     }
   ]

--- a/tests/test-dirs/server-tests/pwo-uid-stability.t
+++ b/tests/test-dirs/server-tests/pwo-uid-stability.t
@@ -35,7 +35,8 @@
       "end": {
         "line": 3,
         "col": 5
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main.ml",
@@ -46,7 +47,8 @@
       "end": {
         "line": 1,
         "col": 14
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -83,7 +85,8 @@ We are not missing the occurrence in main.ml
       "end": {
         "line": 3,
         "col": 5
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main.ml",
@@ -94,7 +97,8 @@ We are not missing the occurrence in main.ml
       "end": {
         "line": 1,
         "col": 14
-      }
+      },
+      "stale": false
     }
   ]
 
@@ -129,7 +133,8 @@ We are not missing the occurrence in main.ml
       "end": {
         "line": 3,
         "col": 5
-      }
+      },
+      "stale": false
     },
     {
       "file": "$TESTCASE_ROOT/main.ml",
@@ -140,7 +145,8 @@ We are not missing the occurrence in main.ml
       "end": {
         "line": 1,
         "col": 14
-      }
+      },
+      "stale": false
     }
   ]
 


### PR DESCRIPTION
This PR does two things:
1. Fix a bug with Merlin's detection of stale occurrences. Currently, depending on the layout of a repository, Merlin may not line up file paths correctly.
2. Currently, Merlin discards any occurrences it thinks might be stale. This PR changes this so that the stale occurrences are reported, but flagged as being stale.

The net effect for an end user should be nothing - the stale occurrences should still be reported by their editor. But this enables future LSP/editor work.

The reason these two items are in the same PR is:
- Doing just (1) would result in stale occurrences no longer being reported at all.
- Doing just (2) would be hard to test.

I encourage reviewing commit-by-commit. The tests pass after each commit, and changes (1) and (2) are separated into separate commits.