### PR TITLE
Typer domain

### DIFF
--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -112,9 +112,7 @@ let run =
           let store = Mpipeline.Cache.get config in
           Local_store.open_store store;
           let source = Msource.make (Misc.string_of_file stdin) in
-          let pipeline =
-            Mpipeline.get ~state:(Mpipeline.Cache.get config) config source
-          in
+          let pipeline = Mpipeline.get config source in
           let json =
             let class_, message =
               Printexc.record_backtrace true;

--- a/src/kernel/mocaml.mli
+++ b/src/kernel/mocaml.mli
@@ -1,5 +1,5 @@
 (* An instance of load path, environment cache & btype unification log  *)
-type typer_state
+type typer_state = Local_store.store
 
 val new_state : unit -> typer_state
 val with_state : typer_state -> (unit -> 'a) -> 'a

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -4,23 +4,22 @@ let { Logger.log } = Logger.for_section "Pipeline"
 
 let time_shift = ref 0.0
 
-let timed_lazy r x =
-  lazy
-    (let start = Misc.time_spent () in
-     let time_shift0 = !time_shift in
-     let update () =
-       let delta = Misc.time_spent () -. start in
-       let shift = !time_shift -. time_shift0 in
-       time_shift := time_shift0 +. delta;
-       r := !r +. delta -. shift
-     in
-     match Lazy.force x with
-     | x ->
-       update ();
-       x
-     | exception exn ->
-       update ();
-       Std.reraise exn)
+let timed r x =
+  let start = Misc.time_spent () in
+  let time_shift0 = !time_shift in
+  let update () =
+    let delta = Misc.time_spent () -. start in
+    let shift = !time_shift -. time_shift0 in
+    time_shift := time_shift0 +. delta;
+    r := !r +. delta -. shift
+  in
+  match x () with
+  | x ->
+    update ();
+    x
+  | exception exn ->
+    update ();
+    Std.reraise exn
 
 module Cache = struct
   let cache = ref []
@@ -65,7 +64,7 @@ module Cache = struct
 end
 
 module Typer = struct
-  type t = { errors : exn list lazy_t; result : Mtyper.result }
+  type t = { errors : exn list; result : Mtyper.result }
 end
 
 module Ppx = struct
@@ -82,10 +81,10 @@ type t =
   { config : Mconfig.t;
     state : Mocaml.typer_state;
     raw_source : Msource.t;
-    source : (Msource.t * Mreader.parsetree option) lazy_t;
-    reader : Reader.t lazy_t;
-    ppx : Ppx.t lazy_t;
-    typer : Typer.t lazy_t;
+    source : Msource.t * Mreader.parsetree option;
+    reader : Reader.t;
+    ppx : Ppx.t;
+    typer : Typer.t;
     pp_time : float ref;
     reader_time : float ref;
     ppx_time : float ref;
@@ -99,7 +98,7 @@ type t =
 let raw_source t = t.raw_source
 
 let input_config t = t.config
-let input_source t = fst (Lazy.force t.source)
+let input_source t = fst t.source
 
 let with_pipeline t f =
   Mocaml.with_state t.state @@ fun () ->
@@ -110,10 +109,10 @@ let get_lexing_pos t pos =
     ~filename:(Mconfig.filename t.config)
     pos
 
-let reader t = Lazy.force t.reader
+let reader t = t.reader
 
-let ppx t = Lazy.force t.ppx
-let typer t = Lazy.force t.typer
+let ppx t = t.ppx
+let typer t = t.typer
 
 let reader_config t = (reader t).config
 let reader_parsetree t = (reader t).result.Mreader.parsetree
@@ -131,7 +130,7 @@ let ppx_errors t = (ppx t).Ppx.errors
 let final_config t = (ppx t).Ppx.config
 
 let typer_result t = (typer t).Typer.result
-let typer_errors t = Lazy.force (typer t).Typer.errors
+let typer_errors t = (typer t).Typer.errors
 
 module Reader_phase = struct
   type t =
@@ -230,9 +229,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
     | Some state -> state
   in
   let source =
-    timed_lazy pp_time
-      (lazy
-        (match Mconfig.(config.ocaml.pp) with
+    timed pp_time (fun () ->
+        match Mconfig.(config.ocaml.pp) with
         | None -> (raw_source, None)
         | Some { workdir; workval } -> (
           let source = Msource.text raw_source in
@@ -242,73 +240,67 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
               ~source ~pp:workval
           with
           | `Source source -> (Msource.make source, None)
-          | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast))))
+          | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast)))
   in
   let reader =
-    timed_lazy reader_time
-      (lazy
-        (let (lazy ((_, pp_result) as source)) = source in
-         let config = Mconfig.normalize config in
-         Mocaml.setup_reader_config config;
-         let cache_disabling =
-           match (config.merlin.use_ppx_cache, pp_result) with
-           | false, _ -> Some "configuration"
-           | true, Some _ ->
-             (* The cache could be refined in the future to also act on the
+    timed reader_time (fun () ->
+        let ((_, pp_result) as source) = source in
+        let config = Mconfig.normalize config in
+        Mocaml.setup_reader_config config;
+        let cache_disabling =
+          match (config.merlin.use_ppx_cache, pp_result) with
+          | false, _ -> Some "configuration"
+          | true, Some _ ->
+            (* The cache could be refined in the future to also act on the
                 PP phase. For now, let's disable the whole cache when there's
                 a PP. *)
-             Some "source preprocessor usage"
-           | true, None -> None
-         in
-         let { Reader_with_cache.output = { result; cache_version };
-               cache_was_hit
-             } =
-           Reader_with_cache.apply ~cache_disabling
-             { source; for_completion; config }
-         in
-         reader_cache_hit := cache_was_hit;
-         let cache_version =
-           if Option.is_some cache_disabling then None else Some cache_version
-         in
-         { Reader.result; config; cache_version }))
+            Some "source preprocessor usage"
+          | true, None -> None
+        in
+        let { Reader_with_cache.output = { result; cache_version };
+              cache_was_hit
+            } =
+          Reader_with_cache.apply ~cache_disabling
+            { source; for_completion; config }
+        in
+        reader_cache_hit := cache_was_hit;
+        let cache_version =
+          if Option.is_some cache_disabling then None else Some cache_version
+        in
+        { Reader.result; config; cache_version })
   in
   let ppx =
-    timed_lazy ppx_time
-      (lazy
-        (let (lazy
-               { Reader.result = { Mreader.parsetree; _ };
-                 config;
-                 cache_version
-               }) =
-           reader
-         in
-         let caught = ref [] in
-         Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught
-         @@ fun () ->
-         (* Currently the cache is invalidated even for source changes that don't
+    timed ppx_time (fun () ->
+        let { Reader.result = { Mreader.parsetree; _ }; config; cache_version }
+            =
+          reader
+        in
+        let caught = ref [] in
+        Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught
+        @@ fun () ->
+        (* Currently the cache is invalidated even for source changes that don't
              change the parsetree. To avoid that, we'd have to digest the
              parsetree in the cache. *)
-         let cache_disabling, reader_cache =
-           match cache_version with
-           | Some v -> (None, Ppx_phase.Version v)
-           | None -> (Some "reader cache is disabled", Off)
-         in
-         let { Ppx_with_cache.output = parsetree; cache_was_hit } =
-           Ppx_with_cache.apply ~cache_disabling
-             { parsetree; config; reader_cache }
-         in
-         ppx_cache_hit := cache_was_hit;
-         { Ppx.config; parsetree; errors = !caught }))
+        let cache_disabling, reader_cache =
+          match cache_version with
+          | Some v -> (None, Ppx_phase.Version v)
+          | None -> (Some "reader cache is disabled", Off)
+        in
+        let { Ppx_with_cache.output = parsetree; cache_was_hit } =
+          Ppx_with_cache.apply ~cache_disabling
+            { parsetree; config; reader_cache }
+        in
+        ppx_cache_hit := cache_was_hit;
+        { Ppx.config; parsetree; errors = !caught })
   in
   let typer =
-    timed_lazy typer_time
-      (lazy
-        (let (lazy { Ppx.config; parsetree; _ }) = ppx in
-         Mocaml.setup_typer_config config;
-         let result = Mtyper.run config parsetree in
-         let errors = timed_lazy error_time (lazy (Mtyper.get_errors result)) in
-         typer_cache_stats := Mtyper.get_cache_stat result;
-         { Typer.errors; result }))
+    timed typer_time (fun () ->
+        let { Ppx.config; parsetree; _ } = ppx in
+        Mocaml.setup_typer_config config;
+        let result = Mtyper.run config parsetree in
+        let errors = timed error_time (fun () -> Mtyper.get_errors result) in
+        typer_cache_stats := Mtyper.get_cache_stat result;
+        { Typer.errors; result })
   in
   { config;
     state;

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -329,6 +329,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
 
 let make config source = process (Mconfig.normalize config) source
 
+let get ?state config source = process ?state (Mconfig.normalize config) source
+
 let for_completion position
     { config;
       state;

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -1,6 +1,6 @@
 type t
 val make : Mconfig.t -> Msource.t -> t
-val get : ?state:Mocaml.typer_state -> Mconfig.t -> Msource.t -> t
+val get : Mconfig.t -> Msource.t -> t
 
 val with_pipeline : t -> (unit -> 'a) -> 'a
 val for_completion : Msource.position -> t -> t
@@ -33,3 +33,7 @@ val cache_information : t -> Std.json
 module Cache : sig
   val get : Mconfig.t -> Mocaml.typer_state
 end
+
+val close_typer : [ `True | `False | `Exn of exn ] Atomic.t
+
+val domain_typer : unit -> unit

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -1,5 +1,7 @@
 type t
 val make : Mconfig.t -> Msource.t -> t
+val get : ?state:Mocaml.typer_state -> Mconfig.t -> Msource.t -> t
+
 val with_pipeline : t -> (unit -> 'a) -> 'a
 val for_completion : Msource.position -> t -> t
 
@@ -27,3 +29,7 @@ val typer_errors : t -> exn list
 
 val timing_information : t -> (string * float) list
 val cache_information : t -> Std.json
+
+module Cache : sig
+  val get : Mconfig.t -> Mocaml.typer_state
+end

--- a/src/ocaml/utils/local_store.ml
+++ b/src/ocaml/utils/local_store.ml
@@ -57,3 +57,12 @@ let with_store slots f =
     List.iter (fun (Slot s) -> s.value <- !(s.ref)) slots;
     global_bindings.is_bound <- false;
   )
+
+  let open_store slots = 
+    assert (not global_bindings.is_bound);
+    global_bindings.is_bound <- true;
+    List.iter (fun (Slot {ref;value}) -> ref := value) slots
+
+   let close_store slots = 
+    List.iter (fun (Slot s) -> s.value <- !(s.ref)) slots;
+    global_bindings.is_bound <- false    

--- a/src/ocaml/utils/local_store.mli
+++ b/src/ocaml/utils/local_store.mli
@@ -65,3 +65,7 @@ val reset : unit -> unit
 val is_bound : unit -> bool
 (** Returns [true] when a store is active (i.e. when called from the callback
     passed to {!with_store}), [false] otherwise. *)
+
+val open_store : store -> unit
+
+val close_store : store -> unit


### PR DESCRIPTION
## Purposes
This PR is a first draft to experiment with a typer domain, i.e., a dedicated domain that performs typing computations (partially) in parallel with the main domain, which manages the server and analyzes the results. The final implementation should also support:
- Partial typing: The typer domain provides a partial typing result to the main domain, then completes the computation.
- Interruption handling: The main domain can stop the typer when a new request invalidates the previous one

### Current Changes

For now, this PR introduces the following modifications:
- Removal of laziness, which is incompatible with concurrency.
- Extension of the`Local_store` scope to support computations in both domains.
- Spawning of a typer domain to execute typing concurrently.

##  Design Notes & Expected Changes
### Laziness  
As noted in the  [Lazy module documentation](https://ocaml.org/manual/5.1/api/Lazy.html):

> Note: Lazy.force is not concurrency-safe. If you use this module with multiple fibers, systhreads or domains, then you will need to add some locks. The module however ensures memory-safety, and hence, concurrently accessing this module will not lead to a crash but the behavior is unspecified.

Since laziness is inherently unsafe in a multicore context, it has been removed. However, this introduces new bugs as some previously deferred computations now run eagerly:
- The `local_store` scope must be carefully extended.
- At least one exception is currently not properly caught.  

These issues are not currently resolved.

### Local Store Management  

Most computation must take place when the `local_store` is `bound`. Previously, all computations were enclosed within `Local_store.with_store` (via `Mocaml.with_state`). However, this approach is not compatible with computations involving two domains.

To address this, `with_store` has been replaced with `open_store` and `close_store`, allowing more flexible management of the store’s scope.

This design is likely to evolve further, particularly to enable proper interruption of the typer when needed.

### Concurrency with the Typer Domain  

Currently, concurrency is handled using atomic top-level values, which rely on active polling. This approach will likely be replaced (at least partially) with mutexes and conditions variables, allowing the domains to perform passive waiting instead. 

## Credits
This preliminary work was done with @voodoos and @xvw.
