### PR TITLE
Inlay hints: traverse ghost locations

### DIFF
--- a/src/analysis/inlay_hints.ml
+++ b/src/analysis/inlay_hints.ml
@@ -4,6 +4,8 @@ let { Logger.log } = Logger.for_section "inlay-hints"
 
 module Iterator = Ocaml_typing.Tast_iterator
 
+let is_ghost_location avoid_ghost loc = loc.Location.loc_ghost && avoid_ghost
+
 let pattern_has_constraint (type a) (pattern : a Typedtree.general_pattern) =
   List.exists
     ~f:(fun (extra, _, _) ->
@@ -14,8 +16,8 @@ let pattern_has_constraint (type a) (pattern : a Typedtree.general_pattern) =
       | Typedtree.Tpat_unpack -> false)
     pattern.pat_extra
 
-let structure_iterator hint_let_binding hint_pattern_binding typedtree range
-    callback =
+let structure_iterator hint_let_binding hint_pattern_binding
+    avoid_ghost_location typedtree range callback =
   let case_iterator hint_lhs (iterator : Iterator.iterator) case =
     let () = log ~title:"case" "on case" in
     let () = if hint_lhs then iterator.pat iterator case.Typedtree.c_lhs in
@@ -82,6 +84,10 @@ let structure_iterator hint_let_binding hint_pattern_binding typedtree range
     if Location_aux.overlap_with_range range item.Typedtree.str_loc then
       let () = log ~title:"structure_item" "overlap" in
       match item.str_desc with
+      | _ when is_ghost_location avoid_ghost_location item.str_loc ->
+        (* Stop iterating when we see a ghost location to avoid
+           annotating generated code *)
+        log ~title:"ghost" "ghost-location found"
       | Tstr_value (_, bindings) ->
         List.iter
           ~f:(fun binding -> expr_iterator iterator binding.Typedtree.vb_expr)
@@ -141,16 +147,15 @@ let of_structure ~hint_let_binding ~hint_pattern_binding ~avoid_ghost_location
   let range = (start, stop) in
   let hints = ref [] in
   let () =
-    structure_iterator hint_let_binding hint_pattern_binding structure range
-      (fun env typ loc ->
+    structure_iterator hint_let_binding hint_pattern_binding
+      avoid_ghost_location structure range (fun env typ loc ->
         let () =
           log ~title:"hint" "Find hint %a" Logger.fmt (fun fmt ->
               Format.fprintf fmt "%s - %a"
                 (Location_aux.print () loc)
                 Printtyp.type_expr typ)
         in
-        if not (loc.Location.loc_ghost && avoid_ghost_location) then
-          let hint = create_hint env typ loc in
-          hints := hint :: !hints)
+        let hint = create_hint env typ loc in
+        hints := hint :: !hints)
   in
   !hints

--- a/tests/test-dirs/inlay-hint/samples.t
+++ b/tests/test-dirs/inlay-hint/samples.t
@@ -1,6 +1,6 @@
 Optional argument
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location true \
   > -filename inlay.ml <<EOF
   > let f ?x () = x ()
   > EOF
@@ -20,7 +20,7 @@ Optional argument
 
 Optional argument with value
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location true \
   > -filename inlay.ml <<EOF
   > let f ?(x = 1) () = x
   > EOF
@@ -40,7 +40,7 @@ Optional argument with value
 
 Labeled argument
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location true \
   > -filename inlay.ml <<EOF
   > let f ~x = x + 1
   > EOF
@@ -60,7 +60,7 @@ Labeled argument
 
 Case argument
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 2:26 -avoid-ghost-location true \
   > -filename inlay.ml <<EOF
   > let f (Some x) = x + 1
   > EOF
@@ -80,7 +80,7 @@ Case argument
 
 Pattern variables without pattern-binding hint
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location true \
   > -filename inlay.ml <<EOF
   > let f x =
   >   match x with
@@ -103,7 +103,7 @@ Pattern variables without pattern-binding hint
 
 Pattern variables with pattern-binding hint
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location true \
   > -pattern-binding true \
   > -filename inlay.ml <<EOF
   > let f x =
@@ -135,7 +135,7 @@ Pattern variables with pattern-binding hint
 
 Let bindings without let hinting
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location true \
   > -let-binding false \
   > -filename inlay.ml <<EOF
   > let f () = let y = 0 in y
@@ -149,7 +149,7 @@ Let bindings without let hinting
 
 Let bindings with let hinting
 
-  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location false \
+  $ $MERLIN single inlay-hints -start 1:0 -end 4:26 -avoid-ghost-location true \
   > -let-binding true \
   > -filename inlay.ml <<EOF
   > let f () = let y = 0 in y


### PR DESCRIPTION
# Description  

Consider the following code:  

```ocaml
let f = fun x -> x ^ ""
let g _ = fun x -> x ^ ""
```  

In this case, an inlay hint appears for `x` in `f`, but no hint is shown for `g`.  

In VS Code, this results in the following display:  
![image](https://github.com/user-attachments/assets/721014a6-7842-415c-8f3e-dd38e57722fd)  

### Issue  

The inlay hints implementation includes logic to stop traversing "ghost locations" to avoid annotating generated code. However, a simple definition like:  

```ocaml
let f x = ...
```  

is syntactic sugar for:  

```ocaml
let f = fun x -> ...
```  

where `fun x ->` introduces a ghost location. This explains why the ghost location check had to be explicitly disabled in your test.  

### Proposed Fix  

This PR modifies the traversal logic to allow ghost locations even if they originate from "generated code." Instead of blocking traversal, ghost locations are filtered when generating inlay hints.  
