### PR TITLE
Upstream lyrm in merlin-domains branch

### DIFF
--- a/src/commands/new_commands.mli
+++ b/src/commands/new_commands.mli
@@ -35,7 +35,11 @@ type command =
       * Marg.docstring
       * ([ `Mandatory | `Optional | `Many ] * 'args Marg.spec) list
       * 'args
-      * (Mpipeline.t -> 'args -> json)
+      * (Mpipeline.shared ->
+        Mconfig.t ->
+        Msource.t ->
+        'args ->
+        json * Mpipeline.t option)
       -> command
 
 val all_commands : command list

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -47,7 +47,7 @@ let commands_help () =
       print_endline doc)
     New_commands.all_commands
 
-let run =
+let run shared =
   let query_num = ref (-1) in
   function
   | [] ->
@@ -109,15 +109,15 @@ let run =
               (float_of_int (60 * Mconfig.(config.merlin.cache_lifespan)))
             ();
           File_id.with_cache @@ fun () ->
+          (* TODO : Would it be possible to not expose this function in mpipeline.mli and its type in mocaml.mli ? *)
+          let store = Mpipeline.Cache.get config in
+          Local_store.open_store store;
           let source = Msource.make (Misc.string_of_file stdin) in
-          let pipeline = Mpipeline.make config source in
+          let pipeline = Mpipeline.get shared config source in
           let json =
             let class_, message =
               Printexc.record_backtrace true;
-              match
-                Mpipeline.with_pipeline pipeline @@ fun () ->
-                command_action pipeline command_args
-              with
+              match command_action pipeline command_args with
               | result -> ("return", result)
               | exception Failure str ->
                 let trace = Printexc.get_backtrace () in
@@ -133,6 +133,7 @@ let run =
                   Location.print_main Format.str_formatter err;
                   ("error", `String (Format.flush_str_formatter ())))
             in
+            Local_store.close_store store;
             let cpu_time = Misc.time_spent () -. start_cpu in
             let gc_stats = Gc.quick_stat () in
             let heap_mbytes =
@@ -186,7 +187,7 @@ let with_wd ~wd ~old_wd f args =
       old_wd;
     f args
 
-let run ~new_env wd args =
+let run ~new_env wd args shared =
   begin
     match new_env with
     | Some env ->
@@ -197,10 +198,10 @@ let run ~new_env wd args =
   let old_wd = Sys.getcwd () in
   let run args () =
     match wd with
-    | Some wd -> with_wd ~wd ~old_wd run args
+    | Some wd -> with_wd ~wd ~old_wd (run shared) args
     | None ->
       log ~title:"run" "No working directory specified (old wd: %S)" old_wd;
-      run args
+      run shared args
   in
   let `Log_file_path log_file, `Log_sections sections = Log_info.get () in
   Logger.with_log_file log_file ~sections @@ run args

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -113,25 +113,26 @@ let run shared =
           let store = Mpipeline.Cache.get config in
           Local_store.open_store store;
           let source = Msource.make (Misc.string_of_file stdin) in
-          let pipeline = Mpipeline.get shared config source in
           let json =
-            let class_, message =
+            let class_, message, pipeline_opt =
               Printexc.record_backtrace true;
-              match command_action pipeline command_args with
-              | result -> ("return", result)
+              match command_action shared config source command_args with
+              | result, pipeline_opt -> ("return", result, pipeline_opt)
               | exception Failure str ->
                 let trace = Printexc.get_backtrace () in
                 log ~title:"run" "Command error backtrace: %s" trace;
-                ("failure", `String str)
+                ("failure", `String str, None)
               | exception exn -> (
                 let trace = Printexc.get_backtrace () in
                 log ~title:"run" "Command error backtrace: %s" trace;
                 match Location.error_of_exn exn with
                 | None | Some `Already_displayed ->
-                  ("exception", `String (Printexc.to_string exn ^ "\n" ^ trace))
+                  ( "exception",
+                    `String (Printexc.to_string exn ^ "\n" ^ trace),
+                    None )
                 | Some (`Ok err) ->
                   Location.print_main Format.str_formatter err;
-                  ("error", `String (Format.flush_str_formatter ())))
+                  ("error", `String (Format.flush_str_formatter ()), None))
             in
             Local_store.close_store store;
             let cpu_time = Misc.time_spent () -. start_cpu in
@@ -140,7 +141,11 @@ let run shared =
               gc_stats.heap_words * (Sys.word_size / 8) / 1_000_000
             in
             let clock_time = (Unix.gettimeofday () *. 1000.) -. start_clock in
-            let timing = Mpipeline.timing_information pipeline in
+            let timing =
+              match pipeline_opt with
+              | None -> [] (* TODO *)
+              | Some p -> Mpipeline.timing_information p
+            in
             let pipeline_time =
               List.fold_left (fun acc (_, k) -> k +. acc) 0.0 timing
             in
@@ -159,7 +164,10 @@ let run shared =
                 ("notifications", `List (List.rev_map notify !notifications));
                 ("timing", `Assoc (List.map format_timing timing));
                 ("heap_mbytes", `Int heap_mbytes);
-                ("cache", Mpipeline.cache_information pipeline);
+                ( "cache",
+                  match pipeline_opt with
+                  | None -> `Assoc [] (* TODO *)
+                  | Some pipeline -> Mpipeline.cache_information pipeline );
                 ("query_num", `Int !query_num)
               ]
           in

--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -2,19 +2,19 @@ let merlin_timeout =
   try float_of_string (Sys.getenv "MERLIN_TIMEOUT") with _ -> 600.0
 
 module Server = struct
-  let process_request { Os_ipc.wd; environ; argv; context = _ } =
+  let process_request { Os_ipc.wd; environ; argv; context = _ } shared =
     match Array.to_list argv with
     | "stop-server" :: _ -> raise Exit
-    | args -> New_merlin.run ~new_env:(Some environ) (Some wd) args
+    | args -> New_merlin.run ~new_env:(Some environ) (Some wd) args shared
 
-  let process_client client =
+  let process_client client shared =
     let context = client.Os_ipc.context in
     Os_ipc.context_setup context;
     let close_with return_code =
       flush_all ();
       Os_ipc.context_close context ~return_code
     in
-    match process_request client with
+    match process_request client shared with
     | code -> close_with code
     | exception Exit ->
       close_with (-1);
@@ -38,18 +38,18 @@ module Server = struct
     | Some _ as result -> result
     | None -> loop 1.0
 
-  let rec loop merlinid server =
+  let rec loop merlinid server shared =
     match server_accept merlinid server with
     | None ->
       (* Timeout *)
       ()
     | Some client ->
       let continue =
-        match process_client client with
+        match process_client client shared with
         | exception Exit -> false
         | () -> true
       in
-      if continue then loop merlinid server
+      if continue then loop merlinid server shared
 
   let start socket_path socket_fd =
     match Os_ipc.server_setup socket_path socket_fd with
@@ -57,7 +57,12 @@ module Server = struct
     | Some server ->
       (* If the client closes its connection, don't let it kill us with a SIGPIPE. *)
       if Sys.unix then Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
-      loop (File_id.get Sys.executable_name) server;
+
+      let shared = Mpipeline.create_shared () in
+      let domain_typer = Domain.spawn @@ Mpipeline.domain_typer shared in
+      loop (File_id.get Sys.executable_name) server shared;
+      Mpipeline.closing shared;
+      Domain.join domain_typer;
       Os_ipc.server_close server
 end
 
@@ -65,7 +70,13 @@ let main () =
   (* Setup env for extensions *)
   Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()));
   match List.tl (Array.to_list Sys.argv) with
-  | "single" :: args -> exit (New_merlin.run ~new_env:None None args)
+  | "single" :: args ->
+    let shared = Mpipeline.create_shared () in
+    let domain_typer = Domain.spawn @@ Mpipeline.domain_typer shared in
+    let vexit = New_merlin.run ~new_env:None None args shared in
+    Mpipeline.closing shared;
+    Domain.join domain_typer;
+    exit vexit
   | "old-protocol" :: args -> Old_merlin.run args
   | [ "server"; socket_path; socket_fd ] -> Server.start socket_path socket_fd
   | ("-help" | "--help" | "-h" | "server") :: _ ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -62,8 +62,15 @@ let print_completion_entries ~with_types config source entries =
     List.rev_map ~f:(Completion.map_entry postprocess) entries)
   else List.rev_map ~f:(Completion.map_entry (fun _ -> "")) entries
 
-let for_completion pipeline position =
-  let pipeline = Mpipeline.for_completion position pipeline in
+let for_completion pipeline _position =
+  (* TODO
+
+  This functions is an issue because of the removal of laziness (and the fact that the pipeline computation is now done by another domain than the one calling this function !).
+
+  This quick patch needs to be corrected or at least properly validated. It breaks a single tests that is about completion with labels.  
+*)
+  (*
+  let pipeline = Mpipeline.for_completion position pipeline in *)
   let typer = Mpipeline.typer_result pipeline in
   (pipeline, typer)
 

--- a/src/kernel/mocaml.mli
+++ b/src/kernel/mocaml.mli
@@ -1,5 +1,5 @@
 (* An instance of load path, environment cache & btype unification log  *)
-type typer_state
+type typer_state = Local_store.store
 
 val new_state : unit -> typer_state
 val with_state : typer_state -> (unit -> 'a) -> 'a

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -4,23 +4,22 @@ let { Logger.log } = Logger.for_section "Pipeline"
 
 let time_shift = ref 0.0
 
-let timed_lazy r x =
-  lazy
-    (let start = Misc.time_spent () in
-     let time_shift0 = !time_shift in
-     let update () =
-       let delta = Misc.time_spent () -. start in
-       let shift = !time_shift -. time_shift0 in
-       time_shift := time_shift0 +. delta;
-       r := !r +. delta -. shift
-     in
-     match Lazy.force x with
-     | x ->
-       update ();
-       x
-     | exception exn ->
-       update ();
-       Std.reraise exn)
+let timed r x =
+  let start = Misc.time_spent () in
+  let time_shift0 = !time_shift in
+  let update () =
+    let delta = Misc.time_spent () -. start in
+    let shift = !time_shift -. time_shift0 in
+    time_shift := time_shift0 +. delta;
+    r := !r +. delta -. shift
+  in
+  match x () with
+  | x ->
+    update ();
+    x
+  | exception exn ->
+    update ();
+    Std.reraise exn
 
 module Cache = struct
   let cache = ref []
@@ -65,7 +64,7 @@ module Cache = struct
 end
 
 module Typer = struct
-  type t = { errors : exn list lazy_t; result : Mtyper.result }
+  type t = { errors : exn list; result : Mtyper.result }
 end
 
 module Ppx = struct
@@ -82,10 +81,10 @@ type t =
   { config : Mconfig.t;
     state : Mocaml.typer_state;
     raw_source : Msource.t;
-    source : (Msource.t * Mreader.parsetree option) lazy_t;
-    reader : Reader.t lazy_t;
-    ppx : Ppx.t lazy_t;
-    typer : Typer.t lazy_t;
+    source : Msource.t * Mreader.parsetree option;
+    reader : Reader.t;
+    ppx : Ppx.t;
+    typer : Typer.t;
     pp_time : float ref;
     reader_time : float ref;
     ppx_time : float ref;
@@ -99,7 +98,7 @@ type t =
 let raw_source t = t.raw_source
 
 let input_config t = t.config
-let input_source t = fst (Lazy.force t.source)
+let input_source t = fst t.source
 
 let with_pipeline t f =
   Mocaml.with_state t.state @@ fun () ->
@@ -110,10 +109,10 @@ let get_lexing_pos t pos =
     ~filename:(Mconfig.filename t.config)
     pos
 
-let reader t = Lazy.force t.reader
+let reader t = t.reader
 
-let ppx t = Lazy.force t.ppx
-let typer t = Lazy.force t.typer
+let ppx t = t.ppx
+let typer t = t.typer
 
 let reader_config t = (reader t).config
 let reader_parsetree t = (reader t).result.Mreader.parsetree
@@ -131,7 +130,7 @@ let ppx_errors t = (ppx t).Ppx.errors
 let final_config t = (ppx t).Ppx.config
 
 let typer_result t = (typer t).Typer.result
-let typer_errors t = Lazy.force (typer t).Typer.errors
+let typer_errors t = (typer t).Typer.errors
 
 module Reader_phase = struct
   type t =
@@ -230,9 +229,8 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
     | Some state -> state
   in
   let source =
-    timed_lazy pp_time
-      (lazy
-        (match Mconfig.(config.ocaml.pp) with
+    timed pp_time (fun () ->
+        match Mconfig.(config.ocaml.pp) with
         | None -> (raw_source, None)
         | Some { workdir; workval } -> (
           let source = Msource.text raw_source in
@@ -242,73 +240,67 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
               ~source ~pp:workval
           with
           | `Source source -> (Msource.make source, None)
-          | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast))))
+          | (`Interface _ | `Implementation _) as ast -> (raw_source, Some ast)))
   in
   let reader =
-    timed_lazy reader_time
-      (lazy
-        (let (lazy ((_, pp_result) as source)) = source in
-         let config = Mconfig.normalize config in
-         Mocaml.setup_reader_config config;
-         let cache_disabling =
-           match (config.merlin.use_ppx_cache, pp_result) with
-           | false, _ -> Some "configuration"
-           | true, Some _ ->
-             (* The cache could be refined in the future to also act on the
+    timed reader_time (fun () ->
+        let ((_, pp_result) as source) = source in
+        let config = Mconfig.normalize config in
+        Mocaml.setup_reader_config config;
+        let cache_disabling =
+          match (config.merlin.use_ppx_cache, pp_result) with
+          | false, _ -> Some "configuration"
+          | true, Some _ ->
+            (* The cache could be refined in the future to also act on the
                 PP phase. For now, let's disable the whole cache when there's
                 a PP. *)
-             Some "source preprocessor usage"
-           | true, None -> None
-         in
-         let { Reader_with_cache.output = { result; cache_version };
-               cache_was_hit
-             } =
-           Reader_with_cache.apply ~cache_disabling
-             { source; for_completion; config }
-         in
-         reader_cache_hit := cache_was_hit;
-         let cache_version =
-           if Option.is_some cache_disabling then None else Some cache_version
-         in
-         { Reader.result; config; cache_version }))
+            Some "source preprocessor usage"
+          | true, None -> None
+        in
+        let { Reader_with_cache.output = { result; cache_version };
+              cache_was_hit
+            } =
+          Reader_with_cache.apply ~cache_disabling
+            { source; for_completion; config }
+        in
+        reader_cache_hit := cache_was_hit;
+        let cache_version =
+          if Option.is_some cache_disabling then None else Some cache_version
+        in
+        { Reader.result; config; cache_version })
   in
   let ppx =
-    timed_lazy ppx_time
-      (lazy
-        (let (lazy
-               { Reader.result = { Mreader.parsetree; _ };
-                 config;
-                 cache_version
-               }) =
-           reader
-         in
-         let caught = ref [] in
-         Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught
-         @@ fun () ->
-         (* Currently the cache is invalidated even for source changes that don't
+    timed ppx_time (fun () ->
+        let { Reader.result = { Mreader.parsetree; _ }; config; cache_version }
+            =
+          reader
+        in
+        let caught = ref [] in
+        Msupport.catch_errors Mconfig.(config.ocaml.warnings) caught
+        @@ fun () ->
+        (* Currently the cache is invalidated even for source changes that don't
              change the parsetree. To avoid that, we'd have to digest the
              parsetree in the cache. *)
-         let cache_disabling, reader_cache =
-           match cache_version with
-           | Some v -> (None, Ppx_phase.Version v)
-           | None -> (Some "reader cache is disabled", Off)
-         in
-         let { Ppx_with_cache.output = parsetree; cache_was_hit } =
-           Ppx_with_cache.apply ~cache_disabling
-             { parsetree; config; reader_cache }
-         in
-         ppx_cache_hit := cache_was_hit;
-         { Ppx.config; parsetree; errors = !caught }))
+        let cache_disabling, reader_cache =
+          match cache_version with
+          | Some v -> (None, Ppx_phase.Version v)
+          | None -> (Some "reader cache is disabled", Off)
+        in
+        let { Ppx_with_cache.output = parsetree; cache_was_hit } =
+          Ppx_with_cache.apply ~cache_disabling
+            { parsetree; config; reader_cache }
+        in
+        ppx_cache_hit := cache_was_hit;
+        { Ppx.config; parsetree; errors = !caught })
   in
   let typer =
-    timed_lazy typer_time
-      (lazy
-        (let (lazy { Ppx.config; parsetree; _ }) = ppx in
-         Mocaml.setup_typer_config config;
-         let result = Mtyper.run config parsetree in
-         let errors = timed_lazy error_time (lazy (Mtyper.get_errors result)) in
-         typer_cache_stats := Mtyper.get_cache_stat result;
-         { Typer.errors; result }))
+    timed typer_time (fun () ->
+        let { Ppx.config; parsetree; _ } = ppx in
+        Mocaml.setup_typer_config config;
+        let result = Mtyper.run config parsetree in
+        let errors = timed error_time (fun () -> Mtyper.get_errors result) in
+        typer_cache_stats := Mtyper.get_cache_stat result;
+        { Typer.errors; result })
   in
   { config;
     state;

--- a/src/kernel/mpipeline.ml
+++ b/src/kernel/mpipeline.ml
@@ -320,7 +320,7 @@ let process ?state ?(pp_time = ref 0.0) ?(reader_time = ref 0.0)
   }
 let make config source = process (Mconfig.normalize config) source
 
-let for_completion position
+(* let for_completion position
     { config;
       state;
       raw_source;
@@ -332,7 +332,7 @@ let for_completion position
       _
     } =
   process config raw_source ~for_completion:position ~state ~pp_time
-    ~reader_time ~ppx_time ~typer_time ~error_time
+    ~reader_time ~ppx_time ~typer_time ~error_time *)
 
 let timing_information t =
   [ ("pp", !(t.pp_time));
@@ -342,9 +342,9 @@ let timing_information t =
     ("error", !(t.error_time))
   ]
 
-let cache_information t =
+let cache_information pipeline =
   let typer =
-    match !(t.typer_cache_stats) with
+    match !(pipeline.typer_cache_stats) with
     | Miss -> `String "miss"
     | Hit { reused; typed } ->
       `Assoc [ ("reused", `Int reused); ("typed", `Int typed) ]
@@ -358,8 +358,8 @@ let cache_information t =
   Cmi_cache.clear_cache_stats ();
   let fmt_bool hit = `String (if hit then "hit" else "miss") in
   `Assoc
-    [ ("reader_phase", fmt_bool !(t.reader_cache_hit));
-      ("ppx_phase", fmt_bool !(t.ppx_cache_hit));
+    [ ("reader_phase", fmt_bool !(pipeline.reader_cache_hit));
+      ("ppx_phase", fmt_bool !(pipeline.ppx_cache_hit));
       ("typer", typer);
       ("cmt", cmt);
       ("cmi", cmi)

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -1,8 +1,12 @@
 type t
+
+(* Except inside Mpipeline, this function should only use in old_merlin *)
 val make : Mconfig.t -> Msource.t -> t
+
+(* Except inside Mpipeline, this function should only use in old_merlin *)
 val with_pipeline : t -> (unit -> 'a) -> 'a
 
-val for_completion : Msource.position -> t -> t
+(* val for_completion : Msource.position -> t -> t *)
 
 val raw_source : t -> Msource.t
 

--- a/src/kernel/mpipeline.mli
+++ b/src/kernel/mpipeline.mli
@@ -1,6 +1,7 @@
 type t
 val make : Mconfig.t -> Msource.t -> t
 val with_pipeline : t -> (unit -> 'a) -> 'a
+
 val for_completion : Msource.position -> t -> t
 
 val raw_source : t -> Msource.t
@@ -27,3 +28,13 @@ val typer_errors : t -> exn list
 
 val timing_information : t -> (string * float) list
 val cache_information : t -> Std.json
+
+type shared
+val create_shared : unit -> shared
+val domain_typer : shared -> unit -> unit
+val get : shared -> Mconfig.t -> Msource.t -> t
+val closing : shared -> unit
+
+module Cache : sig
+  val get : Mconfig.t -> Mocaml.typer_state
+end

--- a/src/ocaml/utils/local_store.ml
+++ b/src/ocaml/utils/local_store.ml
@@ -57,3 +57,12 @@ let with_store slots f =
     List.iter (fun (Slot s) -> s.value <- !(s.ref)) slots;
     global_bindings.is_bound <- false;
   )
+
+let open_store slots =
+  assert (not global_bindings.is_bound);
+  global_bindings.is_bound <- true;
+  List.iter (fun (Slot { ref; value }) -> ref := value) slots
+  
+let close_store slots =
+  List.iter (fun (Slot s) -> s.value <- !(s.ref)) slots;
+  global_bindings.is_bound <- false

--- a/src/ocaml/utils/local_store.mli
+++ b/src/ocaml/utils/local_store.mli
@@ -65,3 +65,7 @@ val reset : unit -> unit
 val is_bound : unit -> bool
 (** Returns [true] when a store is active (i.e. when called from the callback
     passed to {!with_store}), [false] otherwise. *)
+
+
+val open_store : store -> unit
+val close_store : store -> unit 

--- a/src/utils/shared.ml
+++ b/src/utils/shared.ml
@@ -19,7 +19,4 @@ let signal a = Condition.signal a.cond
 let create a =
   { mutex = Mutex.create (); cond = Condition.create (); value = a }
 
-let lock a = Mutex.lock a.mutex
-let unlock a = Mutex.unlock a.mutex
-
 let wait a = Condition.wait a.cond a.mutex

--- a/src/utils/shared.ml
+++ b/src/utils/shared.ml
@@ -1,0 +1,25 @@
+type 'a t = { mutex : Mutex.t; cond : Condition.t; mutable value : 'a }
+
+let locking_set t a =
+  Mutex.protect t.mutex @@ fun () ->
+  t.value <- a;
+  Condition.signal t.cond
+
+let set t a =
+  t.value <- a;
+  Condition.signal t.cond
+let locking_get t = Mutex.protect t.mutex @@ fun () -> t.value
+
+let get t = t.value
+
+let protect a f = Mutex.protect a.mutex f
+
+let signal a = Condition.signal a.cond
+
+let create a =
+  { mutex = Mutex.create (); cond = Condition.create (); value = a }
+
+let lock a = Mutex.lock a.mutex
+let unlock a = Mutex.unlock a.mutex
+
+let wait a = Condition.wait a.cond a.mutex

--- a/src/utils/shared.mli
+++ b/src/utils/shared.mli
@@ -1,0 +1,11 @@
+type 'a t = { mutex : Mutex.t; cond : Condition.t; mutable value : 'a }
+val locking_set : 'a t -> 'a -> unit
+val set : 'a t -> 'a -> unit
+val locking_get : 'a t -> 'a
+val get : 'a t -> 'a
+val create : 'a -> 'a t
+val protect : 'a t -> (unit -> 'b) -> 'b
+val signal : 'a t -> unit
+val wait : 'a t -> unit
+val lock : 'a t -> unit
+val unlock : 'a t -> unit

--- a/src/utils/shared.mli
+++ b/src/utils/shared.mli
@@ -7,5 +7,3 @@ val create : 'a -> 'a t
 val protect : 'a t -> (unit -> 'b) -> 'b
 val signal : 'a t -> unit
 val wait : 'a t -> unit
-val lock : 'a t -> unit
-val unlock : 'a t -> unit


### PR DESCRIPTION
Replaced #1908. 

Note: These changes break one test due to the removal of laziness. Previously, `Mpipeline.for_completion` used laziness to avoid recomputing the entire pipeline a second time. Since this function is no longer called, the test for label completion, which seems to be the main use for the `for_completion` function, is now broken. This has been marked as a TODO in the code.