### PR TITLE
Handle object expression inside a let in outline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ unreleased
     - `inlay-hints` fix inlay hints on function parameters (#1923)
     - Fix issues with ident validation and Lid comparison for occurrences (#1924)
     - Handle class type in outline (#1932)
+    - Handle locally defined value in outline (#1936)
   + ocaml-index
     - Improve the granularity of index reading by segmenting the marshalization
       of the involved data-structures. (#1889)

--- a/src/analysis/outline.ml
+++ b/src/analysis/outline.ml
@@ -157,19 +157,8 @@ and get_val_elements node =
   match node.t_node with
   | Expression _ ->
     List.concat_map (Lazy.force node.t_children) ~f:get_val_elements
-  | Value_binding vb ->
-    let children =
-      List.concat_map (Lazy.force node.t_children) ~f:get_val_elements
-    in
-    let deprecated = Type_utils.is_deprecated vb.vb_attributes in
-    begin
-      match id_of_patt vb.vb_pat with
-      | None -> []
-      | Some ident ->
-        [ mk ~children ~location:node.t_loc ~deprecated `Value None ident ]
-    end
   | Class_expr _ | Class_structure _ -> get_class_elements node
-  | _ -> []
+  | _ -> Option.to_list (summarize node)
 
 and get_class_elements node =
   match node.t_node with

--- a/src/analysis/outline.ml
+++ b/src/analysis/outline.ml
@@ -48,11 +48,6 @@ let mk ?(children = []) ~location ~deprecated outline_kind outline_type id =
     deprecated
   }
 
-let get_class_field_desc_infos = function
-  | Typedtree.Tcf_val (str_loc, _, _, _, _) -> Some (str_loc, `Value)
-  | Typedtree.Tcf_method (str_loc, _, _) -> Some (str_loc, `Method)
-  | _ -> None
-
 let get_class_signature_field_desc_infos = function
   | Typedtree.Tctf_val (outline_name, _, _, _) -> Some (outline_name, `Value)
   | Typedtree.Tctf_method (outline_name, _, _, _) -> Some (outline_name, `Method)
@@ -69,13 +64,16 @@ let rec summarize node =
   let location = node.t_loc in
   match node.t_node with
   | Value_binding vb ->
+    let children =
+      List.concat_map (Lazy.force node.t_children) ~f:get_val_elements
+    in
     let deprecated = Type_utils.is_deprecated vb.vb_attributes in
     begin
       match id_of_patt vb.vb_pat with
       | None -> None
       | Some ident ->
         let typ = outline_type ~env:node.t_env vb.vb_pat.pat_type in
-        Some (mk ~location ~deprecated `Value typ ident)
+        Some (mk ~children ~location ~deprecated `Value typ ident)
     end
   | Value_description vd ->
     let deprecated = Type_utils.is_deprecated vd.val_attributes in
@@ -155,6 +153,24 @@ let rec summarize node =
       (mk ~children ~location `ClassType None ctd.ci_id_class_type ~deprecated)
   | _ -> None
 
+and get_val_elements node =
+  match node.t_node with
+  | Expression _ ->
+    List.concat_map (Lazy.force node.t_children) ~f:get_val_elements
+  | Value_binding vb ->
+    let children =
+      List.concat_map (Lazy.force node.t_children) ~f:get_val_elements
+    in
+    let deprecated = Type_utils.is_deprecated vb.vb_attributes in
+    begin
+      match id_of_patt vb.vb_pat with
+      | None -> []
+      | Some ident ->
+        [ mk ~children ~location:node.t_loc ~deprecated `Value None ident ]
+    end
+  | Class_expr _ | Class_structure _ -> get_class_elements node
+  | _ -> []
+
 and get_class_elements node =
   match node.t_node with
   | Class_expr _ ->
@@ -164,13 +180,13 @@ and get_class_elements node =
         match child.t_node with
         | Class_field cf -> begin
           cf.cf_desc |> get_class_field_desc_infos
-          |> Option.map ~f:(fun (str_loc, outline_kind) ->
+          |> Option.map ~f:(fun (str_loc, outline_kind, children) ->
                  let deprecated = Type_utils.is_deprecated cf.cf_attributes in
                  { Query_protocol.outline_name = str_loc.Location.txt;
                    outline_kind;
                    outline_type = None;
                    location = str_loc.Location.loc;
-                   children = [];
+                   children;
                    deprecated
                  })
         end
@@ -188,6 +204,43 @@ and get_class_elements node =
                  children = [];
                  deprecated
                }))
+  | _ -> []
+
+and get_class_field_desc_infos = function
+  | Typedtree.Tcf_val (str_loc, _, _, field_kind, _) ->
+    Some (str_loc, `Value, get_class_field_kind_elements field_kind)
+  | Typedtree.Tcf_method (str_loc, _, field_kind) ->
+    Some (str_loc, `Method, get_class_field_kind_elements field_kind)
+  | _ -> None
+
+and get_class_field_kind_elements = function
+  | Tcfk_virtual _ -> []
+  | Tcfk_concrete (_, expr) -> get_expr_elements expr
+
+and get_expr_elements expr =
+  match expr.exp_desc with
+  | Texp_let (_, vbs, expr) ->
+    List.filter_map vbs ~f:(fun vb ->
+        id_of_patt vb.vb_pat
+        |> Option.map ~f:(fun ident ->
+               let children = get_expr_elements vb.vb_expr in
+               let deprecated = Type_utils.is_deprecated vb.vb_attributes in
+
+               mk ~children ~location:vb.vb_loc ~deprecated `Value None ident))
+    @ get_expr_elements expr
+  | Texp_object ({ cstr_fields; _ }, _) ->
+    List.filter_map cstr_fields ~f:(fun field ->
+        field.cf_desc |> get_class_field_desc_infos
+        |> Option.map ~f:(fun (str_loc, outline_kind, children) ->
+               let deprecated = Type_utils.is_deprecated field.cf_attributes in
+               { Query_protocol.outline_name = str_loc.Location.txt;
+                 outline_kind;
+                 outline_type = None;
+                 location = str_loc.Location.loc;
+                 children;
+                 deprecated
+               }))
+  | Texp_function (_, Tfunction_body expr) -> get_expr_elements expr
   | _ -> []
 
 and get_mod_children node =

--- a/tests/test-dirs/outline.t/run.t
+++ b/tests/test-dirs/outline.t/run.t
@@ -27,7 +27,7 @@
             },
             "name": "c",
             "kind": "Value",
-            "type": null,
+            "type": "< foo : int >",
             "children": [
               {
                 "start": {
@@ -192,7 +192,7 @@
                     },
                     "name": "x_inside_a_b",
                     "kind": "Value",
-                    "type": null,
+                    "type": "int",
                     "children": [],
                     "deprecated": false
                   }

--- a/tests/test-dirs/outline.t/run.t
+++ b/tests/test-dirs/outline.t/run.t
@@ -15,7 +15,39 @@
         "name": "final_let",
         "kind": "Value",
         "type": "< foo : int >",
-        "children": [],
+        "children": [
+          {
+            "start": {
+              "line": 68,
+              "col": 2
+            },
+            "end": {
+              "line": 71,
+              "col": 7
+            },
+            "name": "c",
+            "kind": "Value",
+            "type": null,
+            "children": [
+              {
+                "start": {
+                  "line": 70,
+                  "col": 13
+                },
+                "end": {
+                  "line": 70,
+                  "col": 16
+                },
+                "name": "foo",
+                "kind": "Method",
+                "type": null,
+                "children": [],
+                "deprecated": false
+              }
+            ],
+            "deprecated": false
+          }
+        ],
         "deprecated": false
       },
       {
@@ -135,7 +167,39 @@
             "name": "b",
             "kind": "Value",
             "type": null,
-            "children": [],
+            "children": [
+              {
+                "start": {
+                  "line": 49,
+                  "col": 15
+                },
+                "end": {
+                  "line": 49,
+                  "col": 25
+                },
+                "name": "inside_a_b",
+                "kind": "Method",
+                "type": null,
+                "children": [
+                  {
+                    "start": {
+                      "line": 50,
+                      "col": 10
+                    },
+                    "end": {
+                      "line": 50,
+                      "col": 31
+                    },
+                    "name": "x_inside_a_b",
+                    "kind": "Value",
+                    "type": null,
+                    "children": [],
+                    "deprecated": false
+                  }
+                ],
+                "deprecated": false
+              }
+            ],
             "deprecated": false
           }
         ],


### PR DESCRIPTION
ocaml-lsp outline reports imbricated object inside let expression but merlin not. This fix aims to use merlin to generate outlines in ocaml-lsp without introduce regression in ocaml-lsp

The fix is ugly but I can refactor if needed.

cc @voodoos @xvw 