### PR TITLE
Add `locate_type_multi` query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 unreleased
 ==========
+  + merlin binary
+    - Add `locate-types` command (#1951)
   + merlin library
     - Fix `merlin_reader` for OpenBSD (#1956)
     - Improve recovery of mutually recursive definitions (#1962, #1963, fixes #1953)
@@ -30,7 +32,6 @@ Tue Jun 24 16:10:42 CEST 2025
       ocaml/ocaml-lsp#1489)
     - Reproduce and fix a handful of jump-to-definition (locate) issues  (#1930,
       fixes #1580 and #1588, workaround for #1934)
-    - Add `locate-types` command (#1951)
   + ocaml-index
     - Improve the granularity of index reading by segmenting the marshalization
       of the involved data-structures. (#1889)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Tue Jun 24 16:10:42 CEST 2025
       ocaml/ocaml-lsp#1489)
     - Reproduce and fix a handful of jump-to-definition (locate) issues  (#1930,
       fixes #1580 and #1588, workaround for #1934)
+    - Add `locate-types` command (#1951)
   + ocaml-index
     - Improve the granularity of index reading by segmenting the marshalization
       of the involved data-structures. (#1889)

--- a/doc/dev/PROTOCOL.md
+++ b/doc/dev/PROTOCOL.md
@@ -544,6 +544,54 @@ The type is described in another file, and the result will be the following obje
 }
 ```
 
+### `locate-types -position <position>`
+
+	-position <position>  The position of the type to be located
+
+Checks the type of the item at the given position. Unlike `locate-type`, if the type is
+expressed via multiple paths (ex: the type is `int list` or `(int foo * string) -> unit`),
+it will return a tree that represents the type. Each entry in the tree will contains the
+definition location of that type.
+
+The below schema defines the response object (where `response` is the type of the object
+returned):
+```javascript
+response = tree | "Invalid context"
+
+tree = {
+  "data": node_data,
+  "children": [tree]
+}
+
+node_data =
+  | [ "Arrow" ]
+  | [ "Tuple" ]
+  | [ "Object" ]
+  | [ "Poly_variant" ]
+  | [ "Type_ref", { "type": string, "result": [ "Found", file, position ] } ]
+
+file = string
+
+position = {
+  "pos_fname": string,
+  "pos_lnum": int,
+  "pos_bol": int,
+  "pos_cnum": int
+}
+```
+
+The type is described in another file, and the result will be the following object:
+
+```javascript
+{
+  'file': string, // the file where the type is defined
+  'pos': {
+    'start': position, // the start of the region where the type is defined
+	'end': position // the end of the region where the type is defined
+  }
+}
+```
+
 ### `signature-help -position <position>`
 
 	-position <position>  The position where to request additional information for signature help

--- a/src/analysis/locate_types.ml
+++ b/src/analysis/locate_types.ml
@@ -1,0 +1,59 @@
+open Std
+
+module Type_tree = struct
+  type node_data =
+    | Arrow
+    | Tuple
+    | Poly_variant
+    | Object
+    | Type_ref of { path : Path.t; ty : Types.type_expr }
+
+  type t = { data : node_data; children : t list }
+end
+
+let rec flatten_arrow ret_ty =
+  match Types.get_desc ret_ty with
+  | Tarrow (_, ty1, ty2, _) -> ty1 :: flatten_arrow ty2
+  | _ -> [ ret_ty ]
+
+let rec create_type_tree ty : Type_tree.t option =
+  match Types.get_desc ty with
+  | Tarrow (_, ty1, ty2, _) ->
+    let tys = ty1 :: flatten_arrow ty2 in
+    let children = List.filter_map tys ~f:create_type_tree in
+    Some { data = Arrow; children }
+  | Ttuple tys ->
+    let children = List.filter_map tys ~f:create_type_tree in
+    Some { data = Tuple; children }
+  | Tconstr (path, arg_tys, abbrev_memo) ->
+    let ty_without_args =
+      Btype.newty2 ~level:Ident.highest_scope (Tconstr (path, [], abbrev_memo))
+    in
+    let children = List.filter_map arg_tys ~f:create_type_tree in
+    Some { data = Type_ref { path; ty = ty_without_args }; children }
+  | Tlink ty | Tpoly (ty, _) -> create_type_tree ty
+  | Tobject (fields_type, _) ->
+    let rec extract_field_types (ty : Types.type_expr) =
+      match Types.get_desc ty with
+      | Tfield (_, _, ty, rest) -> ty :: extract_field_types rest
+      | _ -> []
+    in
+    let field_types = List.rev (extract_field_types fields_type) in
+    let children = List.filter_map field_types ~f:create_type_tree in
+    Some { data = Object; children }
+  | Tvariant row_desc ->
+    let fields = Types.row_fields row_desc in
+    let children =
+      List.filter_map fields ~f:(fun (_, row_field) ->
+          match Types.row_field_repr row_field with
+          | Rpresent (Some ty) -> create_type_tree ty
+          | Reither (_, tys, _) ->
+            (* If there are multiple types in [tys], they are types that are meant to
+               unify with each other (it'd be a type error if not, see
+               [Ctype.collapse_conj]). So just using the head of the list seems fine
+               (using the entire list results in types being duplicated). *)
+            List.hd_opt tys |> Option.bind ~f:create_type_tree
+          | Rpresent None | Rabsent -> None)
+    in
+    Some { data = Poly_variant; children }
+  | Tnil | Tvar _ | Tsubst _ | Tunivar _ | Tpackage _ | Tfield _ -> None

--- a/src/analysis/locate_types.ml
+++ b/src/analysis/locate_types.ml
@@ -1,14 +1,8 @@
 open Std
 
 module Type_tree = struct
-  type node_data =
-    | Arrow
-    | Tuple
-    | Poly_variant
-    | Object
-    | Type_ref of { path : Path.t; ty : Types.type_expr }
-
-  type t = { data : node_data; children : t list }
+  type type_ref_payload = { path : Path.t; ty : Types.type_expr }
+  type t = type_ref_payload Query_protocol.Locate_types_result.Tree.t
 end
 
 let rec flatten_arrow ret_ty =

--- a/src/analysis/locate_types.mli
+++ b/src/analysis/locate_types.mli
@@ -1,0 +1,13 @@
+module Type_tree : sig
+  type node_data =
+    | Arrow
+    | Tuple
+    | Poly_variant
+    | Object
+    | Type_ref of { path : Path.t; ty : Types.type_expr }
+
+  type t = { data : node_data; children : t list }
+end
+
+(** Convert a type into a simplified tree representation. *)
+val create_type_tree : Types.type_expr -> Type_tree.t option

--- a/src/analysis/locate_types.mli
+++ b/src/analysis/locate_types.mli
@@ -1,12 +1,6 @@
 module Type_tree : sig
-  type node_data =
-    | Arrow
-    | Tuple
-    | Poly_variant
-    | Object
-    | Type_ref of { path : Path.t; ty : Types.type_expr }
-
-  type t = { data : node_data; children : t list }
+  type type_ref_payload = { path : Path.t; ty : Types.type_expr }
+  type t = type_ref_payload Query_protocol.Locate_types_result.Tree.t
 end
 
 (** Convert a type into a simplified tree representation. *)

--- a/src/commands/new_commands.ml
+++ b/src/commands/new_commands.ml
@@ -500,6 +500,23 @@ let all_commands =
           | #Msource.position as pos ->
             run buffer (Query_protocol.Locate_type pos)
       end;
+    command "locate-types"
+      ~spec:
+        [ arg "-position" "<position> Position to locate the type of"
+            (marg_position (fun pos _ -> pos))
+        ]
+      ~doc:
+        "Locate the declaration of the type of the expression. If the type is \
+         expressed via multiple identifiers, it returns the location of each \
+         identifier."
+      ~default:`None
+      begin
+        fun buffer pos ->
+          match pos with
+          | `None -> failwith "-position <pos> is mandatory"
+          | #Msource.position as pos ->
+            run buffer (Query_protocol.Locate_types pos)
+      end;
     command "occurrences"
       ~spec:
         [ arg "-identifier-at" "<position> Position of the identifier"

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -397,7 +397,9 @@ let json_of_locate_types (resp : Locate_types_result.t) =
     in
     `List (`String variant_name :: payload)
   in
-  let json_of_node_data : Locate_types_result.node_data -> _ = function
+  let json_of_node_data :
+      Locate_types_result.(type_ref_payload Tree.node_data) ->
+      _ = function
     | Arrow -> `List [ `String "Arrow" ]
     | Tuple -> `List [ `String "Tuple" ]
     | Object -> `List [ `String "Object" ]
@@ -411,7 +413,7 @@ let json_of_locate_types (resp : Locate_types_result.t) =
             ]
         ]
   in
-  let rec json_of_type_tree { Locate_types_result.data; children } =
+  let rec json_of_type_tree { Locate_types_result.Tree.data; children } =
     `Assoc
       [ ("data", json_of_node_data data);
         ("children", `List (List.map ~f:json_of_type_tree children))

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -358,8 +358,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let structures = Mbrowse.of_typedtree local_defs in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let result =
-      let ( let* ) opt f = Option.bind opt ~f in
-      let ( let+ ) opt f = Option.map opt ~f in
+      let open Option.Infix in
       let* env, node =
         match Mbrowse.enclosing pos [ structures ] with
         | path :: _ -> Some path

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -365,8 +365,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
         | [] -> None
       in
       let* overall_ty =
-        Locate.log ~title:"query_commands Locate_types"
-          "inspecting node: %s"
+        Locate.log ~title:"query_commands Locate_types" "inspecting node: %s"
           (Browse_raw.string_of_node node);
         match node with
         | Expression { exp_type = ty; _ }
@@ -383,8 +382,8 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
         Format.flush_str_formatter ()
       in
       let rec make_result ({ data; children } : Locate_types.Type_tree.t) :
-          Locate_types_result.type_tree =
-        let data : Locate_types_result.node_data =
+          Locate_types_result.(type_ref_payload Tree.t) =
+        let data : Locate_types_result.(type_ref_payload Tree.node_data) =
           match data with
           | Arrow -> Arrow
           | Tuple -> Tuple

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -133,6 +133,27 @@ type occurrences_status =
 
 type occurrence = { loc : Location.t; is_stale : bool }
 
+module Locate_types_result = struct
+  type node_data =
+    | Arrow
+    | Tuple
+    | Object
+    | Poly_variant
+    | Type_ref of
+        { type_ : string;
+          result :
+            [ `Found of string option * Lexing.position
+            | `Builtin of string
+            | `Not_in_env of string
+            | `File_not_found of string
+            | `Not_found of string * string option ]
+        }
+
+  type type_tree = { data : node_data; children : type_tree list }
+
+  type t = Success of type_tree | Invalid_context
+end
+
 type _ t =
   | Type_expr (* *) : string * Msource.position -> string t
   | Type_enclosing (* *) :
@@ -182,6 +203,7 @@ type _ t =
          | `Not_found of string * string option
          | `At_origin ]
          t
+  | Locate_types : Msource.position -> Locate_types_result.t t
   | Locate (* *) :
       string option * [ `ML | `MLI ] * Msource.position
       -> [ `Found of string option * Lexing.position

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -134,24 +134,23 @@ type occurrences_status =
 type occurrence = { loc : Location.t; is_stale : bool }
 
 module Locate_types_result = struct
-  type node_data =
-    | Arrow
-    | Tuple
-    | Object
-    | Poly_variant
-    | Type_ref of
-        { type_ : string;
-          result :
-            [ `Found of string option * Lexing.position
-            | `Builtin of string
-            | `Not_in_env of string
-            | `File_not_found of string
-            | `Not_found of string * string option ]
-        }
+  module Tree = struct
+    type 'a node_data = Arrow | Tuple | Object | Poly_variant | Type_ref of 'a
 
-  type type_tree = { data : node_data; children : type_tree list }
+    type 'a t = { data : 'a node_data; children : 'a t list }
+  end
 
-  type t = Success of type_tree | Invalid_context
+  type type_ref_payload =
+    { type_ : string;
+      result :
+        [ `Found of string option * Lexing.position
+        | `Builtin of string
+        | `Not_in_env of string
+        | `File_not_found of string
+        | `Not_found of string * string option ]
+    }
+
+  type t = Success of type_ref_payload Tree.t | Invalid_context
 end
 
 type _ t =

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -343,6 +343,8 @@ module Option = struct
     let return x = Some x
     let ( >>= ) x f = bind x ~f
     let ( >>| ) x f = map x ~f
+    let ( let* ) opt f = bind opt ~f
+    let ( let+ ) opt f = map opt ~f
   end
 
   include Infix

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -257,6 +257,10 @@ module List = struct
         | Some a' -> Cons (a', lazy (filter_map ~f (Lazy.force tl))))
   end
 
+  let hd_opt = function
+    | [] -> None
+    | x :: _ -> Some x
+
   let rec last = function
     | [] -> None
     | [ x ] -> Some x

--- a/tests/test-dirs/locate-types.t
+++ b/tests/test-dirs/locate-types.t
@@ -1,0 +1,189 @@
+Test the locate-types command
+
+Create a function that runs locate-types on a variable of a given type
+  $ run () {
+  >   type="$1"
+  > 
+  >   # Create a file that creates a variable of the given type. We also define some
+  >   # types for us to be able to reference.
+  >   cat > foo.ml <<EOF
+  > type a
+  > type b
+  > type c
+  > type 'a one_arg
+  > type ('a, 'b) two_arg
+  > type aliased = t
+  > let () =
+  >   let foo : $type = failwith "foo" in
+  >   ()
+  > EOF
+  > 
+  >   $MERLIN single locate-types -position "8:7" -filename foo.ml < foo.ml \
+  >     | jq .value \
+  >     | jq -r '
+  >         def format_node:
+  >           if .data[0] == "Type_ref" then
+  >             # Check if position info is present
+  >             if .data[1].result[0] == "Found" then
+  >               # Extract type, line number, and column
+  >               (.data[1].result[2].pos_cnum - .data[1].result[2].pos_bol) as $col |
+  >               .data[1].result[2].pos_lnum as $line |
+  >               .data[1].type as $type |
+  >               "\($type) (\($line | tostring):\($col | tostring))"
+  >             else
+  >               # No position info available
+  >               .data[1].type
+  >             end
+  >           else
+  >             .data[0]
+  >           end;
+  >         
+  >         def process_tree($indent):
+  >           format_node as $node_text |
+  >           $indent + $node_text + 
+  >           if .children | length > 0 then
+  >             "\n" + (.children | map(process_tree($indent + "  ")) | join("\n"))
+  >           else
+  >             ""
+  >           end;
+  >         
+  >         process_tree("")
+  >         '
+  > }
+
+Basic type constructors
+
+  $ run "a"
+  a (1:5)
+
+  $ run "a one_arg"
+  one_arg (4:8)
+    a (1:5)
+
+  $ run "(a, b) two_arg"
+  two_arg (5:14)
+    a (1:5)
+    b (2:5)
+  $ run "(b, a) two_arg"
+  two_arg (5:14)
+    b (2:5)
+    a (1:5)
+
+Functions
+
+  $ run "a -> b -> c"
+  Arrow
+    a (1:5)
+    b (2:5)
+    c (3:5)
+
+  $ run "x:a -> ?y:b -> c"
+  Arrow
+    a (1:5)
+    option
+      b (2:5)
+    c (3:5)
+
+Tuples
+
+  $ run "a * b * c"
+  Tuple
+    a (1:5)
+    b (2:5)
+    c (3:5)
+
+  $ run "a * b"
+  Tuple
+    a (1:5)
+    b (2:5)
+
+Type variables
+
+  $ run "_ one_arg"
+  one_arg (4:8)
+
+  $ run "'a one_arg"
+  one_arg (4:8)
+
+Objects
+
+  $ run "<x : a; y : b>"
+  Object
+    a (1:5)
+    b (2:5)
+
+Polymorphic variant types
+
+  $ run "[\`A of a | \`B of b ]"
+  Poly_variant
+    b (2:5)
+    a (1:5)
+
+  $ run "[> \`A of a | \`B of b ]"
+  Poly_variant
+    b (2:5)
+    a (1:5)
+
+  $ run "[< \`A of a | \`B of b ]"
+  Poly_variant
+    b (2:5)
+    a (1:5)
+
+  $ run "[\`B | \`A of a]"
+  Poly_variant
+    a (1:5)
+
+  $ run "[\`B | \`A]"
+  Poly_variant
+
+  $ run "[]"
+  Poly_variant
+
+  $ run "[ \`A of (a * b) ]"
+  Poly_variant
+    Tuple
+      a (1:5)
+      b (2:5)
+
+Primitive types
+
+  $ run "string"
+  string
+
+  $ run "int"
+  int
+
+  $ run "a option"
+  option
+    a (1:5)
+
+  $ run "a list"
+  list
+    a (1:5)
+
+Compound types
+
+  $ run "(a * b) one_arg"
+  one_arg (4:8)
+    Tuple
+      a (1:5)
+      b (2:5)
+
+  $ run "(a option, _) two_arg"
+  two_arg (5:14)
+    option
+      a (1:5)
+
+  $ run "a -> b -> (a * b)"
+  Arrow
+    a (1:5)
+    b (2:5)
+    Tuple
+      a (1:5)
+      b (2:5)
+
+  $ run "((a one_arg) list) option"
+  option
+    list
+      one_arg (4:8)
+        a (1:5)


### PR DESCRIPTION
This PR adds a new command, locate-type-multi, that we plan to use at Jane Street for some new VSCode functionality.

A useful current command in VSCode is "Go to Type Definition", which uses the `locate-type` query to go to the definition of the type of the identifier under the cursor. However, this command is rather limited - it only works on `Tconstrs`, and when the `Tconstr` carries arguments, it just ignores the args. In other words, the command doesn't provide the ability to go to a's defintion if the type is any of the following: `a t, (a * _), a -> _, _ -> a`.

`locate-type-multi`, instead of always just returning the location of a single identifier, returns a tree structure that represents all the identifiers within a type. So for example, if the type is `a -> (b * c)`, it returns the locations of all of `a`, `b`, and `c`, and this is in a tree-like data structure that makes it easy for VSCode to present this to the user.