### PR TITLE
Fix `merlin_reader` functionality on OpenBSD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+  + merlin library
+    - Fix `merlin_reader` for OpenBSD (#1956)
+
 merlin 5.5
 ==========
 Tue Jun 24 16:10:42 CEST 2025

--- a/src/extend/extend_driver.ml
+++ b/src/extend/extend_driver.ml
@@ -21,8 +21,9 @@ let run ?(notify = ignore) ?(debug = ignore) name =
   Unix.set_close_on_exec stdin;
   Unix.set_close_on_exec pstdout;
   Unix.set_close_on_exec stdout;
+  let ocamlmerlin_name = "ocamlmerlin-" ^ name in
   let pid =
-    Unix.create_process ("ocamlmerlin-" ^ name) [||] pstdin pstdout Unix.stderr
+    Unix.create_process ocamlmerlin_name [| ocamlmerlin_name |] pstdin pstdout Unix.stderr
   in
   Unix.close pstdout;
   Unix.close pstdin;


### PR DESCRIPTION
OpenBSD's [`execve(2)`](https://man.openbsd.org/execve#EINVAL) needs `argv` to contain at least one element.