### PR TITLE
Test & Fix recovery issue 1953

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ unreleased
 ==========
   + merlin library
     - Fix `merlin_reader` for OpenBSD (#1956)
+    - Improve recovery of mutually recursive definitions (#1962, fixes #1953)
 
 merlin 5.5
 ==========

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -6395,7 +6395,7 @@ and type_let ?check ?check_strict
       (fun {vb_pat=pat} -> match pat.pat_desc with
            Tpat_var _ -> ()
          | Tpat_alias ({pat_desc=Tpat_any}, _, _, _) -> ()
-         | _ -> raise(error(pat.pat_loc, env, Illegal_letrec_pat)))
+         | _ -> raise_error(error(pat.pat_loc, env, Illegal_letrec_pat)))
       l;
   List.iter (fun vb ->
       if pattern_needs_partial_application_check vb.vb_pat then

--- a/tests/test-dirs/recovery/issue1953.t
+++ b/tests/test-dirs/recovery/issue1953.t
@@ -3,21 +3,36 @@
   > and (a,b) = (1,2)
   > EOF
 
-
-FIXME Surely we can do better here
   $ $MERLIN single type-enclosing -position 1:16 -verbosity 0 \
-  > -filename ./main.ml < ./main.ml | jq
+  > -filename ./main.ml < ./main.ml | jq '.value[0]'
   {
-    "class": "return",
-    "value": [],
-    "notifications": []
+    "start": {
+      "line": 1,
+      "col": 16
+    },
+    "end": {
+      "line": 1,
+      "col": 17
+    },
+    "type": "int",
+    "tail": "no"
   }
 
-FIXME Surely we can do better here
   $ $MERLIN single type-enclosing -position 2:15 -verbosity 0 \
-  > -filename ./main.ml < ./main.ml | jq
+  > -filename ./main.ml < ./main.ml | jq '.value[0]'
   {
-    "class": "return",
-    "value": [],
-    "notifications": []
+    "start": {
+      "line": 2,
+      "col": 15
+    },
+    "end": {
+      "line": 2,
+      "col": 16
+    },
+    "type": "int",
+    "tail": "no"
   }
+
+  $ $MERLIN single errors \
+  > -filename ./main.ml < ./main.ml | jq '.value[].message'
+  "Only variables are allowed as left-hand side of let rec"

--- a/tests/test-dirs/recovery/issue1953.t
+++ b/tests/test-dirs/recovery/issue1953.t
@@ -1,0 +1,23 @@
+  $ cat >main.ml <<'EOF'
+  > let rec foo x = x + a + b
+  > and (a,b) = (1,2)
+  > EOF
+
+
+FIXME Surely we can do better here
+  $ $MERLIN single type-enclosing -position 1:16 -verbosity 0 \
+  > -filename ./main.ml < ./main.ml | jq
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }
+
+FIXME Surely we can do better here
+  $ $MERLIN single type-enclosing -position 2:15 -verbosity 0 \
+  > -filename ./main.ml < ./main.ml | jq
+  {
+    "class": "return",
+    "value": [],
+    "notifications": []
+  }


### PR DESCRIPTION
Fixes #1953.

The classic tell of the missing `raise_error`.