### PR TITLE
Vim: Fix crash when text preview is not accurate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
   + merlin library
     - Fix `merlin_reader` for OpenBSD (#1956)
     - Improve recovery of mutually recursive definitions (#1962, #1963, fixes #1953)
+  + vim plugin
+    - Fix error when `:MerlinOccurrencesProjectWide` fails to gather code previews (#1970)
 
 merlin 5.5
 ==========

--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -548,7 +548,8 @@ def with_text_previews(occurs):
         if 'file' not in oc: # Current buffer
             text = vim.current.buffer[lnum - 1]
         else:
-            text = preview_lines_by_file[oc['file']][lnum]
+            buf = preview_lines_by_file.get(oc['file'], [])
+            text = buf[lnum] if lnum < len(buf) else ""
         yield { "text": text, **oc }
 
 # Occurrences


### PR DESCRIPTION
The Vim plugin sometimes crashes due to an out-of-bound access when querying the preview text.

The error was:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nix/store/iifbn3ckdlz6wzjr899lmx6nh08lfccx-source/vim/merlin/autoload/merlin.py", line 563, in vim_occurrences
    for pos in with_text_previews(lst):
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/iifbn3ckdlz6wzjr899lmx6nh08lfccx-source/vim/merlin/autoload/merlin.py", line 551, in with_text_previews
    text = preview_lines_by_file[oc['file']][lnum]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 235
```

With this fix, the plugin find no text at all to show for each occurrences, indicating that there's a problem with `preview_lines_by_file` as well.
But I think `preview_lines_by_file` cannot be perfect (the index might not be uptodate, the file might change after the occurrences were queried) so guarding against this error is important.