### PR TITLE
Introduce `buffer-cache` flag to disable typedtree cache

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -377,7 +377,7 @@ let merlin_flags =
       " DEPRECATED" );
     ( "-use-typer-cache",
       Marg.bool (fun b merlin -> { merlin with use_typer_cache = b }),
-      "Whether to enable the typer cache. Default to true." )
+      "Whether to enable the typer cache. Defaults to true." )
   ]
 
 let query_flags =

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -94,7 +94,8 @@ type merlin =
     flags_applied : string list with_workdir list;
     failures : string list;
     extension_to_reader : (string * string) list;
-    cache_lifespan : int
+    cache_lifespan : int;
+    use_typer_cache : bool
   }
 
 let dump_merlin x =
@@ -373,7 +374,10 @@ let merlin_flags =
     ( (* Legacy support for janestreet. Ignored. To be removed soon. *)
       "-attributes-allowed",
       Marg.unit_ignore,
-      " DEPRECATED" )
+      " DEPRECATED" );
+    ( "-use-typer-cache",
+      Marg.bool (fun b merlin -> { merlin with use_typer_cache = b }),
+      "Whether to enable the typer cache. Default to true." )
   ]
 
 let query_flags =
@@ -682,7 +686,8 @@ let initial =
         flags_applied = [];
         failures = [];
         extension_to_reader = [ (".re", "reason"); (".rei", "reason") ];
-        cache_lifespan = 5
+        cache_lifespan = 5;
+        use_typer_cache = true
       };
     query =
       { filename = "*buffer*";

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -51,7 +51,8 @@ type merlin =
     flags_applied : string list with_workdir list;
     failures : string list;
     extension_to_reader : (string * string) list;
-    cache_lifespan : int
+    cache_lifespan : int;
+    use_typer_cache : bool
   }
 
 val dump_merlin : merlin -> json

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -69,8 +69,9 @@ let get_cache config =
     let index = Stamped_hashtable.create !index_changelog 256 in
     { env; snapshot; ident_stamp; uid_stamp; value = None; index }
 
-let return_and_cache status =
-  cache := Some { status with value = Some status.value };
+let return_and_cache config status =
+  if config.Mconfig.merlin.Mconfig.use_typer_cache then
+    cache := Some { status with value = Some status.value };
   status
 
 type result =
@@ -286,7 +287,8 @@ let type_implementation config caught position shared parsetree =
     let value =
       `Implementation (List.rev_append prefix (preprocessed_suffix @ suffix))
     in
-    return_and_cache { env; snapshot; ident_stamp; uid_stamp; value; index }
+    return_and_cache config
+      { env; snapshot; ident_stamp; uid_stamp; value; index }
   in
   try
     match position with
@@ -358,7 +360,8 @@ let type_interface config caught position shared parsetree =
     let value =
       `Interface (List.rev_append prefix (preprocessed_suffix @ suffix))
     in
-    return_and_cache { env; snapshot; ident_stamp; uid_stamp; value; index }
+    return_and_cache config
+      { env; snapshot; ident_stamp; uid_stamp; value; index }
   in
   try
     match position with


### PR DESCRIPTION
Use `-buffer-cache=no` to disable it.

cc @pitag-ha @xvw @lyrm