### PR TITLE
Add --lalr flag to menhir invocations

### DIFF
--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -10,7 +10,7 @@
  (modules parser_raw)
  (enabled_if (<> %{profile} "release"))
  (mode    (promote (only parser_raw.ml parser_raw.mli)))
- (flags :standard --inspection --table --cmly))
+ (flags :standard --inspection --table --cmly --lalr))
 
 (rule
   (targets parser_recover.ml)

--- a/src/sherlodoc/dune
+++ b/src/sherlodoc/dune
@@ -6,6 +6,6 @@
  (modules type_parser)
  (enabled_if (<> %{profile} "release"))
  (mode promote)
- (flags :standard --explain))
+ (flags :standard --explain --lalr))
 
 (ocamllex type_lexer)


### PR DESCRIPTION
This is a flag that [the compiler passes to menhir](https://github.com/ocaml/ocaml/blob/d197927a89e08d84cbd030ae3112295b31de3f18/Makefile.menhir#L67) as the compiler's parser (and also merlin's) is LALR. This flag enables Menhir to generate more optimal code, so it is a strict improvement given the parser is already LALR. Credit to @let-def for pointing this out to @ccasin, who in turn pointed this out to me.

This corresponds to OxCaml Merlin [PR 194](https://github.com/oxcaml/merlin/pull/194).