### PR TITLE
Vim plugin: fix the KeyError raised by incorrect usage of `itertools.groupby`.

### DIFF
--- a/vim/merlin/autoload/merlin.py
+++ b/vim/merlin/autoload/merlin.py
@@ -538,6 +538,8 @@ def read_lines_of_file(fname, lines):
 # From the result of [command_occurrences], read the start line for each
 # results. Generate the same occurrences with the 'text' field added.
 def with_text_previews(occurs):
+    occurs.sort(key = lambda oc: oc.get('file'))
+
     preview_lines_by_file = {
             fname: read_lines_of_file(fname, [ oc['start']['line'] for oc in occurs ])
             for fname, occurs


### PR DESCRIPTION
Seems to resolve https://github.com/ocaml/merlin/issues/1832 with the fix proposed by @talex5.

cc @voodoos
