### PR TITLE
Add a test to ensure the illustrate the behavior of `type-enclosing` command showed in issue #1949

### DIFF
--- a/tests/test-dirs/type-enclosing/issue1949.t
+++ b/tests/test-dirs/type-enclosing/issue1949.t
@@ -1,0 +1,11 @@
+  $ cat >main.ml <<EOF
+  > let foo a b = b
+  > EOF
+
+  $ $MERLIN single type-enclosing -position 1:6 -filename main.ml <main.ml | jq .value.[0].type
+  "'a -> 'b -> 'b"
+
+Inconsistent type variables are returned by `type-enclosing`. In term of user experience, the type of `b` it should be `'b`.
+See https://github.com/ocaml/merlin/issues/1949.
+  $ $MERLIN single type-enclosing -position 1:14 -filename main.ml <main.ml | jq .value.[0].type
+  "'a"


### PR DESCRIPTION
This PR adds a test to illustrate the issue https://github.com/ocaml/merlin/issues/1949 opened by Liam.
I don't know if it deserves to be fixed or if it is planned to be fixed but in doublt. What do you think @voodoos?
