### PR TITLE
Add LRU to improve the memory usage of the indexer

### DIFF
--- a/src/index-format/dbllist.ml
+++ b/src/index-format/dbllist.ml
@@ -1,5 +1,5 @@
 type 'a cell =
-  { mutable content : 'a;
+  { content : 'a;
     weight : int;
     mutable prev : 'a cell;
     mutable next : 'a cell
@@ -17,9 +17,9 @@ type stats = {
 type 'a dbll =
   | Nil of int
   | List of
-      { mutable first : 'a cell;
-        mutable last : 'a cell;
-        mutable size : int;
+      { first : 'a cell;
+        last : 'a cell;
+        size : int;
         cap : int;
       }
 

--- a/src/index-format/dbllist.ml
+++ b/src/index-format/dbllist.ml
@@ -69,6 +69,7 @@ let discard t =
   | List l ->
     if l.first == l.last then (
       t.dbll <- Nil l.cap;
+      t.stats.discarded_size <- t.stats.discarded_size + l.last.weight;
       l.last.content)
     else
       let discarded_value = l.last.content in

--- a/src/index-format/dbllist.ml
+++ b/src/index-format/dbllist.ml
@@ -29,7 +29,7 @@ exception Action_on_empty_list of string
 
 let pp_stats t =
   let size = match t.dbll with | Nil _ -> 0 | List l -> l.size in
-  Printf.printf "total_cap \t\t: %d\nsize \t\t: %d\npromote_count \t: %d\nadd_count \t\t: %d\ndiscard_count \t: %d\nadd_size \t\t: %d\ndiscard_size \t: %d\nvolume_conservation \t: %d = %d + %d : %b\n%!"
+  Printf.eprintf "total_cap \t\t: %d\nsize \t\t: %d\npromote_count \t: %d\nadd_count \t\t: %d\ndiscard_count \t: %d\nadd_size \t\t: %d\ndiscard_size \t: %d\nvolume_conservation \t: %d = %d + %d : %b\n%!"
   t.stats.total_cap
   size
   t.stats.promote_count

--- a/src/index-format/dbllist.ml
+++ b/src/index-format/dbllist.ml
@@ -1,0 +1,126 @@
+type 'a cell =
+  { mutable content : 'a;
+    weight : int;
+    mutable prev : 'a cell;
+    mutable next : 'a cell
+  }
+
+type stats = {
+  mutable total_cap : int;
+  mutable promote_count : int;
+  mutable add_count : int;
+  mutable discard_count : int;
+  mutable add_size : int;
+  mutable discarded_size : int;
+}
+
+type 'a dbll =
+  | Nil of int
+  | List of
+      { mutable first : 'a cell;
+        mutable last : 'a cell;
+        mutable size : int;
+        cap : int;
+      }
+
+type 'a t = { mutable dbll : 'a dbll; stats : stats }
+
+exception Action_on_empty_list of string
+
+let pp_stats t =
+  let size = match t.dbll with | Nil _ -> 0 | List l -> l.size in
+  Printf.printf "total_cap \t\t: %d\nsize \t\t: %d\npromote_count \t: %d\nadd_count \t\t: %d\ndiscard_count \t: %d\nadd_size \t\t: %d\ndiscard_size \t: %d\nvolume_conservation \t: %d = %d + %d : %b\n%!"
+  t.stats.total_cap
+  size
+  t.stats.promote_count
+  t.stats.add_count
+  t.stats.discard_count
+  t.stats.add_size
+  t.stats.discarded_size
+  t.stats.add_size t.stats.discarded_size size (t.stats.add_size = t.stats.discarded_size + size)
+
+let create cap =
+  let stats = { total_cap = cap; promote_count = 0; add_count = 0; discard_count = 0; add_size = 0; discarded_size = 0 } in
+  { dbll = Nil cap; stats }
+
+let add_front t (v, w) =
+  t.stats.add_count <- t.stats.add_count + 1;
+  t.stats.add_size <- t.stats.add_size + w;
+  match t.dbll with
+  | Nil cap ->
+    let rec c = { content = v; weight = w; prev = c; next = c } in
+    t.dbll <- List { first = c; last = c; size = w; cap };
+    c
+  | List l ->
+    let rec new_first =
+      { content = v; weight = w; prev = new_first; next = l.first }
+    in
+    l.first.prev <- new_first;
+    t.dbll <- List { first = new_first; last = l.last; size = l.size + w; cap = l.cap };
+    new_first
+
+let discard t =
+  t.stats.discard_count <- t.stats.discard_count + 1;
+  match t.dbll with
+  | Nil _ ->
+    raise
+      (Action_on_empty_list
+         "Unable to discard the last element, the doubly linked list is empty.")
+  | List l ->
+    if l.first == l.last then (
+      t.dbll <- Nil l.cap;
+      l.last.content)
+    else
+      let discarded_value = l.last.content in
+      let discarded_weight = l.last.weight in
+      t.stats.discarded_size <- t.stats.discarded_size + discarded_weight;
+      let new_last = l.last.prev in
+      new_last.next <- new_last;
+      t.dbll <-
+        List
+          { first = l.first;
+            last = new_last;
+            size = Int.max 0 (l.size - discarded_weight);
+            cap = l.cap;
+          };
+      discarded_value
+
+let discard_size t s =
+  let rec iter acc t =
+    match t.dbll with
+    | Nil _ -> acc
+    | List l -> if l.size + s <= l.cap then acc else (
+      iter (discard t :: acc) t)
+  in
+  iter [] t
+
+let promote t c =
+  t.stats.promote_count <- t.stats.promote_count + 1;
+  match t.dbll with
+  | Nil _ ->
+    raise
+      (Action_on_empty_list
+         "Unable to promote a cell, the doubly linked list is empty.")
+  | List l ->
+    if l.first == c then ()
+    else if l.last == c then (
+      let new_last = l.last.prev in
+      new_last.next <- new_last;
+      let new_first = c in
+      new_first.next <- l.first;
+      new_first.prev <- new_first;
+      l.first.prev <- new_first;
+      t.dbll <-
+        List { first = new_first; last = new_last; size = l.size; cap = l.cap })
+    else
+      let voisin_prev = c.prev in
+      let voisin_next = c.next in
+      voisin_prev.next <- voisin_next;
+      voisin_next.prev <- voisin_prev;
+      let new_first = c in
+      new_first.prev <- new_first;
+      new_first.next <- l.first;
+      l.first.prev <- new_first;
+      t.dbll <- List { first = new_first; last = l.last; size = l.size; cap = l.cap }
+
+let get c = c.content

--- a/src/index-format/dbllist.mli
+++ b/src/index-format/dbllist.mli
@@ -1,5 +1,5 @@
 type 'a cell =
-  { mutable content : 'a;
+  { content : 'a;
     weight : int;
     mutable prev : 'a cell;
     mutable next : 'a cell
@@ -17,9 +17,9 @@ type stats = {
 type 'a dbll =
   | Nil of int
   | List of
-      { mutable first : 'a cell;
-        mutable last : 'a cell;
-        mutable size : int;
+      { first : 'a cell;
+        last : 'a cell;
+        size : int;
         cap : int;
       }
 

--- a/src/index-format/dbllist.mli
+++ b/src/index-format/dbllist.mli
@@ -1,0 +1,35 @@
+type 'a cell =
+  { mutable content : 'a;
+    weight : int;
+    mutable prev : 'a cell;
+    mutable next : 'a cell
+  }
+
+type stats = {
+  mutable total_cap : int;
+  mutable promote_count : int;
+  mutable add_count : int;
+  mutable discard_count : int;
+  mutable add_size : int;
+  mutable discarded_size : int;
+}
+
+type 'a dbll =
+  | Nil of int
+  | List of
+      { mutable first : 'a cell;
+        mutable last : 'a cell;
+        mutable size : int;
+        cap : int;
+      }
+
+type 'a t = { mutable dbll : 'a dbll; stats : stats }
+
+exception Action_on_empty_list of string
+
+val pp_stats : 'a t -> unit
+val create : int -> 'a t
+val add_front : 'a t -> 'a * int -> 'a cell
+val discard_size : 'a t -> int -> 'a list
+val promote : 'a t -> 'a cell -> unit
+val get : 'a cell -> 'a

--- a/src/index-format/granular_map.ml
+++ b/src/index-format/granular_map.ml
@@ -193,7 +193,7 @@ module Make (Ord : Map.OrderedType) = struct
       iter f r
 
   let rec iter_in_memory f s =
-    if Granular_marshal.is_on_disk s then
+    if not (Granular_marshal.is_on_disk s) then
       match fetch s with
       | Empty -> ()
       | Node { l; v; d; r; _ } ->

--- a/src/index-format/granular_map.ml
+++ b/src/index-format/granular_map.ml
@@ -193,7 +193,7 @@ module Make (Ord : Map.OrderedType) = struct
       iter f r
 
   let rec iter_in_memory f s =
-    if not (Granular_marshal.is_on_disk s) then
+    if Granular_marshal.is_on_disk s then
       match fetch s with
       | Empty -> ()
       | Node { l; v; d; r; _ } ->

--- a/src/index-format/granular_map.ml
+++ b/src/index-format/granular_map.ml
@@ -30,7 +30,6 @@ module type S = sig
   val find_opt : key -> 'a t -> 'a option
   val choose_opt : 'a t -> (key * 'a) option
   val iter : (key -> 'a -> unit) -> 'a t -> unit
-  val iter_in_memory : (key -> 'a -> unit) -> 'a t -> unit
   val fold : (key -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
   val map : ('a -> 'b) -> 'a t -> 'b t
   val is_empty : 'a t -> bool
@@ -191,15 +190,6 @@ module Make (Ord : Map.OrderedType) = struct
       iter f l;
       f v d;
       iter f r
-
-  let rec iter_in_memory f s =
-    if not (Granular_marshal.is_on_disk s) then
-      match fetch s with
-      | Empty -> ()
-      | Node { l; v; d; r; _ } ->
-        iter_in_memory f l;
-        f v d;
-        iter_in_memory f r
 
   let rec map f s =
     match fetch s with

--- a/src/index-format/granular_map.mli
+++ b/src/index-format/granular_map.mli
@@ -28,7 +28,6 @@ module type S = sig
   val find_opt : key -> 'a t -> 'a option
   val choose_opt : 'a t -> (key * 'a) option
   val iter : (key -> 'a -> unit) -> 'a t -> unit
-  val iter_in_memory : (key -> 'a -> unit) -> 'a t -> unit
   val fold : (key -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
   val map : ('a -> 'b) -> 'a t -> 'b t
   val is_empty : 'a t -> bool

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -12,7 +12,7 @@ and 'a repr =
   | Small of 'a
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
-  | On_disk of { store : store; loc : int; schema : 'a schema }
+  | On_disk of { store : store; loc : int; schema : 'a schema; id : int }
   | On_disk_ptr of { filename : string; loc : int; id : int }
   | In_memory of 'a
   | In_memory_reused of 'a
@@ -59,10 +59,31 @@ let int_of_binstring s =
     (Array.init ptr_size (fun i -> Char.code s.[i]))
     0
 
-let fetch_id filename =
-  In_channel.with_open_bin filename (fun fd ->
-      seek_in fd (String.length Config.index_magic_number);
-      int_of_binstring (really_input_string fd ptr_size))
+let last_open_store = ref None
+
+let () =
+  at_exit (fun () ->
+      match !last_open_store with
+      | None -> ()
+      | Some (_, fd) -> close_in fd)
+
+let force_open_store store =
+  let fd = open_in_bin store.filename in
+  last_open_store := Some (store, fd);
+  fd
+
+let open_store store =
+  match !last_open_store with
+  | Some (store', fd) when store == store' -> fd
+  | Some (_, fd) ->
+    close_in fd;
+    force_open_store store
+  | None -> force_open_store store
+
+let fetch_id store =
+  let fd = open_store store in
+  seek_in fd (String.length Config.index_magic_number);
+  int_of_binstring (really_input_string fd ptr_size)
 
 let read_loc store fd loc schema =
   seek_in fd loc;
@@ -74,7 +95,8 @@ let read_loc store fd loc schema =
           | Small v ->
             schema iter v;
             lnk := In_memory v
-          | Serialized { loc } -> lnk := On_disk { store; loc; schema }
+          | Serialized { loc } ->
+            lnk := On_disk { store; loc; schema; id = fetch_id store }
           | Serialized_reused { loc } -> (
             match Cache.find store.cache loc with
             | Link (type b) ((lnk', type_id') : b link * _) -> (
@@ -85,17 +107,12 @@ let read_loc store fd loc schema =
                 invalid_arg
                   "Granular_marshal.read_loc: reuse of a different type")
             | exception Not_found ->
-              lnk := On_disk { store; loc; schema };
+              lnk := On_disk { store; loc; schema; id = fetch_id store };
               Cache.add store.cache loc (Link (lnk, type_id)))
           | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc; id } ->
-            let pointed_index_id = fetch_id filename in
-            if pointed_index_id = id then
-              let store = { filename; cache = Cache_cache.read filename } in
-              lnk := On_disk { store; loc; schema }
-            else
-              failwith
-                "Granular_marshal.read_loc: pointing to an outdated index file"
+            let store = { filename; cache = Cache_cache.read filename } in
+            lnk := On_disk { store; loc; schema; id }
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in
@@ -117,10 +134,14 @@ let rec fetch lnk =
     let v = fetch original_lnk in
     lnk := In_memory v;
     v
-  | On_disk { store; loc; schema } ->
-    let v = fetch_loc store loc schema in
-    lnk := In_memory v;
-    v
+  | On_disk { store; loc; schema; id } ->
+    let pointed_index_id = fetch_id store in
+    if pointed_index_id = id then (
+      let v = fetch_loc store loc schema in
+      lnk := In_memory v;
+      v)
+    else
+      failwith "Granular_marshal.read_loc: pointing to an outdated index file"
 
 let reuse lnk =
   match !lnk with
@@ -164,7 +185,7 @@ let write ?(flags = []) fd root_schema root_value rand_state =
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
           | On_disk { store; loc; _ } ->
-            let id = fetch_id store.filename in
+            let id = fetch_id store in
             lnk := On_disk_ptr { filename = store.filename; loc; id })
     }
   and write_child : type a. a link -> a schema -> a -> _ =

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -24,8 +24,7 @@ and 'a schema = iter -> 'a -> unit
 and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 
 exception
-  Outdated_store of
-    { filename : string; reason : [ `Missing_file | `Index_ids_do_not_match ] }
+  Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
 
 let schema_no_sublinks : _ schema = fun _ _ -> ()
 
@@ -68,14 +67,15 @@ let () =
       | Some (_, fd) -> close_in fd)
 
 let force_open_store store =
-  let fd = open_in_bin store.filename in
-
-  seek_in fd (String.length Config.index_magic_number);
-  let required_id = int_of_binstring (really_input_string fd ptr_size) in
-  if required_id = store.id then (
-    last_open_store := Some (store, fd);
-    fd)
-  else failwith "Granular_marshal.read_loc: pointing to an outdated index file"
+  try
+    let fd = open_in_bin store.filename in
+    seek_in fd (String.length Config.index_magic_number);
+    let required_id = int_of_binstring (really_input_string fd ptr_size) in
+    if required_id = store.id then (
+      last_open_store := Some (store, fd);
+      fd)
+    else raise (Outdated_store `Index_ids_doesn't_match)
+  with Sys_error _ -> raise (Outdated_store (`Missing_file store.filename))
 
 let open_store store =
   match !last_open_store with

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -93,7 +93,9 @@ let read_loc store fd loc schema =
             if pointed_index_id = id then
               let store = { filename; cache = Cache_cache.read filename } in
               lnk := On_disk { store; loc; schema }
-            else failwith "error"
+            else
+              failwith
+                "Granular_marshal.read_loc: pointing to an outdated index file"
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -186,8 +186,7 @@ let write ?(flags = []) fd root_schema root_value =
   output_string fd (binstring_of_int root_loc)
 
 let read filename fd root_schema =
-  let id = int_of_binstring (really_input_string fd 8) in
-  let store = { filename; id; cache = Cache_cache.read filename } in
+  let store = { filename; cache = Cache_cache.read filename } in
   let root_loc = int_of_binstring (really_input_string fd 8) in
   let root_value = read_loc store fd root_loc root_schema in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -13,7 +13,7 @@ and 'a repr =
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
   | On_disk of { store : store; loc : int; schema : 'a schema }
-  | On_disk_ptr of { filename : string; loc : int }
+  | On_disk_ptr of { filename : string; loc : int; id : int }
   | In_memory of 'a
   | In_memory_reused of 'a
   | Duplicate of 'a link
@@ -48,6 +48,22 @@ module Cache_cache = File_cache.Make (struct
   let cache_name = "Cache_cache"
 end)
 
+let ptr_size = 8
+
+let binstring_of_int v =
+  String.init ptr_size (fun i -> Char.chr ((v lsr i lsl 3) land 255))
+
+let int_of_binstring s =
+  Array.fold_right
+    (fun v acc -> (acc lsl 8) + v)
+    (Array.init ptr_size (fun i -> Char.code s.[i]))
+    0
+
+let fetch_id filename =
+  In_channel.with_open_bin filename (fun fd ->
+      seek_in fd (String.length Config.index_magic_number);
+      int_of_binstring (really_input_string fd ptr_size))
+
 let read_loc store fd loc schema =
   seek_in fd loc;
   let v = Marshal.from_channel fd in
@@ -72,9 +88,12 @@ let read_loc store fd loc schema =
               lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
           | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
-          | On_disk_ptr { filename; loc } ->
-            let store = { filename; cache = Cache_cache.read filename } in
-            lnk := On_disk { store; loc; schema }
+          | On_disk_ptr { filename; loc; id } ->
+            let pointed_index_id = fetch_id filename in
+            if pointed_index_id = id then
+              let store = { filename; cache = Cache_cache.read filename } in
+              lnk := On_disk { store; loc; schema }
+            else failwith "error"
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in
@@ -119,18 +138,9 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
       lnk := Duplicate original_lnk
     | exception Not_found -> H.add cache key lnk
 
-let ptr_size = 8
-
-let binstring_of_int v =
-  String.init ptr_size (fun i -> Char.chr ((v lsr i lsl 3) land 255))
-
-let int_of_binstring s =
-  Array.fold_right
-    (fun v acc -> (acc lsl 8) + v)
-    (Array.init ptr_size (fun i -> Char.code s.[i]))
-    0
-
 let write ?(flags = []) fd root_schema root_value =
+  let id = Random.int ((Float.pow 2. 30. |> Float.to_int) - 1) in
+  output_string fd (binstring_of_int id);
   let pt_root = pos_out fd in
   output_string fd (String.make ptr_size '\000');
   let rec iter size ~placeholders ~restore =
@@ -148,7 +158,8 @@ let write ?(flags = []) fd root_schema root_value =
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
           | On_disk { store; loc; _ } ->
-            lnk := On_disk_ptr { filename = store.filename; loc })
+            let id = fetch_id store.filename in
+            lnk := On_disk_ptr { filename = store.filename; loc; id })
     }
   and write_child : type a. a link -> a schema -> a -> _ =
    fun lnk schema v size ~placeholders ~restore ->
@@ -187,6 +198,7 @@ let write ?(flags = []) fd root_schema root_value =
 
 let read filename fd root_schema =
   let store = { filename; cache = Cache_cache.read filename } in
+  let _id = really_input_string fd 8 in
   let root_loc = int_of_binstring (really_input_string fd 8) in
   let root_value = read_loc store fd root_loc root_schema in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -6,7 +6,7 @@ and cache = any_link Cache.t
 
 and any_link = Link : 'a link * 'a link Type.Id.t -> any_link
 
-and papa_link = PLink : 'a link -> papa_link
+and parent_link = PLink : 'a link -> parent_link
 
 and any_value = Value : 'a -> any_value
 
@@ -16,7 +16,7 @@ and 'a link = 'a repr ref
 
 and 'a repr =
   | Small of 'a
-  | Small_from_papa of { papa : papa_link; pos : int }
+  | Small_child of { parent : parent_link; pos : int }
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
   | On_disk of { store : store; loc : int; schema : 'a schema }
@@ -120,7 +120,7 @@ let open_store store =
     force_open_store store
   | None -> force_open_store store
 
-let read_loc store fd loc schema papa_link =
+let read_loc store fd loc schema parent_link =
   seek_in fd loc;
   let v = Marshal.from_channel fd in
   let size_read = pos_in fd - loc in
@@ -132,8 +132,8 @@ let read_loc store fd loc schema papa_link =
           match !lnk with
           | Small v ->
             schema iter v;
-            child_smalls:= (Value (Obj.magic v)) :: !child_smalls;
-            lnk := Small_from_papa { papa = papa_link; pos = !child_pos };
+            child_smalls:= (Value v) :: !child_smalls;
+            lnk := Small_child { parent = parent_link; pos = !child_pos };
             child_pos := !child_pos + 1
           | Serialized { loc } -> lnk := On_disk { store; loc; schema }
           | Serialized_reused { loc } -> (
@@ -148,7 +148,7 @@ let read_loc store fd loc schema papa_link =
             | None ->
               lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
-          | In_memory _ | In_cache _ | In_memory_reused _ | On_disk _ | Small_from_papa _ | Duplicate _ -> ()
+          | In_memory _ | In_cache _ | In_memory_reused _ | On_disk _ | Small_child _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc; id } ->
             let store = { filename; id; cache = Cache_cache.read filename } in
             lnk := On_disk { store; loc; schema }
@@ -168,12 +168,12 @@ let () =
       Dbllist.pp_stats lru;
       )
 
-let fetch_loc store loc schema papa_link =
+let fetch_loc store loc schema parent_link =
   let fd = open_store store in
-  let v, size, small_poses = read_loc store fd loc schema papa_link in
+  let v, size, small_poses = read_loc store fd loc schema parent_link in
   (v, size, small_poses)
 
-let rec fetch lnk =
+let rec fetch : type a. a link -> a = fun lnk ->
   match !lnk with
   | In_cache (v, cell, _) ->
     let Cached (_, _loc, _, _) = Dbllist.get cell in
@@ -183,15 +183,11 @@ let rec fetch lnk =
   | Serialized _ | Serialized_reused _ | Small _ | On_disk_ptr _ ->
     invalid_arg "Granular_marshal.fetch: serialized"
   | Placeholder -> invalid_arg "Granular_marshal.fetch: during a write"
-  | Duplicate original_lnk ->
-    fetch original_lnk
-    (* let v = fetch original_lnk in
-    lnk := In_memory v;
-    v *)
-  | Small_from_papa { papa; pos } ->
-    let PLink papa = papa in
-      ignore(fetch (Obj.magic papa));
-      (match !papa with
+  | Duplicate original_lnk -> fetch original_lnk
+  | Small_child { parent; pos } ->
+    let PLink parent = parent in
+      ignore(fetch parent);
+      (match !parent with
       | In_cache (_, _, small_poses) ->
         let Value v = small_poses.(pos) in
         Obj.magic v
@@ -251,7 +247,7 @@ let write ?(flags = []) fd id root_schema root_value =
             | _ -> failwith "Granular_marshal.write: duplicate not reused");
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
-          | Small_from_papa _ ->
+          | Small_child _ ->
             let v = fetch lnk in
             write_child lnk schema v size ~placeholders ~restore
           | In_cache (_v, t, _children) ->
@@ -299,6 +295,6 @@ let read filename fd root_schema =
   let id = int_of_binstring (really_input_string fd 8) in
   let store = { filename; id; cache = Cache_cache.read filename } in
   let root_loc = int_of_binstring (really_input_string fd 8) in
-  let papa_lien = ref (On_disk { loc = root_loc; store; schema = root_schema }) in
-  let root_value, _, _ = read_loc store fd root_loc root_schema (PLink papa_lien) in
+  let parent_link = ref (On_disk { loc = root_loc; store; schema = root_schema }) in
+  let root_value, _, _ = read_loc store fd root_loc root_schema (PLink parent_link) in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -6,18 +6,23 @@ and cache = any_link Cache.t
 
 and any_link = Link : 'a link * 'a link Type.Id.t -> any_link
 
+and papa_link = PLink : 'a link -> papa_link
+
+and any_value = Value : 'a -> any_value
+
 and cached = Cached : 'a link * int * store * 'a schema -> cached
 
 and 'a link = 'a repr ref
 
 and 'a repr =
   | Small of 'a
+  | Small_from_papa of { papa : papa_link; pos : int }
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
   | On_disk of { store : store; loc : int; schema : 'a schema }
   | On_disk_ptr of { filename : string; loc : int; id : int }
   | In_memory of 'a
-  | In_cache of 'a * cached Dbllist.cell
+  | In_cache of 'a * cached Dbllist.cell * any_value array
   | In_memory_reused of 'a
   | Duplicate of 'a link
   | Placeholder
@@ -29,11 +34,10 @@ and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 exception
   Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
 
-let is_lru = ref false
-
 let lru_dbllist : cached Dbllist.t option ref = ref None
 
-let fetch_count = Hashtbl.create 16
+(* let fetch_count = Hashtbl.create 16
+
 let debug h =
   let r = Hashtbl.create 16 in
   Hashtbl.iter (fun _k v ->
@@ -45,11 +49,9 @@ let debug h =
     acc := !acc + v;
     Format.eprintf "fetché %d fois -> %d valeurs\n%!" k v
   ) r;
-  Format.eprintf "en tout : %d valeurs\n%!" !acc
+  Format.eprintf "en tout : %d valeurs\n%!" !acc *)
 
-let create_lru cap =
-  is_lru := true;
-  lru_dbllist := Some (Dbllist.create cap)
+let create_lru cap = lru_dbllist := Some (Dbllist.create cap)
 
 let get_lru () =
   match !lru_dbllist with
@@ -118,17 +120,21 @@ let open_store store =
     force_open_store store
   | None -> force_open_store store
 
-let read_loc store fd loc schema =
+let read_loc store fd loc schema papa_link =
   seek_in fd loc;
   let v = Marshal.from_channel fd in
   let size_read = pos_in fd - loc in
+  let child_pos = ref 0 in
+  let child_smalls = ref [] in
   let rec iter =
     { yield =
         (fun (type a) (lnk : a link) type_id schema ->
           match !lnk with
           | Small v ->
             schema iter v;
-            lnk := In_memory v
+            child_smalls:= (Value (Obj.magic v)) :: !child_smalls;
+            lnk := Small_from_papa { papa = papa_link; pos = !child_pos };
+            child_pos := !child_pos + 1
           | Serialized { loc } -> lnk := On_disk { store; loc; schema }
           | Serialized_reused { loc } -> (
             match Cache.find_opt store.cache loc with
@@ -142,35 +148,34 @@ let read_loc store fd loc schema =
             | None ->
               lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
-          | In_memory _ | In_cache _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
+          | In_memory _ | In_cache _ | In_memory_reused _ | On_disk _ | Small_from_papa _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc; id } ->
             let store = { filename; id; cache = Cache_cache.read filename } in
             lnk := On_disk { store; loc; schema }
-          | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
+          | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder");
     }
   in
   schema iter v;
-  (v, size_read)
+  let small_poses = Array.of_list (List.rev !child_smalls) in
+  (v, size_read, small_poses)
 
 let () =
   at_exit (fun () ->
-    if !is_lru then
+    (* debug fetch_count; *)
     match !lru_dbllist with
     | None -> ()
     | Some lru ->
       Dbllist.pp_stats lru;
-      debug fetch_count;
       )
 
-let fetch_loc store loc schema =
+let fetch_loc store loc schema papa_link =
   let fd = open_store store in
-  let v, size = read_loc store fd loc schema in
-  (v, size)
+  let v, size, small_poses = read_loc store fd loc schema papa_link in
+  (v, size, small_poses)
 
 let rec fetch lnk =
   match !lnk with
-  | In_cache (v, cell) ->
-    assert(!is_lru);
+  | In_cache (v, cell, _) ->
     let Cached (_, _loc, _, _) = Dbllist.get cell in
     Dbllist.promote (get_lru ()) cell;
     v
@@ -183,30 +188,32 @@ let rec fetch lnk =
     (* let v = fetch original_lnk in
     lnk := In_memory v;
     v *)
+  | Small_from_papa { papa; pos } ->
+    let PLink papa = papa in
+      ignore(fetch (Obj.magic papa));
+      (match !papa with
+      | In_cache (_, _, small_poses) ->
+        let Value v = small_poses.(pos) in
+        Obj.magic v
+      | _ -> assert false)
   | On_disk { store; loc; schema } ->
-    if not !is_lru then (
-      let v, _ = fetch_loc store loc schema in
-      lnk := In_memory v;
-      v
-    ) else (
-      let count = try Hashtbl.find fetch_count (loc, store.filename) with Not_found -> 0 in
-      Hashtbl.replace fetch_count (loc, store.filename) (count + 1);
-      let v, size = fetch_loc store loc schema in
-      let discarded = Dbllist.discard_size (get_lru ()) size in
-      let cell =
-        Dbllist.add_front (get_lru ()) (Cached (lnk, loc, store, schema), size)
-      in
-      List.iter
-        (fun (Cached (link, loc, store, schema)) ->
-          link := On_disk { store; loc; schema })
-        discarded;
-      lnk := In_cache (v, cell);
-      v
-    )
+    (* let count = try Hashtbl.find fetch_count (loc, store.filename) with Not_found -> 0 in
+    Hashtbl.replace fetch_count (loc, store.filename) (count + 1); *)
+    let v, size, small_poses = fetch_loc store loc schema (PLink lnk) in
+    let discarded = Dbllist.discard_size (get_lru ()) size in
+    let cell =
+      Dbllist.add_front (get_lru ()) (Cached (lnk, loc, store, schema), size)
+    in
+    List.iter
+      (fun (Cached (link, loc, store, schema)) ->
+        link := On_disk { store; loc; schema })
+      discarded;
+    lnk := In_cache (v, cell, small_poses);
+    v
 
 let rec reuse lnk =
   match !lnk with
-  | In_memory v | In_cache (v, _) -> lnk := In_memory_reused v
+  | In_memory v | In_cache (v, _, _) -> lnk := In_memory_reused v
   | In_memory_reused _ -> ()
   | On_disk _ -> ()
   | Duplicate original_lnk -> reuse original_lnk
@@ -244,7 +251,10 @@ let write ?(flags = []) fd id root_schema root_value =
             | _ -> failwith "Granular_marshal.write: duplicate not reused");
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
-          | In_cache (_, t) ->
+          | Small_from_papa _ ->
+            let v = fetch lnk in
+            write_child lnk schema v size ~placeholders ~restore
+          | In_cache (_v, t, _children) ->
             let Cached (_, loc, {filename; id; _}, _) = t.content in
             lnk := On_disk_ptr { filename; id; loc }
           | On_disk { store = { filename; id; _ }; loc; _ } ->
@@ -289,5 +299,6 @@ let read filename fd root_schema =
   let id = int_of_binstring (really_input_string fd 8) in
   let store = { filename; id; cache = Cache_cache.read filename } in
   let root_loc = int_of_binstring (really_input_string fd 8) in
-  let root_value, _ = read_loc store fd root_loc root_schema in
+  let papa_lien = ref (On_disk { loc = root_loc; store; schema = root_schema }) in
+  let root_value, _, _ = read_loc store fd root_loc root_schema (PLink papa_lien) in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -1,6 +1,6 @@
 module Cache = Hashtbl.Make (Int)
 
-type store = { filename : string; id : int; cache : cache }
+type store = { filename : string; cache : cache }
 
 and cache = any_link Cache.t
 
@@ -48,50 +48,6 @@ module Cache_cache = File_cache.Make (struct
   let cache_name = "Cache_cache"
 end)
 
-let ptr_size = 8
-
-let binstring_of_int v =
-  String.init ptr_size (fun i -> Char.chr ((v lsr i lsl 3) land 255))
-
-let int_of_binstring s =
-  Array.fold_right
-    (fun v acc -> (acc lsl 8) + v)
-    (Array.init ptr_size (fun i -> Char.code s.[i]))
-    0
-
-let last_open_store = ref None
-
-let () =
-  at_exit (fun () ->
-      match !last_open_store with
-      | None -> ()
-      | Some (_, fd) -> close_in fd)
-
-let force_open_store store =
-  try
-    let fd = open_in_bin store.filename in
-    seek_in fd (String.length Config.index_magic_number);
-    let required_id = int_of_binstring (really_input_string fd ptr_size) in
-    if required_id = store.id then (
-      last_open_store := Some (store, fd);
-      fd)
-    else
-      raise
-        (Outdated_store
-           { filename = store.filename; reason = `Index_ids_do_not_match })
-  with Sys_error _ ->
-    raise (Outdated_store { filename = store.filename; reason = `Missing_file })
-
-let open_store store =
-  match !last_open_store with
-  | Some (store', fd)
-    when Int.equal store.id store'.id
-         && String.equal store.filename store'.filename -> fd
-  | Some (_, fd) ->
-    close_in fd;
-    force_open_store store
-  | None -> force_open_store store
-
 let read_loc store fd loc schema =
   seek_in fd loc;
   let v = Marshal.from_channel fd in
@@ -117,9 +73,8 @@ let read_loc store fd loc schema =
               Cache.add store.cache loc (Link (lnk, type_id)))
           | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc } ->
-            lnk :=
-              On_disk
-                { store = { filename; cache = Cache.create 0 }; loc; schema }
+            let store = { filename; cache = Cache_cache.read filename } in
+            lnk := On_disk { store; loc; schema }
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in
@@ -193,7 +148,6 @@ let write ?(flags = []) fd root_schema root_value =
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
           | On_disk { store; loc; _ } ->
-            incr count;
             lnk := On_disk_ptr { filename = store.filename; loc })
     }
   and write_child : type a. a link -> a schema -> a -> _ =

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -176,8 +176,6 @@ let int_of_binstring s =
     0
 
 let write ?(flags = []) fd root_schema root_value =
-  (* TODO: remove this counter *)
-  let count = ref 0 in
   let pt_root = pos_out fd in
   output_string fd (String.make ptr_size '\000');
   let rec iter size ~placeholders ~restore =
@@ -231,7 +229,6 @@ let write ?(flags = []) fd root_schema root_value =
   let root_loc = pos_out fd in
   Marshal.to_channel fd root_value flags;
   seek_out fd pt_root;
-  prerr_endline @@ Int.to_string !count;
   output_string fd (binstring_of_int root_loc)
 
 let read filename fd root_schema =

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -33,8 +33,8 @@ let link v = ref (In_memory v)
 
 let is_on_disk lnk =
   match !lnk with
-  | On_disk _ | On_disk_ptr _ -> false
-  | _ -> true
+  | On_disk _ | On_disk_ptr _ -> true
+  | _ -> false
 
 let rec normalize lnk =
   match !lnk with

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -141,8 +141,12 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
     | exception Not_found -> H.add cache key lnk
 
 let write ?(flags = []) fd root_schema root_value =
-  let id = Random.int ((Float.pow 2. 30. |> Float.to_int) - 1) in
-  output_string fd (binstring_of_int id);
+  let id =
+    let buf = Bytes.create 8 in
+    Bytes.set_int64_be buf 0 (Random.int64 Int64.max_int);
+    Bytes.to_string buf
+  in
+  output_string fd id;
   let pt_root = pos_out fd in
   output_string fd (String.make ptr_size '\000');
   let rec iter size ~placeholders ~restore =

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -1,6 +1,6 @@
 module Cache = Hashtbl.Make (Int)
 
-type store = { filename : string; cache : cache }
+type store = { filename : string; id : int; cache : cache }
 
 and cache = any_link Cache.t
 
@@ -12,7 +12,7 @@ and 'a repr =
   | Small of 'a
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
-  | On_disk of { store : store; loc : int; schema : 'a schema; id : int }
+  | On_disk of { store : store; loc : int; schema : 'a schema }
   | On_disk_ptr of { filename : string; loc : int; id : int }
   | In_memory of 'a
   | In_memory_reused of 'a
@@ -69,8 +69,13 @@ let () =
 
 let force_open_store store =
   let fd = open_in_bin store.filename in
-  last_open_store := Some (store, fd);
-  fd
+
+  seek_in fd (String.length Config.index_magic_number);
+  let required_id = int_of_binstring (really_input_string fd ptr_size) in
+  if required_id = store.id then (
+    last_open_store := Some (store, fd);
+    fd)
+  else failwith "Granular_marshal.read_loc: pointing to an outdated index file"
 
 let open_store store =
   match !last_open_store with
@@ -79,11 +84,6 @@ let open_store store =
     close_in fd;
     force_open_store store
   | None -> force_open_store store
-
-let fetch_id store =
-  let fd = open_store store in
-  seek_in fd (String.length Config.index_magic_number);
-  int_of_binstring (really_input_string fd ptr_size)
 
 let read_loc store fd loc schema =
   seek_in fd loc;
@@ -95,8 +95,7 @@ let read_loc store fd loc schema =
           | Small v ->
             schema iter v;
             lnk := In_memory v
-          | Serialized { loc } ->
-            lnk := On_disk { store; loc; schema; id = fetch_id store }
+          | Serialized { loc } -> lnk := On_disk { store; loc; schema }
           | Serialized_reused { loc } -> (
             match Cache.find store.cache loc with
             | Link (type b) ((lnk', type_id') : b link * _) -> (
@@ -107,12 +106,12 @@ let read_loc store fd loc schema =
                 invalid_arg
                   "Granular_marshal.read_loc: reuse of a different type")
             | exception Not_found ->
-              lnk := On_disk { store; loc; schema; id = fetch_id store };
+              lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
           | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc; id } ->
-            let store = { filename; cache = Cache_cache.read filename } in
-            lnk := On_disk { store; loc; schema; id }
+            let store = { filename; id; cache = Cache_cache.read filename } in
+            lnk := On_disk { store; loc; schema }
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in
@@ -134,14 +133,10 @@ let rec fetch lnk =
     let v = fetch original_lnk in
     lnk := In_memory v;
     v
-  | On_disk { store; loc; schema; id } ->
-    let pointed_index_id = fetch_id store in
-    if pointed_index_id = id then (
-      let v = fetch_loc store loc schema in
-      lnk := In_memory v;
-      v)
-    else
-      failwith "Granular_marshal.read_loc: pointing to an outdated index file"
+  | On_disk { store; loc; schema } ->
+    let v = fetch_loc store loc schema in
+    lnk := In_memory v;
+    v
 
 let reuse lnk =
   match !lnk with
@@ -161,12 +156,8 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
       lnk := Duplicate original_lnk
     | exception Not_found -> H.add cache key lnk
 
-let write ?(flags = []) fd root_schema root_value rand_state =
-  let id =
-    let buf = Bytes.create 8 in
-    Bytes.set_int64_be buf 0 (Random.State.int64 rand_state Int64.max_int);
-    Bytes.to_string buf
-  in
+let write ?(flags = []) fd id root_schema root_value =
+  let id = binstring_of_int id in
   output_string fd id;
   let pt_root = pos_out fd in
   output_string fd (String.make ptr_size '\000');
@@ -184,9 +175,8 @@ let write ?(flags = []) fd root_schema root_value rand_state =
             | _ -> failwith "Granular_marshal.write: duplicate not reused");
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
-          | On_disk { store; loc; _ } ->
-            let id = fetch_id store in
-            lnk := On_disk_ptr { filename = store.filename; loc; id })
+          | On_disk { store = { filename; id; _ }; loc; _ } ->
+            lnk := On_disk_ptr { filename; id; loc })
     }
   and write_child : type a. a link -> a schema -> a -> _ =
    fun lnk schema v size ~placeholders ~restore ->
@@ -224,8 +214,8 @@ let write ?(flags = []) fd root_schema root_value rand_state =
   output_string fd (binstring_of_int root_loc)
 
 let read filename fd root_schema =
-  let store = { filename; cache = Cache_cache.read filename } in
-  let _id = really_input_string fd 8 in
+  let id = int_of_binstring (really_input_string fd 8) in
+  let store = { filename; id; cache = Cache_cache.read filename } in
   let root_loc = int_of_binstring (really_input_string fd 8) in
   let root_value = read_loc store fd root_loc root_schema in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -32,7 +32,8 @@ and 'a schema = iter -> 'a -> unit
 and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 
 exception
-  Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
+  Outdated_store of
+    { filename : string; reason : [ `Missing_file | `Index_ids_do_not_match ] }
 
 let lru_dbllist : cached Dbllist.t option ref = ref None
 
@@ -57,7 +58,7 @@ let get_lru () =
   match !lru_dbllist with
   | Some lru -> lru
   | None ->
-    let lru = Dbllist.create 1_000 in
+    let lru = Dbllist.create 1_000_000 in
     lru_dbllist := Some lru;
     lru
 
@@ -109,12 +110,18 @@ let force_open_store store =
     if required_id = store.id then (
       last_open_store := Some (store, fd);
       fd)
-    else raise (Outdated_store `Index_ids_doesn't_match)
-  with Sys_error _ -> raise (Outdated_store (`Missing_file store.filename))
+    else
+      raise
+        (Outdated_store
+           { filename = store.filename; reason = `Index_ids_do_not_match })
+  with Sys_error _ ->
+    raise (Outdated_store { filename = store.filename; reason = `Missing_file })
 
 let open_store store =
   match !last_open_store with
-  | Some (store', fd) when store == store' -> fd
+  | Some (store', fd)
+    when Int.equal store.id store'.id
+         && String.equal store.filename store'.filename -> fd
   | Some (_, fd) ->
     close_in fd;
     force_open_store store

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -13,7 +13,7 @@ and 'a repr =
   | Serialized of { loc : int }
   | Serialized_reused of { loc : int }
   | On_disk of { store : store; loc : int; schema : 'a schema }
-  | On_disk_ptr of { filename : string; loc : int; id : int }
+  | On_disk_ptr of { filename : string; loc : int }
   | In_memory of 'a
   | In_memory_reused of 'a
   | Duplicate of 'a link
@@ -33,8 +33,8 @@ let link v = ref (In_memory v)
 
 let is_on_disk lnk =
   match !lnk with
-  | On_disk _ | On_disk_ptr _ -> true
-  | _ -> false
+  | On_disk _ | On_disk_ptr _ -> false
+  | _ -> true
 
 let rec normalize lnk =
   match !lnk with
@@ -116,9 +116,10 @@ let read_loc store fd loc schema =
               lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
           | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
-          | On_disk_ptr { filename; loc; id } ->
-            let store = { filename; id; cache = Cache_cache.read filename } in
-            lnk := On_disk { store; loc; schema }
+          | On_disk_ptr { filename; loc } ->
+            lnk :=
+              On_disk
+                { store = { filename; cache = Cache.create 0 }; loc; schema }
           | Placeholder -> invalid_arg "Granular_marshal.read_loc: Placeholder")
     }
   in
@@ -163,9 +164,20 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
       lnk := Duplicate original_lnk
     | exception Not_found -> H.add cache key lnk
 
-let write ?(flags = []) fd ~id root_schema root_value =
-  let id = binstring_of_int id in
-  output_string fd id;
+let ptr_size = 8
+
+let binstring_of_int v =
+  String.init ptr_size (fun i -> Char.chr ((v lsr i lsl 3) land 255))
+
+let int_of_binstring s =
+  Array.fold_right
+    (fun v acc -> (acc lsl 8) + v)
+    (Array.init ptr_size (fun i -> Char.code s.[i]))
+    0
+
+let write ?(flags = []) fd root_schema root_value =
+  (* TODO: remove this counter *)
+  let count = ref 0 in
   let pt_root = pos_out fd in
   output_string fd (String.make ptr_size '\000');
   let rec iter size ~placeholders ~restore =
@@ -182,8 +194,9 @@ let write ?(flags = []) fd ~id root_schema root_value =
             | _ -> failwith "Granular_marshal.write: duplicate not reused");
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
-          | On_disk { store = { filename; id; _ }; loc; _ } ->
-            lnk := On_disk_ptr { filename; id; loc })
+          | On_disk { store; loc; _ } ->
+            incr count;
+            lnk := On_disk_ptr { filename = store.filename; loc })
     }
   and write_child : type a. a link -> a schema -> a -> _ =
    fun lnk schema v size ~placeholders ~restore ->
@@ -218,6 +231,7 @@ let write ?(flags = []) fd ~id root_schema root_value =
   let root_loc = pos_out fd in
   Marshal.to_channel fd root_value flags;
   seek_out fd pt_root;
+  prerr_endline @@ Int.to_string !count;
   output_string fd (binstring_of_int root_loc)
 
 let read filename fd root_schema =

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -6,6 +6,8 @@ and cache = any_link Cache.t
 
 and any_link = Link : 'a link * 'a link Type.Id.t -> any_link
 
+and cached = Cached : 'a link * int * store * 'a schema -> cached
+
 and 'a link = 'a repr ref
 
 and 'a repr =
@@ -15,6 +17,7 @@ and 'a repr =
   | On_disk of { store : store; loc : int; schema : 'a schema }
   | On_disk_ptr of { filename : string; loc : int; id : int }
   | In_memory of 'a
+  | In_cache of 'a * cached Dbllist.cell
   | In_memory_reused of 'a
   | Duplicate of 'a link
   | Placeholder
@@ -26,13 +29,43 @@ and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 exception
   Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
 
+let is_lru = ref false
+
+let lru_dbllist : cached Dbllist.t option ref = ref None
+
+let fetch_count = Hashtbl.create 16
+let debug h =
+  let r = Hashtbl.create 16 in
+  Hashtbl.iter (fun _k v ->
+    let count = try Hashtbl.find r v with Not_found -> 0 in
+    Hashtbl.replace r v (count + 1);
+  ) h;
+  let acc = ref 0 in
+  Hashtbl.iter (fun k v ->
+    acc := !acc + v;
+    Format.eprintf "fetché %d fois -> %d valeurs\n%!" k v
+  ) r;
+  Format.eprintf "en tout : %d valeurs\n%!" !acc
+
+let create_lru cap =
+  is_lru := true;
+  lru_dbllist := Some (Dbllist.create cap)
+
+let get_lru () =
+  match !lru_dbllist with
+  | Some lru -> lru
+  | None ->
+    let lru = Dbllist.create 1_000 in
+    lru_dbllist := Some lru;
+    lru
+
 let schema_no_sublinks : _ schema = fun _ _ -> ()
 
 let link v = ref (In_memory v)
 
 let is_on_disk lnk =
   match !lnk with
-  | On_disk _ | On_disk_ptr _ -> true
+  | On_disk _ | On_disk_ptr _ | In_cache _ -> true
   | _ -> false
 
 let rec normalize lnk =
@@ -88,6 +121,7 @@ let open_store store =
 let read_loc store fd loc schema =
   seek_in fd loc;
   let v = Marshal.from_channel fd in
+  let size_read = pos_in fd - loc in
   let rec iter =
     { yield =
         (fun (type a) (lnk : a link) type_id schema ->
@@ -97,18 +131,18 @@ let read_loc store fd loc schema =
             lnk := In_memory v
           | Serialized { loc } -> lnk := On_disk { store; loc; schema }
           | Serialized_reused { loc } -> (
-            match Cache.find store.cache loc with
-            | Link (type b) ((lnk', type_id') : b link * _) -> (
+            match Cache.find_opt store.cache loc with
+            | Some (Link (type b) ((lnk', type_id') : b link * _)) -> (
               match Type.Id.provably_equal type_id type_id' with
               | Some (Equal : (a link, b link) Type.eq) ->
                 lnk := Duplicate (normalize lnk')
               | None ->
                 invalid_arg
                   "Granular_marshal.read_loc: reuse of a different type")
-            | exception Not_found ->
+            | None ->
               lnk := On_disk { store; loc; schema };
               Cache.add store.cache loc (Link (lnk, type_id)))
-          | In_memory _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
+          | In_memory _ | In_cache _ | In_memory_reused _ | On_disk _ | Duplicate _ -> ()
           | On_disk_ptr { filename; loc; id } ->
             let store = { filename; id; cache = Cache_cache.read filename } in
             lnk := On_disk { store; loc; schema }
@@ -116,32 +150,66 @@ let read_loc store fd loc schema =
     }
   in
   schema iter v;
-  v
+  (v, size_read)
+
+let () =
+  at_exit (fun () ->
+    if !is_lru then
+    match !lru_dbllist with
+    | None -> ()
+    | Some lru ->
+      Dbllist.pp_stats lru;
+      debug fetch_count;
+      )
 
 let fetch_loc store loc schema =
   let fd = open_store store in
-  let v = read_loc store fd loc schema in
-  v
+  let v, size = read_loc store fd loc schema in
+  (v, size)
 
 let rec fetch lnk =
   match !lnk with
+  | In_cache (v, cell) ->
+    assert(!is_lru);
+    let Cached (_, _loc, _, _) = Dbllist.get cell in
+    Dbllist.promote (get_lru ()) cell;
+    v
   | In_memory v | In_memory_reused v -> v
   | Serialized _ | Serialized_reused _ | Small _ | On_disk_ptr _ ->
     invalid_arg "Granular_marshal.fetch: serialized"
   | Placeholder -> invalid_arg "Granular_marshal.fetch: during a write"
   | Duplicate original_lnk ->
-    let v = fetch original_lnk in
+    fetch original_lnk
+    (* let v = fetch original_lnk in
     lnk := In_memory v;
-    v
+    v *)
   | On_disk { store; loc; schema } ->
-    let v = fetch_loc store loc schema in
-    lnk := In_memory v;
-    v
+    if not !is_lru then (
+      let v, _ = fetch_loc store loc schema in
+      lnk := In_memory v;
+      v
+    ) else (
+      let count = try Hashtbl.find fetch_count (loc, store.filename) with Not_found -> 0 in
+      Hashtbl.replace fetch_count (loc, store.filename) (count + 1);
+      let v, size = fetch_loc store loc schema in
+      let discarded = Dbllist.discard_size (get_lru ()) size in
+      let cell =
+        Dbllist.add_front (get_lru ()) (Cached (lnk, loc, store, schema), size)
+      in
+      List.iter
+        (fun (Cached (link, loc, store, schema)) ->
+          link := On_disk { store; loc; schema })
+        discarded;
+      lnk := In_cache (v, cell);
+      v
+    )
 
-let reuse lnk =
+let rec reuse lnk =
   match !lnk with
-  | In_memory v -> lnk := In_memory_reused v
+  | In_memory v | In_cache (v, _) -> lnk := In_memory_reused v
   | In_memory_reused _ -> ()
+  | On_disk _ -> ()
+  | Duplicate original_lnk -> reuse original_lnk
   | _ -> invalid_arg "Granular_marshal.reuse: not in memory"
 
 let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
@@ -152,6 +220,7 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
     match H.find cache key with
     | original_lnk ->
       assert (original_lnk != lnk);
+      let original_lnk = normalize original_lnk in
       reuse original_lnk;
       lnk := Duplicate original_lnk
     | exception Not_found -> H.add cache key lnk
@@ -170,11 +239,14 @@ let write ?(flags = []) fd id root_schema root_value =
           | In_memory_reused v -> write_child_reused lnk schema v
           | Duplicate original_lnk ->
             (match !original_lnk with
-            | Serialized_reused _ -> ()
+            | Serialized_reused _ | On_disk_ptr _ -> ()
             | In_memory_reused v -> write_child_reused original_lnk schema v
             | _ -> failwith "Granular_marshal.write: duplicate not reused");
             lnk := !original_lnk
           | In_memory v -> write_child lnk schema v size ~placeholders ~restore
+          | In_cache (_, t) ->
+            let Cached (_, loc, {filename; id; _}, _) = t.content in
+            lnk := On_disk_ptr { filename; id; loc }
           | On_disk { store = { filename; id; _ }; loc; _ } ->
             lnk := On_disk_ptr { filename; id; loc })
     }
@@ -217,5 +289,5 @@ let read filename fd root_schema =
   let id = int_of_binstring (really_input_string fd 8) in
   let store = { filename; id; cache = Cache_cache.read filename } in
   let root_loc = int_of_binstring (really_input_string fd 8) in
-  let root_value = read_loc store fd root_loc root_schema in
+  let root_value, _ = read_loc store fd root_loc root_schema in
   root_value

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -52,7 +52,7 @@ let debug h =
   ) r;
   Format.eprintf "en tout : %d valeurs\n%!" !acc *)
 
-let create_lru cap = lru_dbllist := Some (Dbllist.create cap)
+(* let create_lru cap = lru_dbllist := Some (Dbllist.create cap) *)
 
 let get_lru () =
   match !lru_dbllist with
@@ -96,12 +96,6 @@ let int_of_binstring s =
 
 let last_open_store = ref None
 
-let () =
-  at_exit (fun () ->
-      match !last_open_store with
-      | None -> ()
-      | Some (_, fd) -> close_in fd)
-
 let force_open_store store =
   try
     let fd = open_in_bin store.filename in
@@ -139,7 +133,7 @@ let read_loc store fd loc schema parent_link =
           match !lnk with
           | Small v ->
             schema iter v;
-            child_smalls:= (Value v) :: !child_smalls;
+            child_smalls := (Value v) :: !child_smalls;
             lnk := Small_child { parent = parent_link; pos = !child_pos };
             child_pos := !child_pos + 1
           | Serialized { loc } -> lnk := On_disk { store; loc; schema }
@@ -165,15 +159,6 @@ let read_loc store fd loc schema parent_link =
   schema iter v;
   let small_poses = Array.of_list (List.rev !child_smalls) in
   (v, size_read, small_poses)
-
-let () =
-  at_exit (fun () ->
-    (* debug fetch_count; *)
-    match !lru_dbllist with
-    | None -> ()
-    | Some lru ->
-      Dbllist.pp_stats lru;
-      )
 
 let fetch_loc store loc schema parent_link =
   let fd = open_store store in
@@ -266,8 +251,20 @@ let write ?(flags = []) fd id root_schema root_value =
   and write_child : type a. a link -> a schema -> a -> _ =
    fun lnk schema v size ~placeholders ~restore ->
     let v_size = write_children schema v in
-    if v_size > 1024 then (
+    if v_size > 1 then (
       lnk := Serialized { loc = pos_out fd };
+      let rec iter =
+        { yield =
+            (fun (type b) (lnk : b link) _type_id schema ->
+              match !lnk with
+              | Small v -> schema iter v
+              | On_disk { store = { filename; id; _ }; loc; _ } ->
+                lnk := On_disk_ptr { filename; id; loc }
+              | _ -> ()
+            );
+        }
+      in
+      schema iter v;
       Marshal.to_channel fd v flags)
     else (
       size := !size + v_size;
@@ -294,6 +291,18 @@ let write ?(flags = []) fd id root_schema root_value =
   in
   let _ : int = write_children root_schema root_value in
   let root_loc = pos_out fd in
+  let rec iter =
+    { yield =
+        (fun (type b) (lnk : b link) _type_id schema ->
+          match !lnk with
+          | Small v -> schema iter v
+          | On_disk { store = { filename; id; _ }; loc; _ } ->
+            lnk := On_disk_ptr { filename; id; loc }
+          | _ -> ()
+        );
+    }
+  in
+  root_schema iter root_value;
   Marshal.to_channel fd root_value flags;
   seek_out fd pt_root;
   output_string fd (binstring_of_int root_loc)
@@ -305,3 +314,18 @@ let read filename fd root_schema =
   let parent_link = ref (On_disk { loc = root_loc; store; schema = root_schema }) in
   let root_value, _, _ = read_loc store fd root_loc root_schema (PLink parent_link) in
   root_value
+
+let () =
+  at_exit (fun () ->
+      match !last_open_store with
+      | None -> ()
+      | Some (_, fd) -> close_in fd)
+
+let () =
+  at_exit (fun () ->
+    (* debug fetch_count; *)
+    match !lru_dbllist with
+    | None -> ()
+    | Some lru ->
+      Dbllist.pp_stats lru;
+      )

--- a/src/index-format/granular_marshal.ml
+++ b/src/index-format/granular_marshal.ml
@@ -140,10 +140,10 @@ let cache (type a) (module Key : Hashtbl.HashedType with type t = a) =
       lnk := Duplicate original_lnk
     | exception Not_found -> H.add cache key lnk
 
-let write ?(flags = []) fd root_schema root_value =
+let write ?(flags = []) fd root_schema root_value rand_state =
   let id =
     let buf = Bytes.create 8 in
-    Bytes.set_int64_be buf 0 (Random.int64 Int64.max_int);
+    Bytes.set_int64_be buf 0 (Random.State.int64 rand_state Int64.max_int);
     Bytes.to_string buf
   in
   output_string fd id;

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -56,9 +56,18 @@ and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 (** A schema usable when the ['a] value does not contain any links. *)
 val schema_no_sublinks : 'a schema
 
+(** Exception raised when attempting to consult an outdated store. *)
+exception
+  Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
+
 (** [write oc id schema value] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [id] is used as index UID. *)
 val write :
-  ?flags:Marshal.extern_flags list -> out_channel -> int -> 'a schema -> 'a -> unit
+  ?flags:Marshal.extern_flags list ->
+  out_channel ->
+  int ->
+  'a schema ->
+  'a ->
+  unit
 
 (** [read ic schema] reads the value marshalled in the input channel [ic],
     stopping the unmarshalling on every link boundary indicated by the [schema].

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -1,6 +1,12 @@
 (** A pointer to an ['a] value, either residing in memory or on disk. *)
 type 'a link
 
+type cached
+
+val create_lru : int -> unit
+
+val get_lru : unit -> cached Dbllist.t
+
 (** [link v] returns a new link to the in-memory value [v]. *)
 val link : 'a -> 'a link
 

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -56,9 +56,9 @@ and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 (** A schema usable when the ['a] value does not contain any links. *)
 val schema_no_sublinks : 'a schema
 
-(** [write oc schema value rand_state] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [rand_state] is used to generate random index ID. *)
+(** [write oc id schema value] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [id] is used as index UID. *)
 val write :
-  ?flags:Marshal.extern_flags list -> out_channel -> 'a schema -> 'a -> Random.State.t -> unit
+  ?flags:Marshal.extern_flags list -> out_channel -> int -> 'a schema -> 'a -> unit
 
 (** [read ic schema] reads the value marshalled in the input channel [ic],
     stopping the unmarshalling on every link boundary indicated by the [schema].

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -56,19 +56,9 @@ and iter = { yield : 'a. 'a link -> 'a link Type.Id.t -> 'a schema -> unit }
 (** A schema usable when the ['a] value does not contain any links. *)
 val schema_no_sublinks : 'a schema
 
-(** Exception raised when attempting to consult an outdated store. *)
-exception
-  Outdated_store of
-    { filename : string; reason : [ `Missing_file | `Index_ids_do_not_match ] }
-
-(** [write oc ~id schema value] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [id] is used as index UID. *)
+(** [write oc schema value rand_state] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [rand_state] is used to generate random index ID. *)
 val write :
-  ?flags:Marshal.extern_flags list ->
-  out_channel ->
-  id:int ->
-  'a schema ->
-  'a ->
-  unit
+  ?flags:Marshal.extern_flags list -> out_channel -> 'a schema -> 'a -> Random.State.t -> unit
 
 (** [read ic schema] reads the value marshalled in the input channel [ic],
     stopping the unmarshalling on every link boundary indicated by the [schema].

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -64,9 +64,10 @@ val schema_no_sublinks : 'a schema
 
 (** Exception raised when attempting to consult an outdated store. *)
 exception
-  Outdated_store of [ `Missing_file of string | `Index_ids_doesn't_match ]
+  Outdated_store of
+    { filename : string; reason : [ `Missing_file | `Index_ids_do_not_match ] }
 
-(** [write oc id schema value] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [id] is used as index UID. *)
+(** [write oc ~id schema value] writes the [value] in the output channel [oc], creating unmarshalling boundaries on every link in [value] specified by the [schema]. [id] is used as index UID. *)
 val write :
   ?flags:Marshal.extern_flags list ->
   out_channel ->

--- a/src/index-format/granular_marshal.mli
+++ b/src/index-format/granular_marshal.mli
@@ -3,7 +3,7 @@ type 'a link
 
 type cached
 
-val create_lru : int -> unit
+(* val create_lru : int -> unit *)
 
 val get_lru : unit -> cached Dbllist.t
 

--- a/src/index-format/granular_set.ml
+++ b/src/index-format/granular_set.ml
@@ -268,7 +268,7 @@ module Make (Ord : Set.OrderedType) = struct
       iter f r
 
   let rec iter_in_memory f t =
-    if Granular_marshal.is_on_disk t then
+    if not (Granular_marshal.is_on_disk t) then
       match fetch t with
       | Empty -> ()
       | Node { l; v; r; _ } ->

--- a/src/index-format/granular_set.ml
+++ b/src/index-format/granular_set.ml
@@ -29,7 +29,6 @@ module type S = sig
   val union : t -> t -> t
   val map : (elt -> elt) -> t -> t
   val iter : (elt -> unit) -> t -> unit
-  val iter_in_memory : (elt -> unit) -> t -> unit
   val cardinal : t -> int
   val elements : t -> elt list
   val fold : ('acc -> elt -> 'acc) -> 'acc -> t -> 'acc
@@ -266,15 +265,6 @@ module Make (Ord : Set.OrderedType) = struct
       iter f l;
       f v;
       iter f r
-
-  let rec iter_in_memory f t =
-    if not (Granular_marshal.is_on_disk t) then
-      match fetch t with
-      | Empty -> ()
-      | Node { l; v; r; _ } ->
-        iter_in_memory f l;
-        f v;
-        iter_in_memory f r
 
   let type_id = Type.Id.make ()
 

--- a/src/index-format/granular_set.ml
+++ b/src/index-format/granular_set.ml
@@ -268,7 +268,7 @@ module Make (Ord : Set.OrderedType) = struct
       iter f r
 
   let rec iter_in_memory f t =
-    if not (Granular_marshal.is_on_disk t) then
+    if Granular_marshal.is_on_disk t then
       match fetch t with
       | Empty -> ()
       | Node { l; v; r; _ } ->

--- a/src/index-format/granular_set.mli
+++ b/src/index-format/granular_set.mli
@@ -27,7 +27,6 @@ module type S = sig
   val union : t -> t -> t
   val map : (elt -> elt) -> t -> t
   val iter : (elt -> unit) -> t -> unit
-  val iter_in_memory : (elt -> unit) -> t -> unit
   val cardinal : t -> int
   val elements : t -> elt list
   val fold : ('acc -> elt -> 'acc) -> 'acc -> t -> 'acc

--- a/src/index-format/index_format.ml
+++ b/src/index-format/index_format.ml
@@ -131,11 +131,11 @@ let magic_number = Config.index_magic_number
 
 let write ~file index =
   let index = compress index in
+  let rand_state = Random.State.make_self_init () in
   Misc.output_to_file_via_temporary ~mode:[ Open_binary ] file
     (fun _temp_file_name oc ->
       output_string oc magic_number;
-      Random.self_init ();
-      Granular_marshal.write oc index_schema (index : index))
+      Granular_marshal.write oc index_schema (index : index) rand_state)
 
 type file_content = Cmt of Cmt_format.cmt_infos | Index of index | Unknown
 

--- a/src/index-format/index_format.ml
+++ b/src/index-format/index_format.ml
@@ -131,11 +131,11 @@ let magic_number = Config.index_magic_number
 
 let write ~file index =
   let index = compress index in
-  let rand_state = Random.State.make_self_init () in
   Misc.output_to_file_via_temporary ~mode:[ Open_binary ] file
     (fun _temp_file_name oc ->
       output_string oc magic_number;
-      Granular_marshal.write oc index_schema (index : index) rand_state)
+      let id = Random.State.(full_int (make_self_init ()) max_int) in
+      Granular_marshal.write oc id index_schema (index : index))
 
 type file_content = Cmt of Cmt_format.cmt_infos | Index of index | Unknown
 

--- a/src/index-format/index_format.ml
+++ b/src/index-format/index_format.ml
@@ -134,8 +134,8 @@ let write ~file index =
   Misc.output_to_file_via_temporary ~mode:[ Open_binary ] file
     (fun _temp_file_name oc ->
       output_string oc magic_number;
-      let id = Random.State.(full_int (make_self_init ()) max_int) in
-      Granular_marshal.write oc ~id index_schema (index : index))
+      Random.self_init ();
+      Granular_marshal.write oc index_schema (index : index))
 
 type file_content = Cmt of Cmt_format.cmt_infos | Index of index | Unknown
 

--- a/src/index-format/index_format.ml
+++ b/src/index-format/index_format.ml
@@ -57,25 +57,6 @@ let index_schema (iter : Granular_marshal.iter) index =
     (fun iter _ v -> Union_find.schema iter v)
     index.related_uids
 
-let compress index =
-  let cache = Lid.cache () in
-  let compress_map_set =
-    Uid_map.iter_in_memory (fun _ ->
-        Lid_set.iter_in_memory (Lid.deduplicate cache))
-  in
-  compress_map_set index.defs;
-  compress_map_set index.approximated;
-  let related_uids =
-    Uid_map.map
-      (fun set ->
-        let uid = Uid_set.min_elt (Union_find.get set) in
-        let reference_set = Uid_map.find uid index.related_uids in
-        Granular_marshal.reuse reference_set;
-        reference_set)
-      index.related_uids
-  in
-  { index with related_uids }
-
 let pp_lidset fmt locs =
   Format.pp_print_list
     ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@;")
@@ -130,7 +111,6 @@ let ext = "ocaml-index"
 let magic_number = Config.index_magic_number
 
 let write ~file index =
-  let index = compress index in
   Misc.output_to_file_via_temporary ~mode:[ Open_binary ] file
     (fun _temp_file_name oc ->
       output_string oc magic_number;

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -77,20 +77,14 @@ let () =
   try
     (match !command with
     | Some Aggregate ->
-      Gc.compact ();
-      let before = Gc.quick_stat () in
       let root = if String.equal "" !root then None else Some !root in
-      Granular_marshal.create_lru 10_000_000;
       Index.from_files ~store_shapes:!store_shapes ~root
         ~rewrite_root:!rewrite_root ~output_file:!output_file
         ~build_path:
           { visible = List.rev !build_path_rev.visible;
             hidden = List.rev !build_path_rev.hidden
           }
-        ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files;
-      Gc.compact ();
-      let after = Gc.quick_stat () in
-      Printf.eprintf "Major words before: %.0f, after: %.0f\n" before.Gc.major_words after.Gc.major_words
+        ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files
     | Some Dump ->
       List.iter
         (fun file ->
@@ -121,12 +115,12 @@ let () =
         !input_files
     | _ -> Printf.printf "Nothing to do.\n%!");
     exit 0
-  with Granular_marshal.Outdated_store reason ->
+  with Granular_marshal.Outdated_store { filename; reason } ->
     let msg =
       match reason with
-      | `Missing_file filename ->
-        Format.asprintf "Missing file \"%s\"." filename
-      | `Index_ids_doesn't_match -> "Index IDs doesn't match."
+      | `Missing_file -> Format.asprintf "Missing file \"%s\"." filename
+      | `Index_ids_do_not_match ->
+        Format.asprintf "Index IDs doesn't match for \"%s\"." filename
     in
     Printf.printf
       "%s\nHint: try to rebuild indexes with dune build @ocaml-index.\n%!" msg;

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -115,12 +115,12 @@ let () =
         !input_files
     | _ -> Printf.printf "Nothing to do.\n%!");
     exit 0
-  with Granular_marshal.Outdated_store { filename; reason } ->
+  with Granular_marshal.Outdated_store reason ->
     let msg =
       match reason with
-      | `Missing_file -> Format.asprintf "Missing file \"%s\"." filename
-      | `Index_ids_do_not_match ->
-        Format.asprintf "Index IDs doesn't match for \"%s\"." filename
+      | `Missing_file filename ->
+        Format.asprintf "Missing file \"%s\"." filename
+      | `Index_ids_doesn't_match -> "Index IDs doesn't match."
     in
     Printf.printf
       "%s\nHint: try to rebuild indexes with dune build @ocaml-index.\n%!" msg;

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -90,7 +90,7 @@ let () =
         ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files;
       Gc.compact ();
       let after = Gc.quick_stat () in
-      Printf.printf "Major words before: %.0f, after: %.0f\n" before.Gc.major_words after.Gc.major_words
+      Printf.eprintf "Major words before: %.0f, after: %.0f\n" before.Gc.major_words after.Gc.major_words
     | Some Dump ->
       List.iter
         (fun file ->

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -77,14 +77,20 @@ let () =
   try
     (match !command with
     | Some Aggregate ->
+      Gc.compact ();
+      let before = Gc.quick_stat () in
       let root = if String.equal "" !root then None else Some !root in
+      Granular_marshal.create_lru 10_000_000;
       Index.from_files ~store_shapes:!store_shapes ~root
         ~rewrite_root:!rewrite_root ~output_file:!output_file
         ~build_path:
           { visible = List.rev !build_path_rev.visible;
             hidden = List.rev !build_path_rev.hidden
           }
-        ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files
+        ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files;
+      Gc.compact ();
+      let after = Gc.quick_stat () in
+      Printf.printf "Major words before: %.0f, after: %.0f\n" before.Gc.major_words after.Gc.major_words
     | Some Dump ->
       List.iter
         (fun file ->

--- a/tests/test-dirs/occurrences/project-wide/union.t
+++ b/tests/test-dirs/occurrences/project-wide/union.t
@@ -37,12 +37,7 @@ Then for `both`:
 
 Merge everything together, which reveals the relation between `test` and `sig` uids:
 
-~66 write operation avoided thanks to on_disk_ptr
   $ ocaml-index aggregate test_sig.ocaml-index project.ocaml-index
-
-~384691 bytes before.
-  $ stat -c "%s" project.ocaml-index
-  167646
 
 All files should be listed on queries: (except `both.ml`)
 

--- a/tests/test-dirs/occurrences/project-wide/union.t
+++ b/tests/test-dirs/occurrences/project-wide/union.t
@@ -37,7 +37,12 @@ Then for `both`:
 
 Merge everything together, which reveals the relation between `test` and `sig` uids:
 
+~66 write operation avoided thanks to on_disk_ptr
   $ ocaml-index aggregate test_sig.ocaml-index project.ocaml-index
+
+~384691 bytes before.
+  $ stat -c "%s" project.ocaml-index
+  167646
 
 All files should be listed on queries: (except `both.ml`)
 


### PR DESCRIPTION
The index links are stored in a Hashtable, which grows without bound as we add new entries. This is using a lot of memory. 
This PR replaces the use of a Hashtable with an LRU cache to bound memory usage, keeping only the most recently used indices and evicting the least recently used entry when the capacity is reached.