### PR TITLE
Fix jq array indexing in issue1949.t

### DIFF
--- a/tests/test-dirs/type-enclosing/issue1949.t
+++ b/tests/test-dirs/type-enclosing/issue1949.t
@@ -3,11 +3,11 @@
   > EOF
 
   $ $MERLIN single type-enclosing -position 1:6 -filename main.ml <main.ml | \
-  > jq '.value.[0].type'
+  > jq '.value[0].type'
   "'a -> 'b -> 'b"
 
 Inconsistent type variables are returned by `type-enclosing`. In term of user experience, the type of `b` it should be `'b`.
 See https://github.com/ocaml/merlin/issues/1949.
   $ $MERLIN single type-enclosing -position 1:14 -filename main.ml <main.ml | \
-  > jq '.value.[0].type'
+  > jq '.value[0].type'
   "'a"


### PR DESCRIPTION
On my system, I was getting:
```
File "tests/test-dirs/type-enclosing/issue1949.t", line 1, characters 0-0:
-tests/test-dirs/type-enclosing/issue1949.t
+tests/test-dirs/type-enclosing/issue1949.t.corrected
File "tests/test-dirs/type-enclosing/issue1949.t", line 7, characters 0-1:
   $ cat >main.ml <<EOF
   > let foo a b = b
   > EOF
 
   $ $MERLIN single type-enclosing -position 1:6 -filename main.ml <main.ml | \
   > jq '.value.[0].type'
-  "'a -> 'b -> 'b"
+  jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
+  .value.[0].type       
+  jq: 1 compile error
+  [3]
 
 Inconsistent type variables are returned by `type-enclosing`. In term of user experience, the type of `b` it should be `'b`.
 See https://github.com/ocaml/merlin/issues/1949.
   $ $MERLIN single type-enclosing -position 1:14 -filename main.ml <main.ml | \
   > jq '.value.[0].type'
-  "'a"
+  jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
+  .value.[0].type       
+  jq: 1 compile error
+  [3]
```

Seemingly, my version of jq (1.6) is unhappy with using `.value.[0]` rather than `.value[0]`. It looks like the former syntax was [added in 1.7](https://github.com/jqlang/jq/pull/2650).