### PR TITLE
Saved parts testing

### DIFF
--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -3874,8 +3874,7 @@ let rec type_exp ?recarg env sexp =
 
 and type_expect ?recarg env sexp ty_expected_explained =
   Msupport.with_saved_types
-    ~save_part:(fun e -> Partial_expression e)
-    ~warning_attribute:sexp.pexp_attributes
+    ~warning_attribute:sexp.pexp_attributes ?save_part:None
       (fun () ->
         let saved = save_levels () in
         try

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -3874,7 +3874,8 @@ let rec type_exp ?recarg env sexp =
 
 and type_expect ?recarg env sexp ty_expected_explained =
   Msupport.with_saved_types
-    ~warning_attribute:sexp.pexp_attributes ?save_part:None
+    ~save_part:(fun e -> Partial_expression e)
+    ~warning_attribute:sexp.pexp_attributes
       (fun () ->
         let saved = save_levels () in
         try

--- a/tests/test-dirs/saved-parts.t
+++ b/tests/test-dirs/saved-parts.t
@@ -1,0 +1,53 @@
+# Small test
+
+A file with 2 type errors:
+- arg passed to "maybe_gen" should be unit, it is an int
+- return type of "maybe_gen" is int option, in a context where an int is expected
+
+  $ cat >foo.ml <<EOF
+  > let maybe_gen () = Some 0 in
+  > (maybe_gen 3) + 2
+  > EOF
+
+  $ $MERLIN single errors -filename foo.ml < foo.ml | grep "message" | wc -l
+  2
+
+The number of "saved parts" corresponds to the number of errors:
+
+  $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
+  > grep "saved-parts" | wc -l
+  2
+
+
+# Bigger test
+
+Basically the same test with one level of nesting, we go from 2 to 4 errors:
+
+  $ cat >foo.ml <<EOF
+  > let maybe_gen () = Some 0 in
+  > (maybe_gen ((maybe_gen 3) + 2)) + 3
+  > EOF
+
+  $ $MERLIN single errors -filename foo.ml < foo.ml | grep "message" | wc -l
+  4
+
+And the number of saved parts stays in sync with the number of errors:
+
+  $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
+  > grep "saved-parts" | wc -l
+  4
+
+And we could nest once more, and everything is fine and linear:
+
+  $ cat >foo.ml <<EOF
+  > let maybe_gen () = Some 0 in
+  > (maybe_gen ((maybe_gen ((maybe_gen 3) + 2)) + 3)) + 4
+  > EOF
+
+  $ $MERLIN single errors -filename foo.ml < foo.ml | grep "message" | wc -l
+  6
+
+  $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
+  > grep "saved-parts" | wc -l
+  6
+

--- a/tests/test-dirs/saved-parts.t
+++ b/tests/test-dirs/saved-parts.t
@@ -16,7 +16,7 @@ The number of "saved parts" corresponds to the number of errors:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  3
+  2
 
 
 # Bigger test
@@ -35,7 +35,7 @@ And the number of saved parts stays in sync with the number of errors:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  9
+  4
 
 And we could nest once more, and everything is fine and linear:
 
@@ -49,4 +49,5 @@ And we could nest once more, and everything is fine and linear:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  21
+  6
+

--- a/tests/test-dirs/saved-parts.t
+++ b/tests/test-dirs/saved-parts.t
@@ -16,7 +16,7 @@ The number of "saved parts" corresponds to the number of errors:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  2
+  3
 
 
 # Bigger test
@@ -35,7 +35,7 @@ And the number of saved parts stays in sync with the number of errors:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  4
+  9
 
 And we could nest once more, and everything is fine and linear:
 
@@ -49,5 +49,4 @@ And we could nest once more, and everything is fine and linear:
 
   $ $MERLIN single dump -what browse -filename foo.ml < foo.ml | \
   > grep "saved-parts" | wc -l
-  6
-
+  21


### PR DESCRIPTION
Some investigations into merlin's saved parts motivated by the review of https://github.com/ocaml/ocaml/pull/14241 .

A very short summary of a couple of long discussions:
- merlin's handling of saved types *in the absence of type errors* is different from the typechecker and seemed potentially incorrect (?)
- turns out if you try to mimick the type checker's behavior, you get unwanted nesting/duplication of the saved-parts, leading to a browse tree blowup (cf. 95ba06e) ; thanks to @let-def for pointing me in this direction, I'd have missed it

Some key points:
- you have to look at the browse tree, because that's where merlin "unfolds" the saved parts, looking at the typedtree straight out of the typechecker wouldn't have shown the issue
- this PR is for illustration purposes ... though if you want to be a bit defensive against future compiler updates, I suggest you reproduce and adapt the latest test (which shows when things blow up) for the other parts of the codebase which currently do not "save parts" on success.
- I suspect the blow up wouldn't produce an observable difference in behavior with regular merlin commands (because most of them deduplicate nodes they receive from enclosing, the nodes they return, etc based on location) ... but it probably maybe could have a negative impact on performances? (notice the uncertainty)