### PR TITLE
Fix locate in let punnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
 
   + merlin library
     - Fix signature-help with type aliases (#2067, fixes #1927)
+    - Fix locate on punned let bindings, to use the common identifier as the
+      expression (instead of the pattern) (#2066)
   + test suite
     - Remove the FIXME line for #1404 as the issue was already fixed and add two tests (#2073).
 

--- a/src/analysis/context.ml
+++ b/src/analysis/context.ml
@@ -118,10 +118,10 @@ let inspect_expression ~cursor ~lid e : t =
   | Texp_constant _ -> Constant
   | _ -> Expr
 
-let inspect_browse_tree ~cursor lid browse : t option =
+let inspect_browse_tree ?disambiguate ~cursor lid browse : t option =
   log ~title:"inspect_context" "current node is: [%s]"
     (String.concat ~sep:"|" (List.map ~f:(Mbrowse.print ()) browse));
-  match Mbrowse.enclosing cursor browse with
+  match Mbrowse.enclosing ?disambiguate cursor browse with
   | [] ->
     log ~title:"inspect_context" "no enclosing around: %a" Lexing.print_position
       cursor;

--- a/src/analysis/context.mli
+++ b/src/analysis/context.mli
@@ -47,6 +47,9 @@ val to_string : t -> string
    information given the selected identifier, the position of the cursor and the
    typed tree. It is used by Locate and Type_enclosing.
 
+   [disambiguate] is used to get the enclosing node when some nodes share the
+   same location (but have different context).
+
    The cursor position is used to distinguished whether a module path or an actual
    constructor name is pointed at when the cursor is in the middle of a
    longident, e.g. [Foo.B|ar.Constructor] (with | being the cursor).
@@ -55,4 +58,8 @@ val to_string : t -> string
    breaking the context inference.
 *)
 val inspect_browse_tree :
-  cursor:Std.Lexing.position -> Longident.t -> Mbrowse.t list -> t option
+  ?disambiguate:Mbrowse.Tie_breaker.t ->
+  cursor:Std.Lexing.position ->
+  Longident.t ->
+  Mbrowse.t list ->
+  t option

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -845,7 +845,10 @@ let infer_namespace ?namespaces ~pos lid browse is_label =
       `Error `Missing_labels_namespace)
   | None -> (
     match
-      (Context.inspect_browse_tree ~cursor:pos lid [ browse ], is_label)
+      ( Context.inspect_browse_tree
+          ~disambiguate:Mbrowse.Tie_breaker.prefer_expression ~cursor:pos lid
+          [ browse ],
+        is_label )
     with
     | None, _ ->
       log ~title:"from_string" "already at origin, doing nothing";

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -844,12 +844,11 @@ let infer_namespace ?namespaces ~pos lid browse is_label =
         "input is clearly a label, but the given namespaces don't cover that";
       `Error `Missing_labels_namespace)
   | None -> (
-    match
-      ( Context.inspect_browse_tree
-          ~disambiguate:Mbrowse.Tie_breaker.prefer_expression ~cursor:pos lid
-          [ browse ],
-        is_label )
-    with
+    let context =
+      let disambiguate = Mbrowse.Tie_breaker.prefer_expression in
+      Context.inspect_browse_tree ~disambiguate ~cursor:pos lid [ browse ]
+    in
+    match (context, is_label) with
     | None, _ ->
       log ~title:"from_string" "already at origin, doing nothing";
       `Error `At_origin

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -562,7 +562,11 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let typer = Mpipeline.typer_result pipeline in
     let local_defs = Mtyper.get_typedtree typer in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
-    let env, _ = Mbrowse.leaf_node (Mtyper.node_at typer pos) in
+    let env, _ =
+      Mbrowse.leaf_node
+        (Mtyper.node_at ~disambiguate:Mbrowse.Tie_breaker.prefer_expression
+           typer pos)
+    in
     let path =
       match patho with
       | Some p -> p

--- a/src/kernel/mbrowse.ml
+++ b/src/kernel/mbrowse.ml
@@ -69,7 +69,6 @@ let node_loc node = approximate_loc Browse_raw.node_real_loc node
 let node_merlin_loc node = approximate_loc Browse_raw.node_merlin_loc node
 
 let leaf_node = List.hd
-let leaf_loc t = node_loc (snd (leaf_node t))
 
 let drop_leaf t =
   match t with
@@ -102,15 +101,30 @@ let select_leafs pos root =
   (try traverse root with Exit -> ());
   !branches
 
-let compare_locations pos l1 l2 =
+module Tie_breaker = struct
+  type tie_break = [ `Prefer_first | `Prefer_second ]
+  type t = node -> node -> tie_break option
+
+  let prefer_expression node1 node2 : tie_break option =
+    match (node1, node2) with
+    | Expression _, Expression _ -> None
+    | Expression _, _ -> Some `Prefer_first
+    | _, Expression _ -> Some `Prefer_second
+    | _ -> None
+end
+
+let compare_locations ?tie_break pos l1 l2 =
   let t2_first = 1 in
   let t1_first = -1 in
   match (Location_aux.compare_pos pos l1, Location_aux.compare_pos pos l2) with
-  (* Cursor inside both locations: favor non-ghost closer to the end *)
+  (* Cursor inside both locations: favor non-ghost, fallback to user-provided
+     tie-break, fallback to being closer to the end *)
   | 0, 0 ->
-    begin match (l1.Location.loc_ghost, l2.Location.loc_ghost) with
-    | true, false -> 1
-    | false, true -> -1
+    begin match (tie_break, l1.Location.loc_ghost, l2.Location.loc_ghost) with
+    | _, true, false -> 1
+    | _, false, true -> -1
+    | Some `Prefer_first, _, _ -> t1_first
+    | Some `Prefer_second, _, _ -> t2_first
     | _ -> Lexing.compare_pos l1.Location.loc_end l2.Location.loc_end
     end
   (* Cursor inside one location: it has priority *)
@@ -122,21 +136,29 @@ let compare_locations pos l1 l2 =
   (* Cursor is after both, select the closest one *)
   | _, _ -> Lexing.compare_pos l2.Location.loc_end l1.Location.loc_end
 
-let best_node pos = function
+let best_node ?disambiguate pos = function
   | [] -> []
   | init :: xs ->
     let f acc x =
-      if compare_locations pos (leaf_loc acc) (leaf_loc x) <= 0 then acc else x
+      let node1 = snd @@ leaf_node acc and node2 = snd @@ leaf_node x in
+      let tie_break =
+        Option.bind
+          ~f:(fun disambiguate -> disambiguate node1 node2)
+          disambiguate
+      in
+      if compare_locations ?tie_break pos (node_loc node1) (node_loc node2) <= 0
+      then acc
+      else x
     in
     List.fold_left ~f ~init xs
 
-let enclosing pos roots =
-  match best_node pos roots with
+let enclosing ?disambiguate pos roots =
+  match best_node ?disambiguate pos roots with
   | [] -> []
-  | root -> best_node pos (select_leafs pos root)
+  | root -> best_node ?disambiguate pos (select_leafs pos root)
 
-let deepest_before pos roots =
-  match enclosing pos roots with
+let deepest_before ?disambiguate pos roots =
+  match enclosing ?disambiguate pos roots with
   | [] -> []
   | root ->
     let rec aux path =
@@ -150,8 +172,15 @@ let deepest_before pos roots =
           || Lexing.compare_pos loc.Location.loc_end loc0.Location.loc_end = 0
         then
           match acc with
-          | Some (_, loc', _) when compare_locations pos loc' loc <= 0 -> acc
-          | Some _ | None -> Some (env, loc, node)
+          | Some (_, loc', node') ->
+            let tie_break =
+              Option.bind
+                ~f:(fun disambiguate -> disambiguate node node')
+                disambiguate
+            in
+            if compare_locations ?tie_break pos loc' loc <= 0 then acc
+            else Some (env, loc, node)
+          | None -> Some (env, loc, node)
         else acc
       in
       match fold_node select_candidate env0 node0 None with

--- a/src/kernel/mbrowse.ml
+++ b/src/kernel/mbrowse.ml
@@ -102,14 +102,14 @@ let select_leafs pos root =
   !branches
 
 module Tie_breaker = struct
-  type tie_break = [ `Prefer_first | `Prefer_second ]
+  type tie_break = Prefer_first | Prefer_second
   type t = node -> node -> tie_break option
 
   let prefer_expression node1 node2 : tie_break option =
     match (node1, node2) with
     | Expression _, Expression _ -> None
-    | Expression _, _ -> Some `Prefer_first
-    | _, Expression _ -> Some `Prefer_second
+    | Expression _, _ -> Some Prefer_first
+    | _, Expression _ -> Some Prefer_second
     | _ -> None
 end
 
@@ -123,8 +123,8 @@ let compare_locations ?tie_break pos l1 l2 =
     begin match (tie_break, l1.Location.loc_ghost, l2.Location.loc_ghost) with
     | _, true, false -> 1
     | _, false, true -> -1
-    | Some `Prefer_first, _, _ -> t1_first
-    | Some `Prefer_second, _, _ -> t2_first
+    | Some Tie_breaker.Prefer_first, _, _ -> t1_first
+    | Some Prefer_second, _, _ -> t2_first
     | _ -> Lexing.compare_pos l1.Location.loc_end l2.Location.loc_end
     end
   (* Cursor inside one location: it has priority *)

--- a/src/kernel/mbrowse.mli
+++ b/src/kernel/mbrowse.mli
@@ -39,16 +39,41 @@ val drop_leaf : t -> t option
 
 (* Navigate through tree *)
 
+module Tie_breaker : sig
+  (** Some nodes in the typedtree may share the same, non-ghost, location, while
+      being different. One example of this is let-punning:
+
+      {@ocaml[
+      let+ x in
+      ]}
+
+      Both [x] as an expression and as a pattern share the exact same location.
+
+      This module is about tie-breaking those cases to select the node that we
+      want.  *)
+
+  (** If [f : t], then [f node1 node2] answers:
+      - [Some `Prefer_first] to select [node1]
+      - [Some `Prefer_first] to select [node1]
+      - [None] to let the default disambiguation mechanism break the tie.
+  *)
+  type t = node -> node -> [ `Prefer_first | `Prefer_second ] option
+
+  (** Tie-break by preferring expression over other nodes *)
+  val prefer_expression : t
+end
+
 (** The deepest context inside or before the node, for instance, navigating
  * through:
  *    foo bar (baz :: tail) <cursor>
  * asking for node from cursor position will return context of "tail".
  * Returns the matching node and all its ancestors or the empty list. *)
-val deepest_before : Lexing.position -> t list -> t
+val deepest_before :
+  ?disambiguate:Tie_breaker.t -> Lexing.position -> t list -> t
 
 val select_open_node : t -> (Path.t * Longident.t * t) option
 
-val enclosing : Lexing.position -> t list -> t
+val enclosing : ?disambiguate:Tie_breaker.t -> Lexing.position -> t list -> t
 
 val range_enclosing :
   start:Lexing.position -> stop:Lexing.position -> t list -> t

--- a/src/kernel/mbrowse.mli
+++ b/src/kernel/mbrowse.mli
@@ -52,12 +52,14 @@ module Tie_breaker : sig
       This module is about tie-breaking those cases to select the node that we
       want.  *)
 
+  type tie_break = Prefer_first | Prefer_second
+
   (** If [f : t], then [f node1 node2] answers:
-      - [Some `Prefer_first] to select [node1]
-      - [Some `Prefer_first] to select [node1]
+      - [Some Prefer_first] to select [node1]
+      - [Some Prefer_second] to select [node2]
       - [None] to let the default disambiguation mechanism break the tie.
   *)
-  type t = node -> node -> [ `Prefer_first | `Prefer_second ] option
+  type t = node -> node -> tie_break option
 
   (** Tie-break by preferring expression over other nodes *)
   val prefer_expression : t

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -302,7 +302,7 @@ let get_index t =
 
 let get_stamp t = t.stamp
 
-let node_at ?(skip_recovered = false) t pos_cursor =
+let node_at ?disambiguate ?(skip_recovered = false) t pos_cursor =
   let node = Mbrowse.of_typedtree (get_typedtree t) in
   log ~title:"node_at" "Node: %s" (Mbrowse.print () node);
   let rec select = function
@@ -312,7 +312,7 @@ let node_at ?(skip_recovered = false) t pos_cursor =
       -> select ancestors
     | l -> l
   in
-  match Mbrowse.deepest_before pos_cursor [ node ] with
+  match Mbrowse.deepest_before ?disambiguate pos_cursor [ node ] with
   | [] -> [ (get_env t, Browse_raw.Dummy) ]
   | path when skip_recovered -> select path
   | path ->

--- a/src/kernel/mtyper.mli
+++ b/src/kernel/mtyper.mli
@@ -53,5 +53,13 @@ val get_cache_stat : result -> typer_cache_stats
  *      In this case, the env found is the same as in case a, however it is
  *      preferable to use env from enclosing module rather than an env from
  *      inside x definition.
+ *
+ *  [disambiguate] argument is used to select the node at cursor when multiple
+ *  nodes share the same location.
  *)
-val node_at : ?skip_recovered:bool -> result -> Lexing.position -> Mbrowse.t
+val node_at :
+  ?disambiguate:Mbrowse.Tie_breaker.t ->
+  ?skip_recovered:bool ->
+  result ->
+  Lexing.position ->
+  Mbrowse.t

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -442,7 +442,7 @@ let rec of_expression_desc loc = function
     in
     let bindops = let_ :: ands in
     let patterns = flatten_patterns ~size:(List.length ands) [] body.c_lhs in
-    let of_letop (pat, bindop) = of_pattern pat ** of_bop bindop in
+    let of_letop (pat, bindop) = of_bop bindop ** of_pattern pat in
     list_fold of_letop (List.combine patterns bindops)
     ** of_expression body.c_rhs
   | Texp_open (od, e) -> app (Module_expr od.open_expr) ** of_expression e

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -442,7 +442,7 @@ let rec of_expression_desc loc = function
     in
     let bindops = let_ :: ands in
     let patterns = flatten_patterns ~size:(List.length ands) [] body.c_lhs in
-    let of_letop (pat, bindop) = of_bop bindop ** of_pattern pat in
+    let of_letop (pat, bindop) = of_pattern pat ** of_bop bindop in
     list_fold of_letop (List.combine patterns bindops)
     ** of_expression body.c_rhs
   | Texp_open (od, e) -> app (Module_expr od.open_expr) ** of_expression e

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -9,13 +9,10 @@
   > EOF
 
 Should locate to the `x` in `f x`
-  $ $MERLIN single locate -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value
+  $ $MERLIN single locate -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value.pos
   {
-    "file": "$TESTCASE_ROOT/let_punning.ml",
-    "pos": {
-      "line": 3,
-      "col": 7
-    }
+    "line": 3,
+    "col": 7
   }
 
 Should answer the type of x in the pattern: "int"
@@ -30,13 +27,10 @@ Should answer the type of x in the pattern: "int"
   > let g x = f ~x
   > EOF
 
-  $ $MERLIN single locate -position 3:13 -filename arg_punning.ml < arg_punning.ml | jq .value
+  $ $MERLIN single locate -position 3:13 -filename arg_punning.ml < arg_punning.ml | jq .value.pos
   {
-    "file": "$TESTCASE_ROOT/arg_punning.ml",
-    "pos": {
-      "line": 3,
-      "col": 6
-    }
+    "line": 3,
+    "col": 6
   }
 
 # Testing locate on field punnings
@@ -47,11 +41,8 @@ Should answer the type of x in the pattern: "int"
   > let make x y = {x; y}
   > EOF
 
-  $ $MERLIN single locate -position 3:16 -filename field_punning.ml < field_punning.ml | jq .value
+  $ $MERLIN single locate -position 3:16 -filename field_punning.ml < field_punning.ml | jq .value.pos
   {
-    "file": "$TESTCASE_ROOT/field_punning.ml",
-    "pos": {
-      "line": 3,
-      "col": 9
-    }
+    "line": 3,
+    "col": 9
   }

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -18,7 +18,7 @@ Should locate to the `x` in `f x`
     }
   }
 
-FIXME: Should answer the type of x in the pattern: "int"
+Should answer the type of x in the pattern: "int"
   $ $MERLIN single type-enclosing -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value[0].type
   "int"
 

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -1,0 +1,47 @@
+# Testing locate on let punnings
+
+  $ cat > let_punning.ml <<EOF
+  > let (let+) x f = f x
+  > 
+  > let f x =
+  >   let+ x in
+  >   x
+  > EOF
+
+FIXME: Should locate to the `x` in `f x`, not say that we are at the definition
+  $ $MERLIN single locate -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value
+  "Already at definition point"
+
+# Testing locate on argument punnings
+
+  $ cat > arg_punning.ml <<EOF
+  > let f ~x = x
+  > 
+  > let g x = f ~x
+  > EOF
+
+  $ $MERLIN single locate -position 3:13 -filename arg_punning.ml < arg_punning.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/arg_punning.ml",
+    "pos": {
+      "line": 3,
+      "col": 6
+    }
+  }
+
+# Testing locate on field punnings
+
+  $ cat > field_punning.ml <<EOF
+  > type record = { x : int; y : int }
+  > 
+  > let make x y = {x; y}
+  > EOF
+
+  $ $MERLIN single locate -position 3:16 -filename field_punning.ml < field_punning.ml | jq .value
+  {
+    "file": "$TESTCASE_ROOT/field_punning.ml",
+    "pos": {
+      "line": 3,
+      "col": 9
+    }
+  }

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -20,7 +20,7 @@ Should locate to the `x` in `f x`
 
 FIXME: Should answer the type of x in the pattern: "int"
   $ $MERLIN single type-enclosing -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value[0].type
-  "int * 'a"
+  "int"
 
 # Testing locate on argument punnings
 

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -8,13 +8,19 @@
   >   x
   > EOF
 
-FIXME: Should locate to the `x` in `f x`, not say that we are at the definition
+Should locate to the `x` in `f x`
   $ $MERLIN single locate -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value
-  "Already at definition point"
+  {
+    "file": "$TESTCASE_ROOT/let_punning.ml",
+    "pos": {
+      "line": 3,
+      "col": 7
+    }
+  }
 
-Should answer the type of x in the pattern: "int"
+FIXME: Should answer the type of x in the pattern: "int"
   $ $MERLIN single type-enclosing -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value[0].type
-  "int"
+  "int * 'a"
 
 # Testing locate on argument punnings
 

--- a/tests/test-dirs/punning.t
+++ b/tests/test-dirs/punning.t
@@ -1,9 +1,9 @@
-# Testing locate on let punnings
+# Testing queries on punned forms
 
   $ cat > let_punning.ml <<EOF
-  > let (let+) x f = f x
+  > let (let+) x f = f (fst x)
   > 
-  > let f x =
+  > let f (x : int * _) =
   >   let+ x in
   >   x
   > EOF
@@ -11,6 +11,10 @@
 FIXME: Should locate to the `x` in `f x`, not say that we are at the definition
   $ $MERLIN single locate -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value
   "Already at definition point"
+
+Should answer the type of x in the pattern: "int"
+  $ $MERLIN single type-enclosing -position 4:7 -filename let_punning.ml < let_punning.ml | jq .value[0].type
+  "int"
 
 # Testing locate on argument punnings
 


### PR DESCRIPTION
This fixes an issue with the locate query reported in #1796.

(Sorry this is quite verbose for such a small PR but it is also here to help me be corrected if I have assumed something wrong)

In a punned let binding, both the pattern and the expression have the same location. None of them is ghost. I think that somehow breaks the assumption that "sibling nodes have disjoint locations".

During a locate query, the first thing is to load the environment at the point of the cursor. The lookup of "nodes at cursor position" will suppose the invariant mentioned above to return a list all nodes the cursor is in (of which we take the first one, the "deepest").

Since two siblings (the pattern and expression) have the same location, the order in which they are considered matter: when the first one is found, we never look at the other siblings, and "enter" it to continue the search.

In the current implementation, patterns are looked first, and we end up with the environment at the pattern to do our "locate". And so, the unhelpful "Already at definition point".

This PR fixes this by folding let operators in a different order, making the expressions side be entered first.

Having the behaviour depend on the order of the fold is slightly brittle, but I think this PR is still fine to solve #1796 without refactoring a huge part to solve a bigger underlying issue ("siblings might have the same location"). But I'm new to the codebase so I might miss something!
(I'm happy to implement a better fix, but then I'd like to discuss with more experienced Merlin disciple first)