### PR TITLE
Fix signature-help with type aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+============
+  + merlin library
+    - Fix signature-help with type aliases (#2067, fixes #1927)
+
 merlin 5.7.1
 ============
 Thu Apr 30 14:15:42 CEST 2026

--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -47,7 +47,6 @@ let pp_type env ppf ty =
 let rec type_is_arrow ty =
   match Types.get_desc ty with
   | Tarrow _ -> true
-  | Tlink ty -> type_is_arrow ty
   | Tpoly (ty, _) -> type_is_arrow ty
   | _ -> false
 
@@ -89,7 +88,13 @@ let separate_function_signature ~args (e : Typedtree.expression) =
   let buffer = Buffer.create 16 in
   let ppf = Format.formatter_of_buffer buffer in
   let rec separate ?(parameters = []) args ty =
-    match (args, Types.get_desc ty) with
+    let desc =
+      match args with
+      | _ :: _ -> Types.get_desc (Ctype.expand_head e.exp_env ty)
+      (* expand the type only if there are remaining arguments *)
+      | [] -> Types.get_desc ty
+    in
+    match (args, desc) with
     | (_l, arg) :: args, Tarrow (label, ty1, ty2, _) ->
       let parameter =
         print_parameter_offset ~arg ppf buffer e.exp_env label ty1
@@ -110,7 +115,8 @@ let separate_function_signature ~args (e : Typedtree.expression) =
         active_param = None
       }
   in
-  separate args e.exp_type
+  let expanded_ty = Ctype.expand_head e.exp_env e.exp_type in
+  separate args expanded_ty
 
 let active_parameter_by_arg ~arg params =
   let find_by_arg = function
@@ -160,8 +166,8 @@ let active_parameter_by_prefix ~prefix params =
   in
   find_by_prefix params
 
-let is_arrow t =
-  match Types.get_desc t with
+let is_arrow env t =
+  match Types.get_desc (Ctype.expand_head env t) with
   | Tarrow _ -> true
   | _ -> false
 
@@ -169,10 +175,11 @@ let application_signature ~prefix ~cursor node =
   match node with
   | (_, Browse_raw.Expression arg)
     :: ( _,
-         Expression { exp_desc = Texp_apply (({ exp_type; _ } as e), args); _ }
+         Expression
+           { exp_desc = Texp_apply (({ exp_type; exp_env; _ } as e), args); _ }
        )
     :: _
-    when is_arrow exp_type ->
+    when is_arrow exp_env exp_type ->
     log ~title:"application_signature" "Last arg:\n%a" Logger.fmt (fun fmt ->
         Printtyped.expression fmt arg);
     let result = separate_function_signature e ~args in
@@ -192,7 +199,8 @@ let application_signature ~prefix ~cursor node =
         | None -> active_parameter_by_prefix ~prefix result.parameters
     in
     Some { result with active_param }
-  | (_, Expression ({ exp_type; _ } as e)) :: _ when is_arrow exp_type ->
+  | (_, Expression ({ exp_type; exp_env; _ } as e)) :: _
+    when is_arrow exp_env exp_type ->
     (* provide signature information directly after an unapplied function-type
        value *)
     let result = separate_function_signature e ~args:[] in
@@ -207,9 +215,8 @@ let application_signature ~prefix ~cursor node =
           let v =
             List.find_opt
               ~f:(fun (value_binding : Typedtree.value_binding) ->
-                match Types.get_desc value_binding.vb_expr.exp_type with
-                | Tarrow _ -> true
-                | _ -> false)
+                is_arrow value_binding.vb_expr.exp_env
+                  value_binding.vb_expr.exp_type)
               vlist
           in
           Option.map ~f:(fun (v : Typedtree.value_binding) -> v.vb_expr) v

--- a/tests/test-dirs/signature-help/issue1927.t
+++ b/tests/test-dirs/signature-help/issue1927.t
@@ -31,10 +31,9 @@
     "notifications": []
   }
 
-FIXME: Signature help does not appear for M.f:
+Regression for #1927: signature help on a function whose type is reached through a type abbreviation (`type t = int -> unit`).
 
   $ cat >test.ml <<'EOF'
-  > 
   > type t = int -> unit
   > 
   > module M : sig
@@ -46,9 +45,25 @@ FIXME: Signature help does not appear for M.f:
   > let () = M.f (* keep whitespace *)
   > EOF
 
-  $ $MERLIN single signature-help -position 7:13 -filename test <test.ml 
+  $ $MERLIN single signature-help -position 9:13 -filename test <test.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "M.f : int -> unit",
+          "parameters": [
+            {
+              "label": [
+                6,
+                9
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }

--- a/tests/test-dirs/signature-help/issue1927.t
+++ b/tests/test-dirs/signature-help/issue1927.t
@@ -67,3 +67,251 @@ Regression for #1927: signature help on a function whose type is reached through
     },
     "notifications": []
   }
+
+  $ cat >test.ml <<'EOF'
+  > type t = int * int
+  > 
+  > let f (_ : t) = ()
+  > 
+  > let () = f (* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:11 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : t -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                5
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+  $ cat >test.ml <<'EOF'
+  > type t = int -> int 
+  > 
+  > let f (a : int) (op : t) : int = op a
+  > 
+  > let _ = f 1 (* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:12 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> t -> int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                12
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+
+  $ cat >test.ml <<'EOF'
+  > type t = int -> unit
+  > 
+  > let f (_ : int) : t = fun (_ : int) -> ()
+  > 
+  > let () = f (* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:11 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> t",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+  $ cat >test.ml <<'EOF'
+  > type t = int -> unit
+  > 
+  > let f (_ : int) : t = fun (_ : int) -> ()
+  > 
+  > let _ = f 1 2 (* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:13 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> int -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                14
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+ 
+
+  $ cat >test.ml <<'EOF'
+  > type t = int -> int -> unit
+  > 
+  > let f (_ : int) : t = fun (_ : int) -> ()
+  > 
+  > let _ = f 1 2 (* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:14 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> int -> int -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                14
+              ]
+            },
+            {
+              "label": [
+                18,
+                21
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 2,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+  $ cat >test.ml <<'EOF'
+  > type t = x:int -> int
+  > let f : t = fun ~x -> x + 1
+  > 
+  > let _ = f ~(* keep whitespace *)
+  > EOF
+
+  $ $MERLIN single signature-help -position 4:10 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : x:int -> int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                9
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+  $ cat >test.ml <<'EOF'
+  > type t = s:string -> count:int -> unit 
+  > 
+  > let f : t = fun ~s:_ ~count:_ -> ()
+  > 
+  > let _ = f ~s:"hello" 
+  > EOF
+
+  $ $MERLIN single signature-help -position 5:21 -filename test <test.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : s:string -> count:int -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                12
+              ]
+            },
+            {
+              "label": [
+                16,
+                25
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }


### PR DESCRIPTION
Fixes issue #1927.

## What changes
`signature help` now expands types once to decide whether a value is a function:

```ocaml
type t = int -> unit
let f : t = fun _ -> ()
let _ = f  (* before: nothing; after: f : int -> unit *)
```

Same when there is an alias exposed mid-call: if the call supplies more arguments than the visible arrows allow, the alias is expanded.

```ocaml
type t = int -> unit
let f (_ : int) : t = …
let _ = f 1 2  (* f : int -> int -> unit *)
```

## What have not changed

```ocaml
type t = int * int
let f (_ : t) = ()         
let _ = f  (* f : t -> unit, not f : int * int -> unit *)
```
```ocaml
type t = int -> unit
let f (_ : int) : t = unit 
let _ = f  (* f : int -> t` *)
```


## What is still broken? (or is it on purpose?)

```ocaml
let f ~x = x + 1     
let _ = f  (* nothing *)
```

Even so
```ocaml
let f ~x = x + 1     
let _ = f  ~  (* f: x:int -> int *)
```
and 
```ocaml
type t = x:int -> int
let f : t = fun ~x -> x + 1     
let _ = f  ~  (* f: x:int -> int *)
```
both work. 
