### PR TITLE
emacs: replace obsolete when-let to silence Emacs 31 warning

### DIFF
--- a/emacs/merlin.el
+++ b/emacs/merlin.el
@@ -1545,16 +1545,17 @@ strictly within, or nil if there is no such element."
 
 If WITH-LOCAL-VALUES is non-nil, pass \"-with-values local\" to
 include local values in the candidate list."
-  (when-let ((result (merlin-call "construct"
-                                  "-position" (merlin-unmake-point point)
-                                  "-with-values"
-                                  (if (or with-local-values merlin-construct-with-local-values)
-                                      "local"
-                                    "null"))))
-    (let* ((loc   (car result))
-           (start (cdr (assoc 'start loc)))
-           (stop  (cdr (assoc 'end loc))))
-      (merlin--construct-complete start stop (cadr result)))))
+  (let ((result (merlin-call "construct"
+                             "-position" (merlin-unmake-point point)
+                             "-with-values"
+                             (if (or with-local-values merlin-construct-with-local-values)
+                                 "local"
+                               "null"))))
+    (when result
+      (let* ((loc   (car result))
+             (start (cdr (assoc 'start loc)))
+             (stop  (cdr (assoc 'end loc))))
+        (merlin--construct-complete start stop (cadr result))))))
 
 (defun merlin-construct (&optional arg)
   "Construct over the current hole.


### PR DESCRIPTION
On Emacs 31.1 the byte-compiler reports `when-let` as obsolete (use
`when-let*` or `and-let*`). This silences the warning in
`merlin--construct-point` without raising the package's minimum Emacs.

Rather than switch to `when-let*` (which requires Emacs 26.1, while
`emacs/merlin.el` declares `Package-Requires: ((emacs "25.1"))`), the
single call site is rewritten with `let` + `when`, which is valid on
every Emacs version. Behaviour is unchanged.

Verified: balanced parens (`check-parens`) and no obsoletion warning on
byte-compile.