### PR TITLE
Decouple no-dune.t test from dune internal paths

### DIFF
--- a/tests/test-dirs/config/no-dune.t
+++ b/tests/test-dirs/config/no-dune.t
@@ -1,6 +1,6 @@
   $ mkdir bin
-  $ cp ../../../../install/default/bin/ocamlmerlin bin/ocamlmerlin
-  $ cp ../../../../install/default/bin/ocamlmerlin-server bin/ocamlmerlin-server
+  $ cp $(dune describe location ocamlmerlin 2>&1) bin/ocamlmerlin
+  $ cp $(dune describe location ocamlmerlin-server 2>&1) bin/ocamlmerlin-server
 
   $ cat >dune-project <<EOF
   > (lang dune 2.0)

--- a/tests/test-dirs/config/no-dune.t
+++ b/tests/test-dirs/config/no-dune.t
@@ -1,6 +1,6 @@
   $ mkdir bin
-  $ cp $(dune describe location ocamlmerlin 2>&1) bin/ocamlmerlin
-  $ cp $(dune describe location ocamlmerlin-server 2>&1) bin/ocamlmerlin-server
+  $ cp $(which ocamlmerlin) bin/ocamlmerlin
+  $ cp $(which ocamlmerlin-server) bin/ocamlmerlin-server
 
   $ cat >dune-project <<EOF
   > (lang dune 2.0)


### PR DESCRIPTION
Dune doesn't provide the layout of its install directories as part of its public API. These internals are changing in dune 3.24, as a result of https://github.com/ocaml/dune/pull/14432,  so this path will change. Using `dune describe location` uses dunes stable API to find the path for the needed binaries.

The need for this update was identified in the revdeps tests on the pre-releas for dune 3.24 in https://github.com/ocaml/opam-repository/pull/29996#issuecomment-4651407043 .

Thanks to @Alizter for diagnosing the affect of the breaking change here.