### PR TITLE
Fix fuzzy CI

### DIFF
--- a/.github/fuzzy-ci-helpers/irmin.3.10.0.opam.locked
+++ b/.github/fuzzy-ci-helpers/irmin.3.10.0.opam.locked
@@ -18,14 +18,15 @@ depends: [
   "bigstringaf" {= "0.10.0" & ?vendor}
   "checkseum" {= "0.5.3" & ?vendor}
   "cmdliner" {= "1.3.0+dune" & ?vendor}
+  "compiler-cloning" {= "enabled"}
   "conf-gmp" {= "5"}
   "conf-gnuplot" {= "0.1"}
   "cppo" {= "1.8.0" & ?vendor}
   "csexp" {= "1.5.2" & ?vendor}
   "cstruct" {= "6.2.0" & ?vendor}
   "digestif" {= "1.3.0" & ?vendor}
-  "dune" {= "3.23.0"}
-  "dune-configurator" {= "3.23.0" & ?vendor}
+  "dune" {= "3.24.0"}
+  "dune-configurator" {= "3.24.0" & ?vendor}
   "either" {= "1.0.0" & ?vendor}
   "eqaf" {= "0.10" & ?vendor}
   "findlib" {= "1.9.5+dune" & ?vendor}
@@ -40,11 +41,10 @@ depends: [
   "metrics" {= "0.5.0" & ?vendor}
   "metrics-unix" {= "0.5.0" & ?vendor}
   "mtime" {= "2.1.0+dune" & ?vendor}
-  "ocaml" {= "5.4.0"}
-  "ocaml-base-compiler" {= "5.4.0"}
-  "ocaml-compiler" {= "5.4.0"}
+  "ocaml" {= "5.5.0"}
+  "ocaml-base-compiler" {= "5.5.0"}
+  "ocaml-compiler" {= "5.5.0"}
   "ocaml-compiler-libs" {= "v0.17.0" & ?vendor}
-  "ocaml-config" {= "3"}
   "ocaml-options-vanilla" {= "1"}
   "ocaml-syntax-shims" {= "1.0.0" & ?vendor}
   "ocamlfind" {= "1.9.5+dune" & ?vendor}
@@ -166,8 +166,8 @@ pin-depends: [
     "https://github.com/mirage/digestif/releases/download/v1.3.0/digestif-1.3.0.tbz"
   ]
   [
-    "dune-configurator.3.23.0"
-    "https://github.com/ocaml/dune/releases/download/3.23.0/dune-3.23.0.tbz"
+    "dune-configurator.3.24.0"
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
   ]
   [
     "either.1.0.0"
@@ -351,7 +351,7 @@ pin-depends: [
   ]
 ]
 x-opam-monorepo-cli-args: [
-  "irmin" "irmin-pack" "irmin-tezos" "--ocaml-version=5.4.0"
+  "irmin" "irmin-pack" "irmin-tezos" "--ocaml-version=5.5.0"
 ]
 x-opam-monorepo-duniverse-dirs: [
   [
@@ -522,7 +522,11 @@ x-opam-monorepo-duniverse-dirs: [
   [
     "https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz"
     "bigstringaf"
-    ["md5=be0a44416840852777651150757a0a3b"]
+    [
+      "sha512=b51c756925d7016ffd7eac49e69393a1897391ca2685a8c30c7b6e3917b4d66c9400b49e8986d0f03329197b95ad52e096ff83dea5e03571cb5bc3d9a5170602"
+      "sha256=ed92f5b05fbc11b9defcec734d59b1068f3717a9ae4f9705c16c7f7ac3729f28"
+      "md5=be0a44416840852777651150757a0a3b"
+    ]
   ]
   [
     "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz"
@@ -724,11 +728,11 @@ x-opam-monorepo-duniverse-dirs: [
     ]
   ]
   [
-    "https://github.com/ocaml/dune/releases/download/3.23.0/dune-3.23.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
     "dune_"
     [
-      "sha256=e92987ffe4bc7956b18b2251b0f9844d55dfa387035ce60a3f0fd5ac4e2617d4"
-      "sha512=ef42c7ac24f300c00c429ea0e7e152bb46f7bbb1e81cf1dad225c4f41598f744b83d404a8ac949c2da074288f5560c8770421ba474a5751a20090b2f9cfa2435"
+      "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+      "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
     ]
   ]
   [

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -43,7 +43,7 @@ env:
 
   # Pinned Merl-an version commit hash
   MERL_AN_SHA: a61cb2b6c2f57baf00b88a74f67b332c459575ef
-  
+
   # The compiler version used on the respective branches. It also needs to form part of Irmin's build cache key.
   # Bump either of these whenever the compiler version is bumped on either of the two branches.
   merge_branch_COMPILER_VERSION: ocaml-base-compiler.5.5.0
@@ -130,6 +130,7 @@ jobs:
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
           cp ".github/fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked" irmin/irmin.opam.locked
+          cat irmin/irmin.opam.locked
 
       - name: Install opam monorepo
         if: steps.irmin-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -41,6 +41,9 @@ env:
   # Irmin version and merl-an version need to be consistent for reproducibility (Irmin is used as the test code base to test `ocamlmerlin` on)
   IRMIN_VERSION: 3.10.0
 
+  # Pinned Merl-an version commit hash
+  MERL_AN_SHA: a61cb2b6c2f57baf00b88a74f67b332c459575ef
+  
   # The compiler version used on the respective branches. It also needs to form part of Irmin's build cache key.
   # Bump either of these whenever the compiler version is bumped on either of the two branches.
   merge_branch_COMPILER_VERSION: ocaml-base-compiler.5.5.0
@@ -164,11 +167,11 @@ jobs:
         id: merl-an-cache
         with:
           path: /usr/local/bin/merl-an
-          key: os${{ runner.os }}+arch${{ runner.arch }}+merl-an
+          key: os${{ runner.os }}+arch${{ runner.arch }}+merl-an-sha$MERL_AN_SHA
 
       - name: Install merl-an
         if: steps.merl-an-cache.outputs.cache-hit != 'true'
-        run: opam pin -y merl-an https://github.com/tarides/merl-an.git
+        run: opam pin -y merl-an https://github.com/tarides/merl-an.git#$MERL_AN_SHA
 
       - name: Add merl-an to /usr/local/bin/
         if: steps.merl-an-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -40,13 +40,11 @@ env:
 
   # Irmin version and merl-an version need to be consistent for reproducibility (Irmin is used as the test code base to test `ocamlmerlin` on)
   IRMIN_VERSION: 3.10.0
-  # TODO: Release merl-an and install a certain version instead of pinning it to a certain commit
-  MERL_AN_SHA: 344a079bf502f27e9269498db9ed5369753f2ddb
 
   # The compiler version used on the respective branches. It also needs to form part of Irmin's build cache key.
   # Bump either of these whenever the compiler version is bumped on either of the two branches.
-  merge_branch_COMPILER_VERSION: ocaml-base-compiler.5.4.0
-  base_branch_COMPILER_VERSION: ocaml-base-compiler.5.4.0
+  merge_branch_COMPILER_VERSION: ocaml-base-compiler.5.5.0
+  base_branch_COMPILER_VERSION: ocaml-base-compiler.5.5.0
 
 jobs:
   data:
@@ -110,7 +108,7 @@ jobs:
         id: irmin-cache
         with:
           path: irmin/
-          key: os${{ runner.os }}+arch${{ runner.arch }}+${{ hashFiles('fuzzy-ci-helpers/irmin.3.10.0.opam.locked') }}+${{ env.IRMIN_VERSION }}+${{ steps.compiler.outputs.version }}
+          key: os${{ runner.os }}+arch${{ runner.arch }}+${{ hashFiles('fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked') }}+${{ env.IRMIN_VERSION }}+${{ steps.compiler.outputs.version }}
 
       - name: Download Irmin tarball
         if: steps.irmin-cache.outputs.cache-hit != 'true'
@@ -128,7 +126,7 @@ jobs:
       - name: Get Irmin's lock files
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
-          cp .github/fuzzy-ci-helpers/irmin.3.10.0.opam.locked irmin/irmin.opam.locked
+          cp .github/fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked irmin/irmin.opam.locked
 
       - name: Install opam monorepo
         if: steps.irmin-cache.outputs.cache-hit != 'true'
@@ -166,11 +164,11 @@ jobs:
         id: merl-an-cache
         with:
           path: /usr/local/bin/merl-an
-          key: os${{ runner.os }}+arch${{ runner.arch }}+merl-an-sha$MERL_AN_SHA
+          key: os${{ runner.os }}+arch${{ runner.arch }}+merl-an
 
       - name: Install merl-an
         if: steps.merl-an-cache.outputs.cache-hit != 'true'
-        run: opam pin -y merl-an https://github.com/xvw/merl-an.git#$MERL_AN_SHA
+        run: opam pin -y merl-an https://github.com/tarides/merl-an.git
 
       - name: Add merl-an to /usr/local/bin/
         if: steps.merl-an-cache.outputs.cache-hit != 'true'
@@ -184,7 +182,7 @@ jobs:
           # `--queries`: The `ocamlmerlin` queries that are being run.
           opam exec -- merl-an behavior \
           --queries=type-enclosing,occurrences,locate,complete-prefix,errors \
-          --sample-size=30 \
+          --per-file-samples=30 \
           --data=${{ env.data_dir }} \
           --merlin=ocamlmerlin \
           --project=irmin/src/irmin,irmin/src/irmin-pack,irmin/test/irmin-pack

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Download Irmin tarball
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/mirage/irmin/releases/download/$IRMIN_VERSION/irmin-$IRMIN_VERSION.tbz
+          wget "https://github.com/mirage/irmin/releases/download/$IRMIN_VERSION/irmin-$IRMIN_VERSION.tbz"
 
       - name: Create irmin dir
         if: steps.irmin-cache.outputs.cache-hit != 'true'
@@ -124,12 +124,12 @@ jobs:
 
       - name: Decompress Irmin tarball
         if: steps.irmin-cache.outputs.cache-hit != 'true'
-        run: tar xvf irmin-$IRMIN_VERSION.tbz -C irmin --strip-components=1
+        run: tar xvf "irmin-$IRMIN_VERSION.tbz" -C irmin --strip-components=1
 
       - name: Get Irmin's lock files
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
-          cp .github/fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked irmin/irmin.opam.locked
+          cp ".github/fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked" irmin/irmin.opam.locked
 
       - name: Install opam monorepo
         if: steps.irmin-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -142,6 +142,10 @@ jobs:
           opam monorepo pull --lockfile=irmin.opam.locked --yes
         working-directory: irmin
 
+      - name: Debug ppxlib version
+        run: opam monorepo list
+        working-directory: irmin
+
       - name: Prune Irmin
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/fuzzy-ci.yml
+++ b/.github/workflows/fuzzy-ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Download Irmin tarball
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
-          wget "https://github.com/mirage/irmin/releases/download/$IRMIN_VERSION/irmin-$IRMIN_VERSION.tbz"
+          wget https://github.com/mirage/irmin/releases/download/${{ env.IRMIN_VERSION }}/irmin-${{ env.IRMIN_VERSION }}.tbz
 
       - name: Create irmin dir
         if: steps.irmin-cache.outputs.cache-hit != 'true'
@@ -124,12 +124,12 @@ jobs:
 
       - name: Decompress Irmin tarball
         if: steps.irmin-cache.outputs.cache-hit != 'true'
-        run: tar xvf "irmin-$IRMIN_VERSION.tbz" -C irmin --strip-components=1
+        run: tar xvf irmin-${{ env.IRMIN_VERSION }}.tbz -C irmin --strip-components=1
 
       - name: Get Irmin's lock files
         if: steps.irmin-cache.outputs.cache-hit != 'true'
         run: |
-          cp ".github/fuzzy-ci-helpers/irmin.$IRMIN_VERSION.opam.locked" irmin/irmin.opam.locked
+          cp .github/fuzzy-ci-helpers/irmin.${{ env.IRMIN_VERSION }}.opam.locked irmin/irmin.opam.locked
           cat irmin/irmin.opam.locked
 
       - name: Install opam monorepo


### PR DESCRIPTION
- Update from OCaml 5.3 to 5.5
- Update Merl-an CLI usage
- Regenerate Irmin lock file using this method:
```bash
$ opam switch create ocaml-base-compiler.5.5.0
$ opam switch ocaml-base-compiler.5.5.0
$ git clone https://github.com/mirage/irmin
$ git checkout 7fa4b043a97944635cc100ae2e7dd85f73d8a4ce # The release commit hash of the release of Irmin version 3.10
$ opam install opam-monorepo
$ opam repository add dune-universe git+https://github.com/dune-universe/opam-overlays.git
$ opam-monorepo lock irmin irmin-pack irmin-tezos --ocaml-version=5.5.0 
```
Merging this PR should close that issue https://github.com/ocaml/merlin/issues/2006