### PR TITLE
Fix issue 1748: locate on a open with a module shadowing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+  + merlin library
+    - Fix `locate` and `document` on `open` paths in `.mli` files: resolve the
+      open path in the environment before the open, so a self-shadowing
+      submodule no longer hides the opened module (fixes #1748)
+
 merlin 5.8
 ==========
 Tue Jun 23 12:15:42 CEST 2026

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -619,7 +619,8 @@ let of_node = function
         | None -> app (Signature_item (item, sig_final_env))
         | Some item' -> app (Signature_item (item, item'.sig_env)))
       sig_items
-  | Signature_item ({ sig_desc; sig_env}, _) -> of_signature_item_desc sig_env sig_desc
+  | Signature_item ({ sig_desc; sig_env }, _) ->
+    of_signature_item_desc sig_env sig_desc
   | Module_declaration md ->
     of_module_type md.md_type ** app (Module_declaration_name md)
   | Module_type_declaration mtd ->

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -74,7 +74,7 @@ type node =
   | Binding_op of binding_op
   | Include_description of include_description
   | Include_declaration of include_declaration
-  | Open_description of open_description
+  | Open_description of open_description * Env.t
   | Open_declaration of open_declaration
   | Method_call of expression * meth * Location.t
   | Record_field of
@@ -102,7 +102,8 @@ let node_update_env env0 = function
   | Structure_item (_, env)
   | Signature_item (_, env)
   | Core_type { ctyp_env = env }
-  | Class_type { cltyp_env = env } -> env
+  | Class_type { cltyp_env = env }
+  | Open_description (_, env) -> env
   | Dummy
   | Case _
   | Class_structure _
@@ -140,7 +141,6 @@ let node_update_env env0 = function
   | Class_type_field _
   | Include_description _
   | Include_declaration _
-  | Open_description _
   | Open_declaration _
   | Binding_op _ -> env0
 
@@ -178,7 +178,7 @@ let node_real_loc loc0 = function
   | Extension_constructor { ext_loc = loc }
   | Include_description { incl_loc = loc }
   | Include_declaration { incl_loc = loc }
-  | Open_description { open_loc = loc }
+  | Open_description ({ open_loc = loc }, _)
   | Open_declaration { open_loc = loc }
   | Binding_op { bop_op_name = { loc } } -> loc
   | Module_type_declaration_name { mtd_name = loc } -> loc.Location.loc
@@ -213,7 +213,7 @@ let node_attributes = function
   | Module_type mt -> mt.mty_attributes
   | Module_declaration md -> md.md_attributes
   | Module_type_declaration mtd -> mtd.mtd_attributes
-  | Open_description o -> o.open_attributes
+  | Open_description (o, _) -> o.open_attributes
   | Include_declaration i -> i.incl_attributes
   | Include_description i -> i.incl_attributes
   | Core_type ct -> ct.ctyp_attributes
@@ -514,9 +514,9 @@ and of_module_type_desc = function
     ** of_module_type mt
   | Tmty_typeof me -> of_module_expr me
 
-and of_signature_item_desc = function
+and of_signature_item_desc sig_env = function
   | Tsig_attribute _ -> id_fold
-  | Tsig_open d -> app (Open_description d)
+  | Tsig_open d -> app (Open_description (d, sig_env))
   | Tsig_value vd -> app (Value_description vd)
   | Tsig_type (_, tds) -> list_fold (fun td -> app (Type_declaration td)) tds
   | Tsig_typext text -> app (Type_extension text)
@@ -619,7 +619,7 @@ let of_node = function
         | None -> app (Signature_item (item, sig_final_env))
         | Some item' -> app (Signature_item (item, item'.sig_env)))
       sig_items
-  | Signature_item ({ sig_desc }, _) -> of_signature_item_desc sig_desc
+  | Signature_item ({ sig_desc; sig_env}, _) -> of_signature_item_desc sig_env sig_desc
   | Module_declaration md ->
     of_module_type md.md_type ** app (Module_declaration_name md)
   | Module_type_declaration mtd ->

--- a/src/ocaml/merlin_specific/browse_raw.mli
+++ b/src/ocaml/merlin_specific/browse_raw.mli
@@ -87,7 +87,7 @@ type node =
   | Binding_op of binding_op
   | Include_description of include_description
   | Include_declaration of include_declaration
-  | Open_description of open_description
+  | Open_description of open_description * Env.t
   | Open_declaration of open_declaration
   | Method_call of expression * meth * Location.t
   | Record_field of

--- a/tests/test-dirs/document/issue1748.t
+++ b/tests/test-dirs/document/issue1748.t
@@ -1,0 +1,60 @@
+Companion to tests/test-dirs/locate/issue1748.t, for the `document` command.
+
+The unit `Import` (here `import.ml = include Bar`) contains a submodule `Import`
+(`Bar.Import`). In a `.mli`, `open! Import` used to resolve the bare `Import` in
+the post-open environment, where the submodule shadows the unit, so `document`
+returned the submodule's doc. 
+
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (name jump_to_wrong_import))
+  > EOF
+
+  $ cat >bar.ml <<'EOF'
+  > (** SHADOW submodule doc *)
+  > module Import = struct
+  >   type hello = string
+  > end
+  > EOF
+
+  $ cat >import.ml <<'EOF'
+  > (** UNIT module doc *)
+  > 
+  > include Bar
+  > EOF
+
+  $ cat >foo.ml <<'EOF'
+  > open! Import
+  > EOF
+
+  $ cat >foo.mli <<'EOF'
+  > open! Import
+  > EOF
+
+  $ dune build @check 2>&1 | head -n 5
+
+`document` on `Import` from `foo.mli` must return the unit's doc, not the
+shadowing submodule's (before the fix this returned "SHADOW submodule doc"):
+
+  $ $MERLIN single document -position 1:8 -look-for implementation \
+  > -filename foo.mli <foo.mli
+  {
+    "class": "return",
+    "value": "UNIT module doc",
+    "notifications": []
+  }
+
+`document` from `foo.ml` behaves the same (it always did, the `.ml` leaf node
+already carried the pre-open env):
+
+  $ $MERLIN single document -position 1:8 -look-for implementation \
+  > -filename foo.ml <foo.ml
+  {
+    "class": "return",
+    "value": "UNIT module doc",
+    "notifications": []
+  }

--- a/tests/test-dirs/locate/issue1748.t
+++ b/tests/test-dirs/locate/issue1748.t
@@ -1,0 +1,67 @@
+Reproduction for https://github.com/ocaml/merlin/issues/1748
+
+When a module `Import` exists (here `import.ml`) and it includes another module
+that itself contains a nested module named `Import` (here `Bar.Import`), calling
+locate on `Import` from an `open Import` should jump to `import.ml` and not to 
+`Bar.Import`.
+
+  $ cat >dune-project <<'EOF'
+  > (lang dune 3.0)
+  > EOF
+
+  $ cat >dune <<'EOF'
+  > (library
+  >  (name jump_to_wrong_import))
+  > EOF
+
+  $ cat >bar.ml <<'EOF'
+  > module Import = struct
+  >   type hello = string
+  > end
+  > EOF
+
+  $ cat >import.ml <<'EOF'
+  > include Bar
+  > EOF
+
+  $ cat >foo.ml <<'EOF'
+  > open! Import
+  > EOF
+
+  $ cat >foo.mli <<'EOF'
+  > open! Import
+  > EOF
+
+  $ dune build @check 2>&1 | head -n 5
+
+Locating `Import` from `foo.ml` correctly jumps to `import.ml`:
+
+  $ $MERLIN single locate -position 1:10 -look-for implementation \
+  > -filename foo.ml <foo.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/import.ml",
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }
+
+Locating `Import` from `foo.mli` should also jump to `import.ml`:
+
+  $ $MERLIN single locate -position 1:10 -look-for implementation \
+  > -filename foo.mli <foo.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/import.ml",
+      "pos": {
+        "line": 1,
+        "col": 0
+      }
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/locate/open-path.t
+++ b/tests/test-dirs/locate/open-path.t
@@ -1,0 +1,124 @@
+Locating each segment of a dotted `open A.B.C` path must jump to the
+corresponding module, both in implementations and interfaces.
+
+  $ cat >test.ml <<'EOF'
+  > module A = struct
+  >   module B = struct
+  >     module C = struct
+  >       let x = ()
+  >     end
+  >   end
+  > end
+  > 
+  > open A.B.C
+  > EOF
+
+Cursor on `A` jumps to module `A` (prefix segment, textual fallback):
+
+  $ $MERLIN single locate -look-for ml -position 9:6 \
+  > -filename test.ml <test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.ml",
+      "pos": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `B` jumps to module `B` (prefix segment, textual fallback):
+
+  $ $MERLIN single locate -look-for ml -position 9:8 \
+  > -filename test.ml <test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.ml",
+      "pos": {
+        "line": 2,
+        "col": 9
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `C` jumps to module `C` (full open path, resolved by the typer):
+
+  $ $MERLIN single locate -look-for ml -position 9:10 \
+  > -filename test.ml <test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.ml",
+      "pos": {
+        "line": 3,
+        "col": 11
+      }
+    },
+    "notifications": []
+  }
+
+The same should hold in an interface:
+
+  $ cat >test.mli <<'EOF'
+  > module A : sig
+  >   module B : sig
+  >     module C : sig
+  >       val x : unit
+  >     end
+  >   end
+  > end
+  > 
+  > open A.B.C
+  > EOF
+
+Cursor on `A`:
+
+  $ $MERLIN single locate -look-for mli -position 9:6 \
+  > -filename test.mli <test.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.mli",
+      "pos": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `B`:
+
+  $ $MERLIN single locate -look-for mli -position 9:8 \
+  > -filename test.mli <test.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.mli",
+      "pos": {
+        "line": 2,
+        "col": 9
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `C`:
+
+  $ $MERLIN single locate -look-for mli -position 9:10 \
+  > -filename test.mli <test.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/test.mli",
+      "pos": {
+        "line": 3,
+        "col": 11
+      }
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/locate/open-path.t
+++ b/tests/test-dirs/locate/open-path.t
@@ -122,3 +122,137 @@ Cursor on `C`:
     },
     "notifications": []
   }
+
+Now the same dotted `open A.B.C`, but where the opened module `A.B.C` itself
+brings submodules named `A`, `B` and `C` into scope. After the `open`, those
+inner submodules shadow the top-level `A`, `B` and `C`. Locating a segment of
+the `open` path must still jump to the top-level modules that the path actually
+refers to (lines 1/2/3), not to the shadowing submodules (lines 4/5/6).
+
+  $ cat >shadow.ml <<'EOF'
+  > module A = struct
+  >   module B = struct
+  >     module C = struct
+  >       module A = struct let dummy_a = () end
+  >       module B = struct let dummy_b = () end
+  >       module C = struct let dummy_c = () end
+  >     end
+  >   end
+  > end
+  > 
+  > open A.B.C
+  > EOF
+
+Cursor on `A` jumps to the top-level `A` (line 1), not the shadowing `A.B.C.A`:
+
+  $ $MERLIN single locate -look-for ml -position 11:6 \
+  > -filename shadow.ml <shadow.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.ml",
+      "pos": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `B` jumps to the top-level `A.B` (line 2), not `A.B.C.B`:
+
+  $ $MERLIN single locate -look-for ml -position 11:8 \
+  > -filename shadow.ml <shadow.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.ml",
+      "pos": {
+        "line": 2,
+        "col": 9
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `C` jumps to the top-level `A.B.C` (line 3), not `A.B.C.C`:
+
+  $ $MERLIN single locate -look-for ml -position 11:10 \
+  > -filename shadow.ml <shadow.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.ml",
+      "pos": {
+        "line": 3,
+        "col": 11
+      }
+    },
+    "notifications": []
+  }
+
+The same must hold in an interface (this is where issue #1748 originally showed
+up: the leaf node of a signature `open` carries the post-open environment, so
+re-resolving the text of a segment finds the shadowing submodule):
+
+  $ cat >shadow.mli <<'EOF'
+  > module A : sig
+  >   module B : sig
+  >     module C : sig
+  >       module A : sig val dummy_a : unit end
+  >       module B : sig val dummy_b : unit end
+  >       module C : sig val dummy_c : unit end
+  >     end
+  >   end
+  > end
+  > 
+  > open A.B.C
+  > EOF
+
+Cursor on `A`:
+
+  $ $MERLIN single locate -look-for mli -position 11:6 \
+  > -filename shadow.mli <shadow.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.mli",
+      "pos": {
+        "line": 1,
+        "col": 7
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `B`:
+
+  $ $MERLIN single locate -look-for mli -position 11:8 \
+  > -filename shadow.mli <shadow.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.mli",
+      "pos": {
+        "line": 2,
+        "col": 9
+      }
+    },
+    "notifications": []
+  }
+
+Cursor on `C`:
+
+  $ $MERLIN single locate -look-for mli -position 11:10 \
+  > -filename shadow.mli <shadow.mli
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/shadow.mli",
+      "pos": {
+        "line": 3,
+        "col": 11
+      }
+    },
+    "notifications": []
+  }


### PR DESCRIPTION
This is a fix for issue #1748.

## The issue
### Minimal project to trigger the bug
We need 4 files: `bar.ml`, `import.ml`, `foo.ml` and `foo.mli`.

```ocaml
(* bar.ml *)
module Import = struct
  type hello = string
end

(* import.ml *)
include Bar     (* the module `Import` now contains a submodule `Import` *)

(* foo.ml  *)
open! Import

(* foo.mli *)
open! Import
```

### The bug
Calling `locate` on `Import` jumps to
- `import.ml` when called from `foo.ml`
- `bar.ml` when called from `foo.mli`

Both should behave the same and jump to `import.ml`.

The problem only occurs with shadowing: in the `.mli`, the environment used to answer the query is the one *after* the `open`, which already contains the opened `Import`, so the bare name resolves to the submodule instead of the original module. (Rename either `import.ml` or `Bar.Import` and the issue disappears.)

The same bug affects the `document` command (regression test added in `document/issue1748.t`).

## The fix
We want the query answered in the environment *right before* the `open`. That environment was not carried on the `Browse_raw.Open_description` node (only the post-open one was inherited), so the cursor landed on a node with the wrong environment. The fix makes `Open_description` carry the pre-open environment, mirroring what structure opens already get through their `Module_expr` child. This corrects `locate`, `document`, and any other command that resolves a name at the `open`.

## Use of AI
I used Claude to understand the issue and help me fix it, and I reviewed everything carefully.
