### PR TITLE
Destruct open record patterns into closed ones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Tue Jun 23 12:15:42 CEST 2026
     - Fix signature-help with type aliases (#2067, fixes #1927)
     - Fix locate on punned let bindings, to use the common identifier as the
       expression (instead of the pattern) (#2066)
+    - Add destruction of open record patterns into closed one. (#2103, fixes
+      #436)
   + index format
     - Use a LRU to reduce memory usage when indexing. Change the way small
       values are stored. Make sub-indexes paths relative to the working

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -334,9 +334,10 @@ let rec get_every_pattern loc = function
 let rec destructible patt =
   let open Typedtree in
   match patt.pat_desc with
-  | Tpat_any | Tpat_var _ -> true
+  | Tpat_any | Tpat_var _ -> `Var
+  | Tpat_record (record, Open) -> `Open_record record
   | Tpat_alias (p, _, _, _, _) -> destructible p
-  | _ -> false
+  | _ -> `Not_destructible
 
 let is_package ty =
   match ty.Types.desc with
@@ -717,11 +718,12 @@ let refine_complete_match (type a) parents (patt : a Typedtree.general_pattern)
     config source (patterns : Typedtree.pattern list) =
   match Typedtree.classify_pattern patt with
   | Computation -> raise (Not_allowed "computation pattern")
-  | Value ->
-    if not (destructible patt) then raise Nothing_to_do
-    else
+  | Value -> (
+    match destructible patt with
+    | `Not_destructible -> raise Nothing_to_do
+    | `Var ->
       let ty = patt.Typedtree.pat_type in
-      begin match gen_patterns patt.Typedtree.pat_env ty with
+      begin match gen_patterns patt.pat_env ty with
       | [] -> assert false
       | [ more_precise_pattern ] ->
         (* If only one pattern is generated, then we're only refining the
@@ -732,6 +734,45 @@ let refine_complete_match (type a) parents (patt : a Typedtree.general_pattern)
              branches. *)
         refine_and_generate_branches patt config source patterns sub_patterns
       end
+    | `Open_record existing_fields ->
+      let ty = patt.pat_type in
+      let new_pattern =
+        match Types.get_desc ty with
+        | Tconstr (path, _params, _) ->
+          begin match Env.find_type_descrs path patt.pat_env with
+          | Type_record (all_fields, _) ->
+            let lst =
+              List.filter_map all_fields ~f:(fun lbl_descr ->
+                  match
+                    List.find_opt
+                      ~f:(fun (_, existing_field, _) ->
+                        existing_field.Data_types.lbl_name
+                        = lbl_descr.Data_types.lbl_name)
+                      existing_fields
+                  with
+                  | Some _ -> None
+                  | None ->
+                    let lidloc = mk_id lbl_descr.Data_types.lbl_name in
+                    Some
+                      ( lidloc,
+                        lbl_descr,
+                        Tast_helper.Pat.var
+                          Types.Uid.internal_not_actually_unique patt.pat_env ty
+                          (mk_var lbl_descr.lbl_name) ))
+            in
+            let lst = existing_fields @ lst in
+            Tast_helper.Pat.record patt.pat_env ty lst Asttypes.Closed
+          | _ ->
+            (* The type of a record pattern has to be a record unless it does not
+                 compile which can be the case I guess! But in this case we are
+                 unable to compute the closed pattern. *)
+            raise Nothing_to_do
+          end
+        | _ ->
+          (* See comment above *)
+          raise Nothing_to_do
+      in
+      refine_current_pattern parents patt config source new_pattern)
 
 let destruct_pattern (type a) (patt : a Typedtree.general_pattern) config source
     loc parents =

--- a/tests/test-dirs/destruct/destruct-open-records.t
+++ b/tests/test-dirs/destruct/destruct-open-records.t
@@ -131,3 +131,29 @@ And last but not least, the original example for #436:
     ],
     "notifications": []
   }
+
+And finally with a module qualification
+
+  $ $MERLIN single case-analysis -start 4:12 -end 4:12 -filename test.ml <<EOF
+  > module T = struct
+  >   type r = {a:int; b:int; c:int; d:int;}
+  > end
+  > let f {T.a;_} = a + b + c + d
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 4,
+          "col": 6
+        },
+        "end": {
+          "line": 4,
+          "col": 13
+        }
+      },
+      "{ T.a = a; b; c; d }"
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/destruct/destruct-open-records.t
+++ b/tests/test-dirs/destruct/destruct-open-records.t
@@ -1,0 +1,110 @@
+We'll always have a record type with three fields.
+
+When the pattern-match is not exhaustive, we always prefer to make it
+exhaustive:
+
+- On the [Some _] wildcard
+
+  $ $MERLIN single case-analysis -start 3:12 -end 3:12 -filename test.ml <<EOF
+  > type t = { a : int; b : bool option; c : int }
+  > let () = match x with
+  >  {b = Some _ ; _ } -> 1
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 23
+        },
+        "end": {
+          "line": 3,
+          "col": 23
+        }
+      },
+      "
+  | { b = None;_} -> _"
+    ],
+    "notifications": []
+  }
+
+- On the [; _] wildcard
+
+  $ $MERLIN single case-analysis -start 3:16 -end 3:16 -filename test.ml <<EOF
+  > type t = { a : int; b : bool option; c : int }
+  > let () = match x with
+  >  {b = Some _ ; _ } -> 1
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 23
+        },
+        "end": {
+          "line": 3,
+          "col": 23
+        }
+      },
+      "
+  | { b = None;_} -> _"
+    ],
+    "notifications": []
+  }
+
+Only when the pattern-match is exhaustive, we look whether we can refine the
+pattern at point:
+
+- On the [b = _] wildcard
+
+  $ $MERLIN single case-analysis -start 3:7 -end 3:7 -filename test.ml <<EOF
+  > type t = { a : int; b : bool option; c : int }
+  > let () = match x with
+  >  {b = _ ; _ } -> 1
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 1
+        },
+        "end": {
+          "line": 3,
+          "col": 13
+        }
+      },
+      "{ b = None;_} | { b = Some _;_}"
+    ],
+    "notifications": []
+  }
+
+- On the [; _] wildcard. TODO: it could refine the open record into a closed
+one, but it does not.
+
+  $ $MERLIN single case-analysis -start 3:11 -end 3:11 -filename test.ml <<EOF
+  > type t = { a : int; b : bool option; c : int }
+  > let () = match x with
+  >  {b = _ ; _ } -> 1
+  > EOF
+  {
+    "class": "error",
+    "value": "Nothing to do",
+    "notifications": []
+  }
+
+And last but not least, the original example for #436:
+
+  $ $MERLIN single case-analysis -start 2:9 -end 2:9 -filename test.ml <<EOF
+  > type r = {a:int; b:int; c:int; d:int;}
+  > let f {a;_} = a + b + c + d
+  > EOF
+  {
+    "class": "error",
+    "value": "Nothing to do",
+    "notifications": []
+  }

--- a/tests/test-dirs/destruct/destruct-open-records.t
+++ b/tests/test-dirs/destruct/destruct-open-records.t
@@ -83,8 +83,7 @@ pattern at point:
     "notifications": []
   }
 
-- On the [; _] wildcard. TODO: it could refine the open record into a closed
-one, but it does not.
+- On the [; _] wildcard, it destructs the open record pattern into a closed one.
 
   $ $MERLIN single case-analysis -start 3:11 -end 3:11 -filename test.ml <<EOF
   > type t = { a : int; b : bool option; c : int }
@@ -92,8 +91,20 @@ one, but it does not.
   >  {b = _ ; _ } -> 1
   > EOF
   {
-    "class": "error",
-    "value": "Nothing to do",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 1
+        },
+        "end": {
+          "line": 3,
+          "col": 13
+        }
+      },
+      "{ b = _; a; c }"
+    ],
     "notifications": []
   }
 
@@ -104,7 +115,19 @@ And last but not least, the original example for #436:
   > let f {a;_} = a + b + c + d
   > EOF
   {
-    "class": "error",
-    "value": "Nothing to do",
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 6
+        },
+        "end": {
+          "line": 2,
+          "col": 11
+        }
+      },
+      "{ a; b; c; d }"
+    ],
     "notifications": []
   }


### PR DESCRIPTION
Fixes #436 

Whenever you have a complete match, and your cursor is on an open record pattern, destruct will close the pattern. For instance:

```ocaml
type t = { a : int; b : int; c : int}

let () = match (x : t) with
  | { b = _; _ } -> ()
```

when destructing the second open record pattern, is turned into:

```ocaml
type t = { a : int; b : int; c : int}

let () = match (x : t) with
  | { b = _; a; c } -> ()
```
