### PR TITLE
occurrences: fix a bug where out-of-sync files were never reported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+  + merlin library
+    - occurrences: fix files modified since the index was built never being
+      reported as out-of-sync.
+
 merlin 5.8
 ==========
 Tue Jun 23 12:15:42 CEST 2026

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -190,7 +190,10 @@ let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid :
       in
       Option.map external_locs ~f:(fun (index, locs) ->
           let stats = Stat_check.create ~cache_size:128 index in
-          ( Occurrence_set.of_filtered_lid_set locs ~f:(fun lid ->
+          (* Note: [get_outdated_files] must be evaluated after the [Stat_check.check stats ~file...],
+             as the latter one populates the cache inside [stats] *)
+          let occurrences =
+            Occurrence_set.of_filtered_lid_set locs ~f:(fun lid ->
                 let { Location.loc; _ } = Index_format.Lid.to_lid lid in
                 (* We ignore external results that concern the current buffer *)
                 let file_rel_to_root =
@@ -218,8 +221,9 @@ let get_external_locs ~(config : Mconfig.t) ~current_buffer_path uid :
                     | false -> Stale
                   in
                   Some staleness
-                end),
-            Stat_check.get_outdated_files stats )))
+                end)
+          in
+          (occurrences, Stat_check.get_outdated_files stats)))
 
 let lookup_related_uids_in_indexes ~(config : Mconfig.t) uid =
   let title = "lookup_related_uids_in_indexes" in

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -364,8 +364,8 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
     in
     if not (String.Set.is_empty out_of_sync_files) then
       log ~title:"locs_of"
-        "Occurrences may be incomplete: some source files are out-of-sync \
-         with the index: %s"
+        "Occurrences may be incomplete: some source files are out-of-sync with \
+         the index: %s"
         (String.concat ~sep:", " (String.Set.to_list out_of_sync_files));
     let occurrences =
       Occurrence_set.union buffer_occurrences external_occurrences

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -344,6 +344,11 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
           (Occurrence_set.union acc_locs locs, String.Set.union acc_files files))
         external_occurrences
     in
+    if not (String.Set.is_empty out_of_sync_files) then
+      log ~title:"locs_of"
+        "Occurrences may be incomplete: some source files are out-of-sync \
+         with the index: %s"
+        (String.concat ~sep:", " (String.Set.to_list out_of_sync_files));
     let occurrences =
       Occurrence_set.union buffer_occurrences external_occurrences
     in

--- a/tests/test-dirs/occurrences/project-wide/stale-index-status.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index-status.t
@@ -1,0 +1,39 @@
+Merlin checks the files listed in the index against the files on disk, and
+collects the files that were modified since the index was built, to report
+that occurrences might be out-of-sync. The result of these checks used to be
+read *before* the checks were performed (tuple components are evaluated
+right-to-left), so out-of-sync files were never reported. The reported files
+are observable in the logs.
+
+  $ cat >lib.ml <<'EOF'
+  > (* blah *)
+  > let foo = "bar"
+  > EOF
+
+  $ cat >main.ml <<'EOF'
+  > let () = print_string Lib.foo
+  > EOF
+
+  $ $OCAMLC -bin-annot -bin-annot-occurrences -c lib.ml main.ml
+  $ ocaml-index aggregate main.cmt lib.cmt
+
+With a fresh index, no file is reported as out-of-sync:
+  $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
+  > -index-file project.ocaml-index \
+  > -log-file - -log-section occurrences \
+  > -filename main.ml < main.ml 2>&1 | grep "out-of-sync"
+  [1]
+
+Modify lib.ml without rebuilding the index: foo is now defined on line 1
+instead of line 2, and the file's size changed.
+  $ cat >lib.ml <<'EOF'
+  > let foo = "bar"
+  > EOF
+
+The stat-check detects the modification and the query reports lib.ml as
+out-of-sync:
+  $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
+  > -index-file project.ocaml-index \
+  > -log-file - -log-section occurrences \
+  > -filename main.ml < main.ml 2>&1 | grep "out-of-sync"
+  File $TESTCASE_ROOT/lib.ml might be out-of-sync.

--- a/tests/test-dirs/occurrences/project-wide/stale-index-status.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index-status.t
@@ -37,3 +37,4 @@ out-of-sync:
   > -log-file - -log-section occurrences \
   > -filename main.ml < main.ml 2>&1 | grep "out-of-sync"
   File $TESTCASE_ROOT/lib.ml might be out-of-sync.
+  Occurrences may be incomplete: some source files are out-of-sync with the index: lib.ml


### PR DESCRIPTION
Summary
=======

As part of its [occurrences search](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.mli#L3) Merlin computes  the [`occurences_status` ](https://github.com/ikostia/merlin/blob/main/src/frontend/query_protocol.ml#L132), which is intended to give the callers some information about whether the returned list of occurrences is complete or not (see [how `ocaml-lsp` does that](https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/ocaml_lsp_server.ml#L464)).

The status itself is [computed](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L391-L395) based on a set of out-of-sync files, which are in turn [computed by the `get_external_locs` function](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L329-L345). The function [calls](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L222) `Stat_check.get_outdated_files stats`, which just [folds `stats.cache`](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L124-L127). The `cache`  is [populated by `Stat_check.check`](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L151-L159), called from [here](https://github.com/ikostia/merlin/blob/main/src/analysis/occurrences.ml#L211).

The bug arises from the fact that the check is populated in the first tuple element, and it is read in the second tuple element. While the tuple evaluation order is not specified, in practice it is right-to-left, meaning that the cache is always empty at the time of out-of-sync-files computation. Therefore the fix is to evaluate the left tuple element in an explicitly preceeding `let` binding.

Testing
======
A new test, demonstrating the bug and the fix.