### PR TITLE
Fix for Type-enclosing resolves * in tuple types as integer multiplication  

### DIFF
--- a/src/analysis/env_lookup.ml
+++ b/src/analysis/env_lookup.ml
@@ -18,7 +18,7 @@ module Namespace = struct
     | `This_cstr of Data_types.constructor_description ]
 
   let from_context : Context.t -> inferred list = function
-    | Type -> [ `Type; `Mod; `Modtype; `Constr; `Labels; `Vals ]
+    | Type -> [ `Type; `Mod; `Modtype; `Constr; `Labels ]
     | Module_type -> [ `Modtype; `Mod; `Type; `Constr; `Labels; `Vals ]
     | Expr | Constant -> [ `Vals; `Mod; `Modtype; `Constr; `Labels; `Type ]
     | Patt -> [ `Mod; `Modtype; `Type; `Constr; `Labels; `Vals ]

--- a/src/analysis/type_utils.ml
+++ b/src/analysis/type_utils.ml
@@ -321,10 +321,15 @@ let type_in_env ?(verbosity = Verbosity.default) ?keywords ~context env ppf expr
         | _ -> raise Fallback
         end;
         true
-      with _ -> (
+      with original_exn -> (
+        let try_expr () =
+          match context with
+          | Type | Module_type | Patt -> raise Fallback
+          | _ -> print_expr e
+        in
         (* Fallback to contextless typing attempts *)
         try
-          print_expr e;
+          try_expr ();
           true
         with exn -> (
           try
@@ -341,7 +346,8 @@ let type_in_env ?(verbosity = Verbosity.default) ?keywords ~context env ppf expr
                 print_constr ppf env longident;
                 true
               with _ ->
-                print_exn ppf exn;
+                let exn_to_print = match exn with Fallback -> original_exn | _ -> exn in
+                print_exn ppf exn_to_print;
                 false))))
       end
     | `Other -> (

--- a/tests/test-dirs/issue2093.t
+++ b/tests/test-dirs/issue2093.t
@@ -9,25 +9,13 @@ FIXME: the current results promoted is wrong.
       {
         "start": {
           "line": 1,
-          "col": 28
-        },
-        "end": {
-          "line": 1,
-          "col": 29
-        },
-        "type": "int -> int -> int",
-        "tail": "no"
-      },
-      {
-        "start": {
-          "line": 1,
           "col": 25
         },
         "end": {
           "line": 1,
           "col": 32
         },
-        "type": 1,
+        "type": "'a * 'a",
         "tail": "no"
       },
       {
@@ -39,7 +27,7 @@ FIXME: the current results promoted is wrong.
           "line": 1,
           "col": 40
         },
-        "type": 2,
+        "type": 1,
         "tail": "no"
       },
       {
@@ -51,7 +39,7 @@ FIXME: the current results promoted is wrong.
           "line": 1,
           "col": 40
         },
-        "type": 3,
+        "type": 2,
         "tail": "no"
       },
       {
@@ -63,7 +51,7 @@ FIXME: the current results promoted is wrong.
           "line": 1,
           "col": 40
         },
-        "type": 4,
+        "type": 3,
         "tail": "no"
       }
     ],
@@ -73,8 +61,7 @@ FIXME: the current results promoted is wrong.
   $ $MERLIN single document -filename test.mli -position 1:28 < test.mli
   {
     "class": "return",
-    "value": "Integer multiplication.
-      Left-associative operator, see {!Ocaml_operators} for more information.",
+    "value": "Not in environment '*'",
     "notifications": []
   }
 


### PR DESCRIPTION
This PR closes https://github.com/ocaml/merlin/issues/2093. 
Here we remove values from the fallback list when Merlin is looking up a type and added a check so merlin doesn't guess that a text may be a math expression when analyzing a type.

cc @voodoos 