### PR TITLE
test: cover stale load paths across typer states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ unreleased
       submodule no longer hides the opened module (fixes #1748)
     - Fix occurrences staleness detection when the server is not running at the
       project's source root. (#2097)
+    - Reproduce and fix a load_path staleness issue particularly visible when
+      using ocaml-lsp and dune in watch mode (#2109)
   + ocaml index
     - Fix staleness detection in the presence of ppxes. (#2110)
 

--- a/src/ocaml/utils/load_path.ml
+++ b/src/ocaml/utils/load_path.ml
@@ -29,6 +29,7 @@ module Dir = struct
   type t = {
     path : string;
     files : string list;
+    file_id : File_id.t;
     hidden : bool;
   }
 
@@ -52,10 +53,21 @@ module Dir = struct
     in
     List.find_map search t.files
 
-  let create ~hidden path =
-    { path; files = Array.to_list (Directory_content_cache.read path); hidden }
 
-  let check t = Directory_content_cache.check t.path
+  (* Merlin: In server mode we need each typer instance to know that a directory
+     changed at some point. Relying on the global [Directory_content_cache]
+     means only the first such check will notice the invalidation but not
+     following ones. We thus use individual [file_id]s for directory
+     invalidation, so that every impacted instance is eventually updated. *)
+
+  let create ~hidden path =
+    { path;
+      files = Array.to_list (Directory_content_cache.read path);
+      file_id = File_id.get path;
+      hidden
+    }
+
+  let check t = File_id.check (File_id.get t.path) t.file_id
 
 end
 

--- a/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/other.ml
+++ b/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/other.ml
@@ -1,0 +1,2 @@
+open! Foo
+open! Bar

--- a/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
+++ b/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
@@ -7,8 +7,11 @@ Stop the server incase it's already running.
 We create lib/foo.cmi, but lib/bar.cmi is missing.
   $ $OCAMLC -c lib/foo.ml
 
-First query: lib/bar.cmi is not yet on disk, so we get an "Unbound module" error.
+Prime two typechecker states while lib/bar.cmi is not yet on disk. Both report
+an "Unbound module" error.
   $ $MERLIN server errors -filename test.ml < test.ml | jq .value[].message -r
+  Unbound module Bar
+  $ $MERLIN server errors -filename other.ml < other.ml | jq .value[].message -r
   Unbound module Bar
 
 Now create lib/bar.cmi.
@@ -19,9 +22,14 @@ Bump the directory's mtime to defeat File_id's 1-second mtime granularity (the
 systems where the mtime granularity is 1 second.
   $ if [ "$(uname)" = "Darwin" ]; then touch -A 02 lib; else touch -d '+2 seconds' lib; fi
 
-Second query: lib/bar.cmi is now present, so we shouldn't get an "Unbound module Bar"
-error.
+The first typechecker state notices that lib changed and refreshes the shared
+directory-content cache.
   $ $MERLIN server errors -filename test.ml < test.ml | jq .value[].message -r
+
+The second typechecker state must also notice lib/bar.cmi. In particular, the
+shared directory-content cache must not make its stale local load-path snapshot
+look current.
+  $ $MERLIN server errors -filename other.ml < other.ml | jq .value[].message -r
 
 For reference, single mode (which spawns a fresh process and so cannot reuse
 any cache) returns the correct answer:

--- a/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
+++ b/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
@@ -26,11 +26,10 @@ The first typechecker state notices that lib changed and refreshes the shared
 directory-content cache.
   $ $MERLIN server errors -filename test.ml < test.ml | jq .value[].message -r
 
-FIXME The second typechecker state must also notice lib/bar.cmi. In particular, the
+The second typechecker state must also notice lib/bar.cmi. In particular, the
 shared directory-content cache must not make its stale local load-path snapshot
 look current.
   $ $MERLIN server errors -filename other.ml < other.ml | jq .value[].message -r
-  Unbound module Bar
 
 For reference, single mode (which spawns a fresh process and so cannot reuse
 any cache) returns the correct answer:

--- a/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
+++ b/tests/test-dirs/server-tests/typer-cache/cmi-appears.t/run.t
@@ -26,10 +26,11 @@ The first typechecker state notices that lib changed and refreshes the shared
 directory-content cache.
   $ $MERLIN server errors -filename test.ml < test.ml | jq .value[].message -r
 
-The second typechecker state must also notice lib/bar.cmi. In particular, the
+FIXME The second typechecker state must also notice lib/bar.cmi. In particular, the
 shared directory-content cache must not make its stale local load-path snapshot
 look current.
   $ $MERLIN server errors -filename other.ml < other.ml | jq .value[].message -r
+  Unbound module Bar
 
 For reference, single mode (which spawns a fresh process and so cannot reuse
 any cache) returns the correct answer:


### PR DESCRIPTION
This extends the existing `cmi-appears.t` regression test to cover two typechecker states that share the same build directory.

Both states first cache `Bar` as missing. After `bar.cmi` appears, querying the first state refreshes the shared directory-content cache. The second state then incorrectly treats its stale local load-path snapshot as current and continues to report `Unbound module Bar`.

This reproduces ocaml/ocaml-lsp#1209 and demonstrates the multi-state case not covered by #2062. The new assertion currently fails with `Unbound module Bar`.
