### PR TITLE
Fix index staleness in presence of ppxes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ unreleased
       submodule no longer hides the opened module (fixes #1748)
     - Fix occurrences staleness detection when the server is not running at the
       project's source root. (#2097)
+  + ocaml index
+    - Fix staleness detection in the presence of ppxes. (#2110)
 
 merlin 5.8
 ==========

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -309,6 +309,20 @@ let reroot_build_dir ~root path =
     let sep = Printf.sprintf "%c" sep in
     Filename.concat root (String.concat ~sep l)
 
+let sourcefile_for_ppx_sourcefile file =
+  match file |> String.split_on_char ~sep:'.' |> List.rev with
+  | ext :: "pp" :: rev_path -> (
+    (* If the source file was a post-processed file (.pp.mli?), use the
+          regular .mli? file for locate. *)
+    let file = ext :: rev_path |> List.rev |> String.concat ~sep:"." in
+    match
+      Misc.exact_file_exists ~dirname:(Filename.dirname file)
+        ~basename:(Filename.basename file)
+    with
+    | true -> Some file
+    | false -> None)
+  | _ -> None
+
 let move_to (config : Mconfig.t) filename cmt_infos =
   let digest =
     (* [None] only for packs, and we wouldn't have a trie if the cmt was for a
@@ -325,23 +339,9 @@ let move_to (config : Mconfig.t) filename cmt_infos =
       | None -> sourcefile_in_builddir
       | Some root -> reroot_build_dir ~root sourcefile_in_builddir
     in
-    match
-      sourcefile_in_builddir |> String.split_on_char ~sep:'.' |> List.rev
-    with
-    | ext :: "pp" :: rev_path -> (
-      (* If the source file was a post-processed file (.pp.mli?), use the
-         regular .mli? file for locate. *)
-      let sourcefile_in_builddir =
-        ext :: rev_path |> List.rev |> String.concat ~sep:"."
-      in
-      match
-        Misc.exact_file_exists
-          ~dirname:(Filename.dirname sourcefile_in_builddir)
-          ~basename:(Filename.basename sourcefile_in_builddir)
-      with
-      | true -> Digest.file sourcefile_in_builddir
-      | false -> Option.get cmt_infos.cmt_source_digest)
-    | _ -> Option.get cmt_infos.cmt_source_digest
+    match sourcefile_for_ppx_sourcefile sourcefile_in_builddir with
+    | Some raw_src -> Digest.file raw_src
+    | None -> Option.get cmt_infos.cmt_source_digest
   in
   File_switching.move_to ~digest filename
 

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -45,6 +45,13 @@ type result =
     approximated : bool
   }
 
+(** Given the path that looks like a ppx-expanded sourcefile, returns the path of the true
+    sourcefile. If the path does not appear to be for a ppx-expanded file or the
+    sourcefile doesn't exist, returns [None].
+
+    ex: [sourcefile_for_ppx_sourcefile "foo.pp.ml"] -> [Some "foo.ml"] *)
+val sourcefile_for_ppx_sourcefile : string -> string option
+
 val uid_of_result :
   traverse_aliases:bool -> Shape_reduce.result -> Shape.Uid.t option * bool
 

--- a/src/ocaml-index/lib/index.ml
+++ b/src/ocaml-index/lib/index.ml
@@ -123,15 +123,21 @@ let index_of_cmt ~into ~root ~rewrite_root ~build_path ~do_not_use_cmt_loadpath
     match cmt_sourcefile with
     | None -> into.stats
     | Some src -> (
+      let src, preprocessed =
+        match Locate.sourcefile_for_ppx_sourcefile src with
+        | Some raw_src -> (raw_src, true)
+        | None -> (src, false)
+      in
       let rooted_src = with_root ?root src in
       try
         let stats = Unix.stat rooted_src in
+        let source_digest =
+          if preprocessed then Some (Digest.file rooted_src)
+          else cmt_source_digest
+        in
         let src = if rewrite_root then rooted_src else src in
         Stats.add src
-          { mtime = stats.st_mtime;
-            size = stats.st_size;
-            source_digest = cmt_source_digest
-          }
+          { mtime = stats.st_mtime; size = stats.st_size; source_digest }
           into.stats
       with Unix.Unix_error _ -> into.stats)
   in

--- a/tests/test-dirs/occurrences/project-wide/stale-index-ppx.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index-ppx.t
@@ -72,6 +72,6 @@ Foo was defined on line 2 when the index was built, but is now defined on line 1
         "line": 2,
         "col": 7
       },
-      "stale": false
+      "stale": true
     }
   ]

--- a/tests/test-dirs/occurrences/project-wide/stale-index-ppx.t
+++ b/tests/test-dirs/occurrences/project-wide/stale-index-ppx.t
@@ -1,0 +1,77 @@
+First, prepare our preprocessor:
+
+  $ cat >prep.ml <<EOF
+  > let output_to_stdout fn str =
+  >   output_string stdout Config.ast_impl_magic_number;
+  >   output_value  stdout (fn : string);
+  >   output_value  stdout (str : Parsetree.structure)
+  > 
+  > let () =
+  >   let to_file, in_file =
+  >     match Sys.argv.(1) with
+  >     | "-dump-to-file" -> true, Sys.argv.(2)
+  >     | filename -> false, filename
+  >   in
+  >   let str = Pparse.parse_implementation ~tool_name:"prep" in_file in
+  >   if to_file then
+  >     let out_file = Filename.chop_suffix in_file "ml" ^ "pp.ml" in
+  >     Pparse.write_ast Structure out_file str
+  >   else
+  >     output_to_stdout in_file str
+  > EOF
+
+  $ $OCAMLC -I +compiler-libs ocamlcommon.cma -o prep.exe prep.ml
+
+Then create the test project and compile it:
+
+  $ cat >lib.ml <<'EOF'
+  > (* blah *)
+  > let foo = "bar"
+  > EOF
+
+  $ cat >main.ml <<'EOF'
+  > let () = print_string Lib.foo
+  > EOF
+
+  $ ./prep.exe main.ml > main.pp.ml
+  $ ./prep.exe lib.ml > lib.pp.ml
+
+  $ $OCAMLC -bin-annot -bin-annot-occurrences -c lib.pp.ml -o lib
+  $ $OCAMLC -bin-annot -bin-annot-occurrences -c main.pp.ml -o main
+
+  $ ocaml-index aggregate main.cmt lib.cmt
+
+Foo was defined on line 2 when the index was built, but is now defined on line 1
+  $ cat >lib.ml <<'EOF'
+  > let foo = "bar"
+  > EOF
+
+  $ $MERLIN single occurrences -scope project -identifier-at 1:28 \
+  > -index-file project.ocaml-index \
+  > -filename main.ml < main.ml | jq .value
+  [
+    {
+      "file": "$TESTCASE_ROOT/main.ml",
+      "start": {
+        "line": 1,
+        "col": 26
+      },
+      "end": {
+        "line": 1,
+        "col": 29
+      },
+      "stale": false
+    },
+    {
+      "file": "$TESTCASE_ROOT/lib.ml",
+      "start": {
+        "line": 2,
+        "col": 4
+      },
+      "end": {
+        "line": 2,
+        "col": 7
+      },
+      "stale": false
+    }
+  ]


### PR DESCRIPTION
The `occurrences` query's ability to detect staleness in the presence of ppxes is broken. To determine staleness, ocaml-index records the digest of the source file. However, when the file fed into ocaml-index is a file like `foo.pp.ml`, ocaml-index incorrectly uses the digest of `foo.pp.ml` rather than `foo.ml`. (Note that we want to show an occurrence as stale if `foo.ml` has changed, not if `foo.pp.ml` has changed.)

This PR is split into two commits. The first commit adds a test that demonstrates the bug, and the second fixes it.