### PR TITLE
Fix "merlin_loc" in constrained expression.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
 
   + merlin library
     - destruct: allow to destruct let-bindings's patterns (#2117)
+    - Fix detection of expression at cursor in case of type-constrained
+      expression (#2120)
 
 merlin 5.8.1
 ============

--- a/src/commands/new_commands.ml
+++ b/src/commands/new_commands.ml
@@ -45,30 +45,30 @@ let arg ?(kind = `Mandatory) name doc action = (kind, (name, doc, action))
 let optional x = arg ~kind:`Optional x
 let many x = arg ~kind:`Many x
 
-let marg_position f =
-  Marg.param "position" (function
-    | "start" -> f `Start
-    | "end" -> f `End
-    | str -> (
-      match int_of_string str with
-      | n -> f (`Offset n)
-      | exception _ -> (
-        match
-          let offset = String.index str ':' in
-          let line = String.sub str ~pos:0 ~len:offset in
-          let col =
-            String.sub str ~pos:(offset + 1)
-              ~len:(String.length str - offset - 1)
-          in
-          `Logical (int_of_string line, int_of_string col)
-        with
-        | pos -> f pos
-        | exception _ ->
-          failwithf
-            "expecting position, got %S. position can be \
-             start|end|<offset>|<line>:<col>, where offset, line and col are \
-             numbers, lines are indexed from 1."
-            str)))
+let parse_position = function
+  | "start" -> `Start
+  | "end" -> `End
+  | str -> (
+    match int_of_string str with
+    | n -> `Offset n
+    | exception _ -> (
+      match
+        let offset = String.index str ':' in
+        let line = String.sub str ~pos:0 ~len:offset in
+        let col =
+          String.sub str ~pos:(offset + 1) ~len:(String.length str - offset - 1)
+        in
+        `Logical (int_of_string line, int_of_string col)
+      with
+      | pos -> pos
+      | exception _ ->
+        failwithf
+          "expecting position, got %S. position can be \
+           start|end|<offset>|<line>:<col>, where offset, line and col are \
+           numbers, lines are indexed from 1."
+          str))
+
+let marg_position f = Marg.param "position" (fun s -> f (parse_position s))
 
 let marg_completion_kind f =
   Marg.param "completion-kind" (function

--- a/src/commands/new_commands.mli
+++ b/src/commands/new_commands.mli
@@ -29,6 +29,9 @@
 
 open Std
 
+val parse_position :
+  string -> [> `End | `Logical of int * int | `Offset of int | `Start ]
+
 type command =
   | Command :
       string

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -244,23 +244,25 @@ let has_attr ~name node =
 
 let node_merlin_loc loc0 node =
   let attributes = node_attributes node in
-  let loc =
+  let relaxed_loc loc attributes =
     let open Parsetree in
     let pred { attr_name = loc; _ } = Location_aux.is_relaxed_location loc in
     match List.find attributes ~f:pred with
     | { attr_name; _ } -> attr_name.Location.loc
-    | exception Not_found -> node_real_loc loc0 node
+    | exception Not_found -> loc
+  in
+  let loc = relaxed_loc (node_real_loc loc0 node) attributes in
+  let extra_loc loc extra =
+    List.fold_left
+      ~f:(fun loc0 (_, loc, attributes) ->
+        let loc = relaxed_loc loc attributes in
+        Location_aux.union loc0 loc)
+      ~init:loc extra
   in
   let loc =
     match node with
-    | Expression { exp_extra; _ } ->
-      List.fold_left
-        ~f:(fun loc0 (_, loc, _) -> Location_aux.union loc0 loc)
-        ~init:loc exp_extra
-    | Pattern { pat_extra; _ } ->
-      List.fold_left
-        ~f:(fun loc0 (_, loc, _) -> Location_aux.union loc0 loc)
-        ~init:loc pat_extra
+    | Expression { exp_extra; _ } -> extra_loc loc exp_extra
+    | Pattern { pat_extra; _ } -> extra_loc loc pat_extra
     | _ -> loc
   in
   loc

--- a/tests/dune
+++ b/tests/dune
@@ -2,7 +2,8 @@
  (_
   (binaries
     merlin-wrapper
-   (test-dirs/extract_ranges/extract_ranges.exe as extract_ranges))
+   (test-dirs/extract_ranges/extract_ranges.exe as extract_ranges)
+   (test-dirs/show_location/show_location.exe as show_location))
   (env-vars
    (MERLIN merlin-wrapper)
    (OCAMLC ocamlc)
@@ -16,6 +17,7 @@
   %{bin:ocamlmerlin-server}
   %{bin:ocamlmerlin}
   %{bin:extract_ranges}
+  %{bin:show_location}
   %{bin:dot-merlin-reader}))
 
 (cram

--- a/tests/test-dirs/exp_extra_loc.t
+++ b/tests/test-dirs/exp_extra_loc.t
@@ -11,7 +11,7 @@ let a = [( x : int)]
 
 And similarly for coercion, pattern constraints and coercion
 
-However, when in the two situation at the same time, the first one is ignored. Let's test that with a file containing both situations:
+When in the two situation at the same time, merlin successfully compute the extended location. Let's test that with a file containing both situations:
 
   $ cat > extras2.ml <<EOF
   > let a =
@@ -34,8 +34,7 @@ and putting our cursor inbetween "in" and "x" and looking at the corresponding n
     x
   $ $MERLIN single type-enclosing -position $LOC -filename extras2.ml <extras2.ml | jq '[.value[0]]' | extract_ranges extras2.ml
   ---------- Range 0 ----------
-  ··let x = 1 in
-    (x : int)···
+  ···x···
 
   $ export LOC=6:0
   $ show_location extras2.ml $LOC

--- a/tests/test-dirs/exp_extra_loc.t
+++ b/tests/test-dirs/exp_extra_loc.t
@@ -1,0 +1,51 @@
+In Merlin there is a notion of "extended loc", that extends the normal loc in different scenarios. For instance, the loc of x is extended to the following ranges:
+- To account for the space between "in" and the expression:
+
+let _ = 1 in[ x]
+
+(And similarly in many cases, as ifthenelse, while, ::, ...)
+
+- To account for the lack of a node for "extra constraints":
+
+let a = [( x : int)]
+
+And similarly for coercion, pattern constraints and coercion
+
+However, when in the two situation at the same time, the first one is ignored. Let's test that with a file containing both situations:
+
+  $ cat > extras2.ml <<EOF
+  > let a =
+  >   let x = 1 in
+  >   (x : int)
+  > let a' =
+  >   let x = 1 in
+  >   x
+  > EOF
+
+and putting our cursor inbetween "in" and "x" and looking at the corresponding node:
+
+  $ export LOC=3:0
+  $ show_location extras2.ml $LOC
+  let a =
+    let x = 1 in
+  █ (x : int)
+  let a' =
+    let x = 1 in
+    x
+  $ $MERLIN single type-enclosing -position $LOC -filename extras2.ml <extras2.ml | jq '[.value[0]]' | extract_ranges extras2.ml
+  ---------- Range 0 ----------
+  ··let x = 1 in
+    (x : int)···
+
+  $ export LOC=6:0
+  $ show_location extras2.ml $LOC
+  let a =
+    let x = 1 in
+    (x : int)
+  let a' =
+    let x = 1 in
+  █ x
+  $ $MERLIN single type-enclosing -position $LOC -filename extras2.ml <extras2.ml | jq '[.value[0]]' | extract_ranges extras2.ml
+  ---------- Range 0 ----------
+  ··x···
+

--- a/tests/test-dirs/extract_ranges/extract_ranges.ml
+++ b/tests/test-dirs/extract_ranges/extract_ranges.ml
@@ -12,8 +12,8 @@ let pos_of_json (j : Yojson.Safe.t) =
 
 let range_of_json (j : Yojson.Safe.t) =
   match j with
-  | `Assoc [ ("start", pos_start); ("end", pos_end) ]
-  | `Assoc [ ("end", pos_end); ("start", pos_start) ] ->
+  | `Assoc (("start", pos_start) :: ("end", pos_end) :: _)
+  | `Assoc (("end", pos_end) :: ("start", pos_start) :: _) ->
     let start = pos_of_json pos_start in
     let end_ = pos_of_json pos_end in
     { start; end_ }

--- a/tests/test-dirs/locate/local-locate.t
+++ b/tests/test-dirs/locate/local-locate.t
@@ -2,6 +2,9 @@
   > let _ = let x = 42 in x
   > EOF
 
+  $ export LOC=1:22
+  $ show_location main.ml $LOC
+  let _ = let x = 42 in █
   $ $MERLIN single locate -look-for ml -position 1:22 \
   > -filename main.ml <main.ml | jq '.value.pos'
   {

--- a/tests/test-dirs/show_location/dune
+++ b/tests/test-dirs/show_location/dune
@@ -1,0 +1,3 @@
+(executable
+ (name show_location)
+ (libraries merlin_commands))

--- a/tests/test-dirs/show_location/show_location.ml
+++ b/tests/test-dirs/show_location/show_location.ml
@@ -1,0 +1,29 @@
+let cursor = "█"
+
+let () =
+  match Merlin_commands.New_commands.parse_position Sys.argv.(2) with
+  | `Start ->
+    let source = In_channel.with_open_bin Sys.argv.(1) In_channel.input_all in
+    print_endline (cursor ^ source)
+  | `End ->
+    let source = In_channel.with_open_bin Sys.argv.(1) In_channel.input_all in
+    print_endline (source ^ cursor)
+  | `Offset i ->
+    let source = In_channel.with_open_bin Sys.argv.(1) In_channel.input_all in
+    let pre = String.sub source 0 i in
+    let post = String.sub source i (String.length source - i) in
+    print_endline (pre ^ cursor ^ post)
+  | `Logical (line, char) ->
+    let lines = In_channel.with_open_bin Sys.argv.(1) In_channel.input_lines in
+    List.iteri
+      (fun i l ->
+        if i + 1 = line then
+          let pre = String.sub l 0 char in
+          let post =
+            String.sub l
+              (Int.min (String.length l - 1) (char + 1))
+              (Int.max 0 (String.length l - char - 1))
+          in
+          print_endline (pre ^ cursor ^ post)
+        else print_endline l)
+      lines


### PR DESCRIPTION
In Merlin there is a notion of "extended loc", that extends the normal loc in different scenarios. For instance, the loc of x is extended to the following ranges:
- To account for the space between "in" and the expression:
   ```ocaml
   let _ = 1 in[ x]
   ```
   (And similarly in many cases, as ifthenelse, while, ::, ...)

- To account for the lack of a node for "extra constraints":
   ```ocaml
   let a = [( x : int)]
   ```
   And similarly for coercion, pattern constraints and coercion

When in the two situation at the same time, merlin currently drops the first case:
```ocaml
let _ = 1 in [(x : int)]
```
instead of 
```ocaml
let _ = 1 in[ (x : int)]
```

This PR fixes it. It also introduce a small test helper to see where your cursor is, because line and character counting is something I am happy to automate.